### PR TITLE
Add document for schema loader

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,3 +35,5 @@
 * [Deploy ScalarDL on AWS](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/ManualDeploymentGuideScalarDLOnAWS.md)
 * [Deploy ScalarDL on Azure](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/ManualDeploymentGuideScalarDLOnAzure.md)
 
+## Schema Loader
+* [How to use ScalarDL Schema Loader](schema-loader.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
 * [A Guide on How to Handle Errors in ScalarDL](how-to-handle-errors.md)
 * [A Guide on How to Use Asset Proofs in ScalarDL](how-to-use-proof.md)
 * [Getting Started with ScalarDL Auditor](getting-started-auditor.md)
+* [How to use ScalarDL Schema Loader](schema-loader.md)
 * [Trouble-shooting Guide](trouble-shooting-guide.md)
 
 ## Client SDKs
@@ -34,6 +35,3 @@
 ## How to Deploy
 * [Deploy ScalarDL on AWS](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/ManualDeploymentGuideScalarDLOnAWS.md)
 * [Deploy ScalarDL on Azure](https://github.com/scalar-labs/scalar-kubernetes/blob/master/docs/ManualDeploymentGuideScalarDLOnAzure.md)
-
-## Schema Loader
-* [How to use ScalarDL Schema Loader](schema-loader.md)

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -1,6 +1,6 @@
-# scalardl-schema-loader
+# ScalarDL Schema Loader
 
-A Docker image that loads the database schema with [Schema Tool for Scalar DB](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/).
+A Docker image that loads the database schemas of ScalarDL using [Schema Tool for Scalar DB](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/).
 
 ## How to Build
 

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -2,12 +2,6 @@
 
 A Docker image that loads the database schemas of ScalarDL using [Schema Tool for Scalar DB](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/).
 
-## How to Build
-
-```console
-docker build . -t ghcr.io/scalar-labs/scalardl-schema-loader:<version>
-```
-
 ## How to Run
 
 ### For Cosmos DB

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -1,0 +1,50 @@
+# scalardl-schema-loader
+
+A Docker image that loads the database schema with [Schema Tool for Scalar DB](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/).
+
+## How to Build
+
+```console
+docker build . -t ghcr.io/scalar-labs/scalardl-schema-loader:<version>
+```
+
+## How to Run
+
+### For Cosmos DB
+
+```console
+docker run --rm [--env SCHEMA_TYPE=auditor] ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
+  --cosmos -h <YOUR_ACCOUNT_URI> -p <YOUR_ACCOUNT_PASSWORD> [-r BASE_RESOURCE_UNIT]
+```
+
+### For DynamoDB
+
+```console
+docker run --rm [--env SCHEMA_TYPE=auditor] ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
+  --dynamo --region <REGION> -u <ACCESS_KEY_ID> -p <SECRET_ACCESS_KEY> [-r BASE_RESOURCE_UNIT]
+```
+
+### For Cassandra
+
+```console
+docker run --rm [--env SCHEMA_TYPE=auditor] ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
+  --cassandra -h <CASSANDRA_IP> -u <CASSNDRA_USER> -p <CASSANDRA_PASSWORD> [-n <NETWORK_STRATEGY> -R <REPLICATION_FACTOR>]
+```
+
+### For using a config file
+
+* For Ledger
+  ```console
+  docker run --rm \
+    -v <PROPERTIES_FILE_PATH>:/scalardl-schema-loader/database.properties.tmpl \
+    ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
+    --config database.properties --coordinator [<SOME_OPTIONS> [, ...]]
+  ```
+
+* For Auditor
+  ```console
+  docker run --rm --env SCHEMA_TYPE=auditor \
+    -v <PROPERTIES_FILE_PATH>:/scalardl-schema-loader/database.properties.tmpl \
+    ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
+    --config database.properties [<SOME_OPTIONS> [, ...]]
+  ```


### PR DESCRIPTION
This PR adds the document for the ScalarDL schema loader.

It is copied from https://github.com/scalar-labs/scalardl-schema-loader/blob/master/docs/README.md

We copy this document because we migrate the schema loader back to the `scalar` main repository. We need to place to let users refer to the document.