### PR TITLE
Remove the register-cert step from Getting Started with Scalar DL Sandbox

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -19,7 +19,7 @@ We will provide you with a zip file containing the necessary access token, key p
 The access token is only used for authentication with Sandbox API gateway.
 The key pair is used for communicating with Scalar DL network.
 
-Please note that we generate a pair of a private key and a certificate for ease of use for the Sandbox environment, but it is usually required to create the pair in your own environment.
+Please note that we generate a pair of a private key and a certificate and register the certificate for ease of use for the Sandbox environment, but those steps are usually required in your own environment.
 The generated certificate is already registered to Scalar DL in the Sandbox environment, so you don't have to take a step to register it.
 
 ## Before running your first contract 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -19,7 +19,8 @@ We will provide you with a zip file containing the necessary access token, key p
 The access token is only used for authentication with Sandbox API gateway.
 The key pair is used for communicating with Scalar DL network.
 
-Please note that we generate a key pair for ease of use for the Sandbox environment, but it is usually required to create your private key in your own environment.
+Please note that we generate a pair of a private key and a certificate for ease of use for the Sandbox environment, but it is usually required to create the pair in your own environment.
+The generated certificate is already registered to Scalar DL in the Sandbox environment, so you don't have to take a step to register it.
 
 ## Before running your first contract 
 
@@ -35,17 +36,6 @@ Since the Sandbox is a shared environment that anyone can access,
 take special care when choosing appropriate names for your `asset_id`s so that they will not conflict with the `asset_id`s chosen by other user.
 One recommended way to do this is to append your username to the asset name, for example `<username>-<your-asset-name>`.
 Also, the same care is needed when choosing contract IDs and we recommend using `<username>-<your-contract-class-name>`.
-
-## Register your certificate
-
-Next, let's register your certificate in the Scalar DL network.
-The registered certificate will allow you to register and execute contracts, and is also used for tamper detection of the data stored in the network.
-
-In the `scalardl-client-sdk` directory:
-```
-$ client/bin/register-cert -properties client.properties
-```
-* The `client.properties` should be the same file from the zip downloaded earlier.
 
 ## Run the StateUpdater contract
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -59,6 +59,8 @@ In the `scalardl-client-sdk` directory:
     $ client/bin/register-contract -properties client.properties -contract-id <username>-StateUpdater -contract-binary-name com.org1.contract.StateUpdater -contract-class-file build/classes/java/main/com/org1/contract/StateUpdater.class
     ```
 
+    The `client.properties` should be the same file from the zip downloaded earlier.
+
 3. Execute the contract
 
     NOTE: Please replace `<username>` with your GitHub username.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -20,7 +20,6 @@ The access token is only used for authentication with Sandbox API gateway.
 The key pair is used for communicating with Scalar DL network.
 
 Please note that we generate a pair of a private key and a certificate and register the certificate for ease of use for the Sandbox environment, but those steps are usually required in your own environment.
-The generated certificate is already registered to Scalar DL in the Sandbox environment, so you don't have to take a step to register it.
 
 ## Before running your first contract 
 


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-4126

Updates to Getting Started doc to describe that you no longer need to run `register-cert` for the coming new Sandbox with Scalar DL 1.3.1.
