### PR TITLE
Document/Refer Function feature more properly

### DIFF
--- a/docs/how-to-write-contract.md
+++ b/docs/how-to-write-contract.md
@@ -91,7 +91,7 @@ If you need to use the time in a contract, you should pass it to the contract as
 
 ### Deleting an asset
 
-The assets registered thorough contracts are not able to be deleted to provide tamper-evidence.
+The assets registered through contracts are not able to be deleted to provide tamper-evidence.
 However, there are cases where you want to delete some assets to follow the rules and regulations of applications you develop.
 To provide such a data deletion, Scalar DL supports a feature called `Function`.
 For more details about `Function`, please check [How to Write Function for Scalar DL](./how-to-write-function.md) guide.

--- a/docs/how-to-write-contract.md
+++ b/docs/how-to-write-contract.md
@@ -89,6 +89,14 @@ One common way of creating a non-deterministic contract is to generate the time 
 Such a contract will produce different outputs each time it is executed, and makes the system unable to detect tampering.
 If you need to use the time in a contract, you should pass it to the contract as an argument.
 
+### Deleting an asset
+
+The assets registered thorough contracts are not able to be deleted to provide tamper-evidence.
+However, there are cases where you want to delete some assets to follow the rules and regulations of applications you develop.
+To provide such a data deletion, Scalar DL supports a feature called `Function`.
+For more details about `Function`, please check [How to Write Function for Scalar DL](./how-to-write-function.md) guide.
+
+
 ## Write a complex contract
 
 If your contract is more than 40 lines of code, it is a good sign that you are probably doing more than one thing with your contract.

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -85,7 +85,7 @@ register-function --properties client.properties --function-id test-function --f
 
 #### Execute a registered Function
 
-Functions to be executed are specified in a contract argument in a JSON format with `__functions__` as a key and an array of function IDs as a value as follows:
+Functions that are being executed are specified in a contract argument in a JSON format with `__functions__` as a key and an array of function IDs as a value as follows:
 
 ```
 execute-contract --properties client.properties --contract-id test-contract --contract-argument '{..., "__functions__": ["test-function"]}' --function-argument '{...}'

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -67,7 +67,13 @@ Similar to a Contract using `Ledger` object to manage assets, a Function uses `D
 
 ### How Functions and Contracts are tied together
 
-Functions to be executed are specified in a contract argument with `__functions__` JSON key. As described in [the contract guide](how-to-write-contract.md#write-a-complex-contract), a contract can invoke another contract, so multiple contracts and multiple functions can be grouped together.
+Functions to be executed are specified in a contract argument in a JSON format with `__functions__` as a key and an array of function IDs as a value as follows:
+
+```
+execute-contract --properties client.properties --contract-id test-contract --contract-argument '{..., "__functions__": ["test-function"]}'
+```
+
+As described in [the contract guide](how-to-write-contract.md#write-a-complex-contract), a contract can invoke another contract, so multiple contracts and multiple functions can be grouped together.
 
 Scalar DL executes the group of operations in an ACID manner so that they can be done atomically and in a consistent, isolated, and durable manner.
 

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -65,22 +65,34 @@ Similar to a Contract using `Ledger` object to manage assets, a Function uses `D
 
 `contractArgument` and `contractProperties` are the corresponding contract's argument and properties. See [the contract guide](how-to-write-contract.md) to understand what they are.
 
-### How Functions and Contracts are tied together
+### How to use Functions
+
+Here, we explain how to use Functions. The Function feature is enabled by default; thus, nothing needs to be configured in Ledger except for the following things.
+If you want to disable the feature, please set `scalar.dl.ledger.function.enabled` to `false` in the properties of Ledger.
+
+#### Add an application-specific schema
+
+Since Functions can read and write arbitrary records through the Scalar DB CRUD interface, Scalar DL can't define the database schema for the Function by itself.
+It is the applications' owner's responsibility to define such schema and apply it to the database by themselves or asking system admins to do it depending on who owns and manages the database.
+
+#### Register a Function
+
+You then need to register a Function to Ledger before used like you register a Contract.
+
+```
+register-function --properties client.properties --function-id test-function --function-binary-name com.example.function.TestFunction --function-class-file /path/to/TestFunction.class
+```
+
+#### Execute a registered Function
 
 Functions to be executed are specified in a contract argument in a JSON format with `__functions__` as a key and an array of function IDs as a value as follows:
 
 ```
-execute-contract --properties client.properties --contract-id test-contract --contract-argument '{..., "__functions__": ["test-function"]}'
+execute-contract --properties client.properties --contract-id test-contract --contract-argument '{..., "__functions__": ["test-function"]}' --function-argument '{...}'
 ```
 
-As described in [the contract guide](how-to-write-contract.md#write-a-complex-contract), a contract can invoke another contract, so multiple contracts and multiple functions can be grouped together.
-
-Scalar DL executes the group of operations in an ACID manner so that they can be done atomically and in a consistent, isolated, and durable manner.
-
-### How to add an application-specific schema
-
-Since Functions can read and write arbitrary records through the Scalar DB CRUD interface, Scalar DL can't define the database schema for the Function by itself.
-It is the applications' owner's responsibility to define such schema and apply it to the database by themselves or asking system admins to do it depending on who owns and manages the database.
+As similarly to Contract, a Function can invoke another Function so multiple Functions (and multiple Contracts) can be grouped together.
+Scalar DL executes a group of Contracts and Functions in an ACID manner so that they can be done atomically and in a consistent, isolated, and durable manner.
 
 ## How to use Contracts and Functions properly
 


### PR DESCRIPTION
This PR fixes the following issues around `Function` based on feedbacks:
* The Function guide is not properly referred from another guide.
* The Function guide is not easy to follow, especially in how to execute part.