### PR TITLE
Update Scalar DL compatibility test matrix

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,6 +4,7 @@ This document shows Scalar DL Ledger and Auditor compatibility with the Scalar D
 
 |Scalar DL Ledger Version   |Scalar DL Auditor Version  |Scalar DL Java Client SDK Version  |
 |:--------------------------|:--------------------------|:----------------------------------|
+|3.5  |3.5   |3.0 - 3.5   |
 |3.4  |3.4   |3.0 - 3.4   |
 |3.3  |3.3   |3.0 - 3.4   |
 |3.2  |3.2   |3.0 - 3.4   |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,16 +1,14 @@
 # Scalar DL Compatibility Matrix
 
-This document shows the compatibility of the versions of scalar-ledger container and scalardl-java-client-sdk.
+This document shows Scalar DL Ledger and Auditor compatibility with the Scalar DL Java Client SDK.
 
-|scalar-ledger container | scalardl-java-client-sdk    |
-|--------------|-----------------------------|
-|2.1.0         |2.0.9 - 2.1.0                |
-|2.0.8         |2.0.9 - 2.1.0                |
-|2.0.7         |2.0.0 - 2.0.8                |
-|2.0.6         |2.0.0 - 2.0.8                |
-|2.0.5         |2.0.0 - 2.0.8                |
-|2.0.4         |2.0.0 - 2.0.8                |
-|2.0.3         |2.0.0 - 2.0.8                |
-|2.0.2         |2.0.0 - 2.0.8                |
-|2.0.1         |2.0.0 - 2.0.8                |
-|2.0.0         |2.0.0 - 2.0.8                |
+|Scalar DL Ledger Version   |Scalar DL Auditor Version  |Scalar DL Java Client SDK Version  |
+|:--------------------------|:--------------------------|:----------------------------------|
+|3.4  |3.4   |3.0 - 3.4   |
+|3.3  |3.3   |3.0 - 3.4   |
+|3.2  |3.2   |3.0 - 3.4   |
+|3.1  |3.1   |3.0 - 3.4   |
+|3.0  |3.0   |3.0 - 3.4   |
+|2.2  |Not available   |Not tested  |
+|2.1  |Not available   |2.0 - 2.1   |
+|2.0  |Not available   |2.0 - 2.1   |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,14 +2,14 @@
 
 This document shows Scalar DL Ledger and Auditor compatibility with the Scalar DL Java Client SDK.
 
-|Scalar DL Ledger Version   |Scalar DL Auditor Version  |Scalar DL Java Client SDK Version  |
-|:--------------------------|:--------------------------|:----------------------------------|
-|3.5  |3.5   |3.0 - 3.5   |
-|3.4  |3.4   |3.0 - 3.4   |
-|3.3  |3.3   |3.0 - 3.4   |
-|3.2  |3.2   |3.0 - 3.4   |
-|3.1  |3.1   |3.0 - 3.4   |
-|3.0  |3.0   |3.0 - 3.4   |
-|2.2  |Not available   |Not tested  |
-|2.1  |Not available   |2.0 - 2.1   |
-|2.0  |Not available   |2.0 - 2.1   |
+|Scalar DL Ledger/Auditor version   |Scalar DL Java Client SDK version  |
+|:----------------------------------|:----------------------------------|
+|3.5  |3.0 - 3.5   |
+|3.4  |3.0 - 3.4   |
+|3.3  |3.0 - 3.4   |
+|3.2  |3.0 - 3.4   |
+|3.1  |3.0 - 3.4   |
+|3.0  |3.0 - 3.4   |
+|2.2 (Auditor is not available) |Not tested  |
+|2.1 (Auditor is not available) |2.0 - 2.1   |
+|2.0 (Auditor is not available) |2.0 - 2.1   |


### PR DESCRIPTION
Scalar DL compatibility test matrix updated with the following test results.
|Scalar DL Ledger Version   |Scalar DL Auditor Version  |Scalar DL Java Client SDK Version  |
|---------------------------|---------------------------|-----------------------------------|
|3.4.1  |3.4.1   |3.0.5, 3.1.5, 3.2.5, 3.3.4, 3.4.1  |
|3.3.4  |3.3.4   |3.0.5, 3.1.5, 3.2.5, 3.3.4, 3.4.1   |
|3.2.5  |3.2.5   | 3.0.5, 3.1.5, 3.2.5, 3.3.4, 3.4.1  |
|3.1.5  |3.1.5   |3.0.5, 3.1.5, 3.2.5, 3.3.4, 3.4.1   |
|3.0.5  |3.0.5   |3.0.5, 3.1.5, 3.2.5, 3.3.4, 3.4.1   |

Current Scalar DL Java Client SDK tool applicable only for Scalar DL version 3.0 or later.

Scalar DL Ledger and Auditor 3.0.5 were tested with Scalar DL schema loader 3.1.4 because Scalar DL schema loader 3.0.0 does not support the latest schema loader options. 