### PR TITLE
Fix broken URL about database schema in function docs

### DIFF
--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -114,7 +114,7 @@ The Function feature is enabled by default; thus, nothing needs to be configured
 
 #### Add an application-specific schema
 
-Since Functions can read and write arbitrary records through the Scalar DB CRUD interface, Scalar DL can't define the database schema for the Function by itself. It is the applications' owner's responsibility to define such schema and apply it to the database by themselves or asking system admins to do it depending on who owns and manages the database. For more details about defining database schema for Scalar DB, please read [Database schema in Scalar DB](https://github.com/scalar-labs/scalardb/blob/master/docs/schema.md).
+Since Functions can read and write arbitrary records through the Scalar DB CRUD interface, Scalar DL can't define the database schema for the Function by itself. It is the applications' owner's responsibility to define such schema and apply it to the database by themselves or asking system admins to do it depending on who owns and manages the database. For more details about defining database schema for Scalar DB, please read [Scalar DB Schema Loader](https://github.com/scalar-labs/scalardb/blob/master/schema-loader/README.md).
 
 #### Register a Function
 


### PR DESCRIPTION
This PR fixes the broken URL about the schema document of Scalar DB.

The following URL referenced in Function's document returns 404 now.
https://github.com/scalar-labs/scalardb/blob/master/docs/schema.md

It seems that the above document `schema.md` has been merged into another document `schema-loader/README.md` in the following PR.

https://github.com/scalar-labs/scalardb/pull/647

Please take a look!
