### PR TITLE
Add documentation for authentication

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -96,7 +96,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.client.entity.id`
             * Used for identifying a client.
         * `scalar.dl.client.entity.identity.hmac.secret_key`
-            * It is used for signing a request.
+            * Used for signing a request.
         * `scalar.dl.client.entity.identity.hmac.key_version`
     * Ledger-side properties
       * `scalar.dl.ledger.authentication.method` (set "hmac")

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -119,16 +119,16 @@ This section explains what variables you need to configure to use ScalarDL authe
 
 ### Digital signatures
 
-* Register clients' certificates to Ledger (and Auditor).
+* Register clients' certificates to Ledger (and Auditor, if enabled).
     * Use the client library or the command-line tool (`register-cert`).
-* Register contracts to Ledger (and Auditor).
 * Register Auditor's certificates to Ledger.
     * Required only if Auditor is enabled.
 * Register Ledger's certificates to Auditor.
     * Required only if Auditor is enabled.
+* Register contracts to Ledger (and Auditor, if enabled).
 
 ### HMAC
 
-* Register clients' secret keys to Ledger (and Auditor).
+* Register clients' secret keys to Ledger (and Auditor, if enabled).
   * Use the client library or the command-line tool (`register-secret`).
 * Register contracts to Ledger (and Auditor).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -69,7 +69,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.ledger.proof.enabled` (set true)
             * Required because Ledger authentication uses the signatures of asset proofs.
         * `scalar.dl.ledger.proof.private_key_pem` or `scalar.dl.ledger.proof.private_key_path`  
-            * It is used for signing Asset Proofs.
+            * Used for signing asset proofs.
     * Auditor-side properties
         * `scalar.dl.auditor.ledger.cert_holder_id`
         * `scalar.dl.auditor.ledger.cert_version`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -115,7 +115,8 @@ This section explains what variables you need to configure to use the authentica
 
  After configuration, you must do the following to prepare for issuing execution requests.
 
-### Digital Signatures
+### Digital signatures
+
 * Register clients' certificates to Ledger (and Auditor).
     * Use the client library or the command-line tool (`register-cert`).
 * Register contracts to Ledger (and Auditor).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -73,7 +73,7 @@ This section explains what variables you need to configure to use ScalarDL authe
     * Auditor-side properties
         * `scalar.dl.auditor.ledger.cert_holder_id`
         * `scalar.dl.auditor.ledger.cert_version`
-            * It is used for verifying the signatures of Asset Proofs.
+            * Used for verifying the signatures of asset proofs.
 * Auditor authentication
     * Ledger-side properties
         * `scalar.dl.ledger.auditor.cert_holder_id`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -122,7 +122,7 @@ This section explains what variables you need to configure to use the authentica
     * Use the client library or the command-line tool (`register-cert`).
 * Register contracts to Ledger (and Auditor).
 * Register Auditor's certificates to Ledger.
-    * It is needed only when Auditor is enabled.
+    * Required only if Auditor is enabled.
 * Register Ledger's certificates to Auditor.
     * Required only if Auditor is enabled.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,8 +19,8 @@ Also, note that we use the term `signature` here to specify a byte array used fo
 
 ## Authentication methods
 
-ScalarDL supports two authentication methods: Digital Signatures and HMAC.
-The methods have advantages and disadvantages, as shown below, but Byzantine fault detection capability won't be sacrificed either way.
+ScalarDL supports two authentication methods: digital signatures and HMAC.
+Both of these methods have advantages and disadvantages, as described below, but neither method sacrifices Byzantine fault detection capability.
 
 ### Digital Signatures
 * Advantages

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -56,7 +56,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.client.entity.id` (or `scalar.dl.client.cert_holder_id`, which is deprecated.)
             * Used for identifying a client.
         * `scalar.dl.client.entity.identity.digital_signature.cert_pem` or `scalar.dl.client.entity.identity.digital_signature.cert_path` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)
-            * It is used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
+            * Used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
         * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.cert_version`, which is deprecated.)
         * `scalar.dl.client.entity.identity.digital_signature.private_key_pem` or `scalar.dl.client.entity.identity.digital_signature.private_key_path` (or `scalar.dl.client.private_key_pem` or `scalar.dl.client.private_key_path`, which are deprecated.)
             * It is used for signing a request.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -11,7 +11,7 @@ ScalarDL uses authentication in the following three situations:
 * Ledger authentication (for Auditor)
     * Auditor authenticates Ledger using Ledger-generated signatures attached to [Asset Proofs](how-to-use-proof.md).
 * Auditor authentication (for Ledger)
-    * Ledger authenticates Auditor using Auditor-generated signatures attached to client requests.
+    * Ledger authenticates Auditor by using Auditor-generated signatures attached to client requests.
 
 Note that Ledger authentication and Auditor authentication are only used in the Auditor mode. For more details about Auditor, please see the [Getting Started with ScalarDL Auditor](getting-started-auditor.md) and [ScalarDL Implementation](implementation.md).
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -77,7 +77,7 @@ This section explains what variables you need to configure to use ScalarDL authe
 * Auditor authentication
     * Ledger-side properties
         * `scalar.dl.ledger.auditor.cert_holder_id`
-          * It is used for verifying an Auditor-generated signature attached to a client request.
+          * Used for verifying an Auditor-generated signature attached to a client request.
         * `scalar.dl.ledger.auditor.cert_version`
           * It is used for verifying an Auditor-generated signature attached to a client request.
     * Auditor-side properties

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -59,7 +59,7 @@ This section explains what variables you need to configure to use ScalarDL authe
             * Used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
         * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.cert_version`, which is deprecated.)
         * `scalar.dl.client.entity.identity.digital_signature.private_key_pem` or `scalar.dl.client.entity.identity.digital_signature.private_key_path` (or `scalar.dl.client.private_key_pem` or `scalar.dl.client.private_key_path`, which are deprecated.)
-            * It is used for signing a request.
+            * Used for signing a request.
     * Ledger-side properties
       * `scalar.dl.ledger.authentication.method` (set "digital-signature")
     * Auditor-side properties

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -45,7 +45,7 @@ Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor aut
 
 ## Configure
 
-This section explains what variables you need to configure to use the authentication of ScalarDL properly. For the detail of each variable, please also check the [Javadoc](TODO).
+This section explains what variables you need to configure to use ScalarDL authentication properly. For details about each variable, see [Javadoc](TODO).
 
 ### Digital Signatures
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -29,6 +29,7 @@ Both of these methods have advantages and disadvantages, as described below, but
   * Digital Signatures are very slow. They will add non-negligible performance overhead in exchange for the above benefits.
 
 ### HMAC
+
 * Advantages
     * HMAC is way faster than digital signatures.
 * Disadvantages

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -67,7 +67,7 @@ This section explains what variables you need to configure to use ScalarDL authe
 * Ledger authentication 
     * Ledger-side properties
         * `scalar.dl.ledger.proof.enabled` (set true)
-            * It is required because Ledger authentication uses the signatures of Asset Proofs.
+            * Required because Ledger authentication uses the signatures of asset proofs.
         * `scalar.dl.ledger.proof.private_key_pem` or `scalar.dl.ledger.proof.private_key_path`  
             * It is used for signing Asset Proofs.
     * Auditor-side properties

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,4 +1,4 @@
-# A Guide on ScalarDL Authentication
+# ScalarDL Authentication Guide
 
 This document explains the ScalarDL authentication mechanism and how to use it properly. 
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -108,7 +108,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.ledger.proof.enabled` (set true)
             * Required because Ledger authentication uses the signatures of asset proofs.
         * `scalar.dl.ledger.authentication.hmac.cipher_key`
-            * It is used for signing and verifying messages/requests between Ledger and Auditor.
+            * Used for signing and verifying messages and requests between Ledger and Auditor.
     * Auditor-side properties
         * `scalar.dl.auditor.authentication.hmac.cipher_key`
             * It is used for signing and verifying messages/requests between Ledger and Auditor. It must be the same key as `scalar.dl.ledger.authentication.hmac.cipher_key`.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -106,7 +106,7 @@ This section explains what variables you need to configure to use ScalarDL authe
 * Ledger and Auditor authentication
     * Ledger-side properties
         * `scalar.dl.ledger.proof.enabled` (set true)
-            * It is required because Ledger authentication uses the signatures of Asset Proofs.
+            * Required because Ledger authentication uses the signatures of asset proofs.
         * `scalar.dl.ledger.authentication.hmac.cipher_key`
             * It is used for signing and verifying messages/requests between Ledger and Auditor.
     * Auditor-side properties

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -82,7 +82,7 @@ This section explains what variables you need to configure to use ScalarDL authe
           * Used for verifying an Auditor-generated signature attached to a client request.
     * Auditor-side properties
         * `scalar.dl.auditor.cert_holder_id`
-          * It is used for calling Ledger services directly using the client library.
+          * Used for calling Ledger services directly by using the client library.
         * `scalar.dl.auditor.cert_version`
           * It is used for calling Ledger services directly using the client library.
         * `scalar.dl.auditor.private_key_pem` or `scalar.dl.auditor.private_key_path`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -34,7 +34,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 * Advantages
     * HMAC is much faster than digital signatures.
 * Disadvantages
-    * Asset records and asset proofs do not have non-repudiation property.
+    * Asset records and asset proofs do not have the nonrepudiation property.
 
 ### Which should I use?
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,7 +13,7 @@ ScalarDL uses authentication in the following three situations:
 * Auditor authentication (for Ledger)
     * Ledger authenticates Auditor by using Auditor-generated signatures attached to client requests.
 
-Note that Ledger authentication and Auditor authentication are only used in the Auditor mode. For more details about Auditor, please see the [Getting Started with ScalarDL Auditor](getting-started-auditor.md) and [ScalarDL Implementation](implementation.md).
+Note that Ledger authentication and Auditor authentication are only used in the Auditor mode. For more details about Auditor, see [Getting Started with ScalarDL Auditor](getting-started-auditor.md) and [ScalarDL Implementation](implementation.md).
 
 Also, note that we use the term `signature` here to specify a byte array used for authentication.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -84,7 +84,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.auditor.cert_holder_id`
           * Used for calling Ledger services directly by using the client library.
         * `scalar.dl.auditor.cert_version`
-          * It is used for calling Ledger services directly using the client library.
+          * Used for calling Ledger services directly by using the client library.
         * `scalar.dl.auditor.private_key_pem` or `scalar.dl.auditor.private_key_path`
           * It is used for signing a client request and a request from Auditor to Ledger.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,128 @@
+# A Guide on ScalarDL Authentication
+
+This document explains the ScalarDL authentication mechanism and how to use it properly. 
+
+## Authentication in ScalarDL
+
+Authentication is one of the key roles in ScalarDL to make the protocol work as expected.
+ScalarDL uses authentication for the following three places:
+* Client authentication (for Ledger and Auditor)
+    * Client authentication authenticates clients by Ledger and Auditor using client-generated signatures attached to requests from clients.
+* Ledger authentication (for Auditor)
+    * Ledger authentication authenticates Ledger by Auditor using Ledger-generated signatures attached to [Asset Proofs](how-to-use-proof.md).
+* Auditor authentication (for Ledger )
+    * Auditor authentication authenticates Auditor by Ledger using  Auditor-generated signatures attached to client requests.
+
+Note that Ledger authentication and Auditor authentication are only used in the Auditor mode. For more details about Auditor, please see the [Getting Started with ScalarDL Auditor](getting-started-auditor.md) and [ScalarDL Implementation](implementation.md).
+
+## Authentication methods
+
+ScalarDL supports two authentication methods: Digital Signatures and HMAC.
+The methods have advantages and disadvantages, as shown below, but Byzantine fault detection capability won't be sacrificed either way.
+
+### Digital Signatures
+* Advantages
+  * Asset records and asset proofs have non-repudiation property. Specifically, a digital signature attached to a request is stored with the corresponding asset records produced by the request so that the records have non-repudiation property, i.e., we can ensure that the records are created by the owner of the private key that signed the request. Moreover, digital signatures attached to asset proofs returned to a client as the result of execution ensure that the proofs are created by Ledger and Auditor, respectively. If a client (application) keeps the proofs, the client can verify results with the proofs as necessary.
+* Disadvantages
+  * Digital Signatures are very slow. They will add non-negligible performance overhead in exchange for the above benefits.
+
+### HMAC
+* Advantages
+    * HMAC is way faster than digital signatures.
+* Disadvantages
+    * Asset records and asset proofs do not have non-repudiation property.
+
+### Which should I use?
+
+If you do not require non-repudiation property, you should always use HMAC.
+Technically, you could mix authentication methods, e.g., use digital signatures for client authentication and use HMAC for Ledger/Auditor authentication, but it is very confusing; thus, ScalarDL prohibits such usage.
+
+Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor authentication for better performance. Similarly, we plan to unbundle Ledger (Auditor) authentication from how we sign asset proofs. With the above changes, we will be able to return digitally-signed asset proofs while using HMAC authentication between Ledger and Auditor.
+
+## Configure
+
+This section explains what variables you need to configure to use the authentication of ScalarDL properly. For the detail of each variable, please also check the [Javadoc](TODO).
+
+### Digital Signatures
+
+* Client authentication
+    * Client-side properties
+        * `scalar.dl.client.auditor.enabled` (set true if you use Auditor)
+        * `scalar.dl.client.authentication_method` (set "digital-signature")
+        * `scalar.dl.client.entity.id` (or `scalar.dl.client.cert_holder_id`, which is deprecated.)
+            * It is used for identifying a client.
+        * `scalar.dl.client.entity.identity.digital_signature.cert_path` or `scalar.dl.client.entity.identity.digital_signature.cert_pem` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)
+            * It is used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
+        * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.entity.identity.digital_signature.cert_version`, which is deprecated.)
+        * `scalar.dl.client.entity.identity.digital_signature.private_key_pem` or `scalar.dl.client.entity.identity.digital_signature.private_key_path` (or `scalar.dl.client.private_key_pem` or `scalar.dl.client.private_key_path`, which are deprecated.)
+            * It is used for signing a request.
+    * Ledger-side properties
+      * `scalar.dl.ledger.authentication.method` (set "digital-signature")
+    * Auditor-side properties
+      * `scalar.dl.auditor.authentication.method` (set "digital-signature")
+* Ledger authentication 
+    * Ledger-side properties
+        * `scalar.dl.ledger.proof.enabled` (set true)
+            * It is required because Ledger authentication uses the signatures of Asset Proofs.
+        * `scalar.dl.ledger.proof.private_key_pem` or `scalar.dl.ledger.proof.private_key_path`  
+            * It is used for signing Asset Proofs.
+    * Auditor-side properties
+        * `scalar.dl.auditor.ledger.cert_holder_id`
+        * `scalar.dl.auditor.ledger.cert_version`
+            * It is used for verifying the signatures of Asset Proofs.
+* Auditor authentication
+    * Ledger-side properties
+        * `scalar.dl.ledger.auditor.cert_holder_id`
+          * It is used for verifying an Auditor-generated signature attached to a client request.
+        * `scalar.dl.ledger.auditor.cert_version`
+          * It is used for verifying an Auditor-generated signature attached to a client request.
+    * Auditor-side properties
+        * `scalar.dl.auditor.cert_holder_id`
+          * It is used for calling Ledger services directly using the client library.
+        * `scalar.dl.auditor.cert_version`
+          * It is used for calling Ledger services directly using the client library.
+        * `scalar.dl.auditor.private_key_pem` or `scalar.dl.auditor.private_key_path`
+          * It is used for signing a client request and a request from Auditor to Ledger.
+
+### HMAC
+
+* Client authentication
+    * Client-side properties
+        * `scalar.dl.client.authentication_method` (set "hmac")
+        * `scalar.dl.client.entity.id`
+            * It is used for identifying a client.
+        * `scalar.dl.client.entity.identity.hmac.secret_key`
+            * It is used for signing a request.
+        * `scalar.dl.client.entity.identity.hmac.key_version`
+    * Ledger-side properties
+      * `scalar.dl.ledger.authentication.method` (set "hmac")
+    * Auditor-side properties
+      * `scalar.dl.auditor.authentication.method` (set "hmac")
+
+* Ledger and Auditor authentication
+    * Ledger-side properties
+        * `scalar.dl.ledger.proof.enabled` (set true)
+            * It is required because Ledger authentication uses the signatures of Asset Proofs.
+        * `scalar.dl.ledger.authentication.hmac.cipher_key`
+            * It is used for signing and verifying messages/requests between Ledger and Auditor.
+    * Auditor-side properties
+        * `scalar.dl.auditor.authentication.hmac.cipher_key`
+            * It is used for signing and verifying messages/requests between Ledger and Auditor. It must be the same key as `scalar.dl.ledger.authentication.hmac.cipher_key`.
+
+ ## Prepare before executing requests
+
+ After configuration, you must do the following to prepare for issuing execution requests.
+
+### Digital Signatures
+* Register clients' certificates to Ledger (and Auditor).
+    * Use the client library or the command-line tool (`register-cert`).
+* Register contracts to Ledger (and Auditor).
+* Register Auditor's certificates to Ledger.
+    * It is needed only when Auditor is enabled.
+* Register Ledger's certificates to Auditor.
+    * It is needed only when Auditor is enabled.
+
+### HMAC
+* Register clients' secret keys to Ledger (and Auditor).
+  * Use the client library or the command-line tool (`register-secret`).
+* Register contracts to Ledger (and Auditor).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -4,7 +4,7 @@ This document explains the ScalarDL authentication mechanism and how to use it p
 
 ## Authentication in ScalarDL
 
-Authentication is one of the key roles in ScalarDL to make the protocol work as expected.
+Authentication is one of the key roles in ScalarDL and makes the protocol work as expected.
 ScalarDL uses authentication in the following three situations:
 * Client authentication (for Ledger and Auditor)
     * Ledger and Auditor authenticate clients by using client-generated signatures attached to requests from the clients.
@@ -25,7 +25,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 ### Digital signatures
 
 * Advantages
-  * Asset records and asset proofs have the nonrepudiation property. Specifically, a digital signature attached to a request is stored with the corresponding asset records that the request produces so that the records have the nonrepudiation property, i.e., we can ensure that the owner of the private key that signed the request created the records. Moreover, digital signatures attached to asset proofs that are returned to a client as the result of execution ensure that Ledger and Auditor created the proofs, respectively. If a client (application) keeps the proofs, the client can verify the results with the proofs as necessary.
+  * Client requests, asset records, and asset proofs have the nonrepudiation property. Specifically, a digital signature attached to a client request is stored with the corresponding asset records that the request produces so that a client request and the corresponding records have the nonrepudiation property, i.e., we can ensure that the owner of the private key that signed the request created the records. Moreover, digital signatures attached to asset proofs that are returned to a client as the result of execution ensure that Ledger and Auditor created the proofs, respectively. If a client (application) keeps the proofs, the client can verify the results with the proofs as necessary.
 * Disadvantages
   * Digital signatures are very slow. They will add nonnegligible performance overhead in exchange for the above benefits.
 
@@ -34,7 +34,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 * Advantages
     * HMAC is much faster than digital signatures.
 * Disadvantages
-    * Asset records and asset proofs do not have the nonrepudiation property.
+    * Client requests, asset records, and asset proofs do not have the nonrepudiation property.
 
 ### Which should I use?
 
@@ -57,19 +57,23 @@ This section explains what variables you need to configure to use ScalarDL authe
             * Used for identifying a client.
         * `scalar.dl.client.entity.identity.digital_signature.cert_pem` or `scalar.dl.client.entity.identity.digital_signature.cert_path` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)
             * Used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
+            * See [this](https://github.com/scalar-labs/scalardl/blob/master/docs/ca/caclient-getting-started.md) for how to get a certificate.
         * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.cert_version`, which is deprecated.)
         * `scalar.dl.client.entity.identity.digital_signature.private_key_pem` or `scalar.dl.client.entity.identity.digital_signature.private_key_path` (or `scalar.dl.client.private_key_pem` or `scalar.dl.client.private_key_path`, which are deprecated.)
             * Used for signing a request.
+            * See [this](https://github.com/scalar-labs/scalardl/blob/master/docs/ca/caclient-getting-started.md) for how to get a private key.
+        * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.cert_version`, which is deprecated.)
     * Ledger-side properties
-      * `scalar.dl.ledger.authentication.method` (set "digital-signature")
+      * `scalar.dl.ledger.authentication.method` (set to `digital-signature`)
     * Auditor-side properties
-      * `scalar.dl.auditor.authentication.method` (set "digital-signature")
+      * `scalar.dl.auditor.authentication.method` (set to `digital-signature`)
 * Ledger authentication 
     * Ledger-side properties
-        * `scalar.dl.ledger.proof.enabled` (set true)
+        * `scalar.dl.ledger.proof.enabled` (set to `true`)
             * Required because Ledger authentication uses the signatures of asset proofs.
         * `scalar.dl.ledger.proof.private_key_pem` or `scalar.dl.ledger.proof.private_key_path`  
             * Used for signing asset proofs.
+            * See [this](https://github.com/scalar-labs/scalardl/blob/master/docs/ca/caclient-getting-started.md) for how to get a private key.
     * Auditor-side properties
         * `scalar.dl.auditor.ledger.cert_holder_id`
         * `scalar.dl.auditor.ledger.cert_version`
@@ -87,33 +91,43 @@ This section explains what variables you need to configure to use ScalarDL authe
           * Used for calling Ledger services directly by using the client library.
         * `scalar.dl.auditor.private_key_pem` or `scalar.dl.auditor.private_key_path`
           * Used for signing a client request and a request from Auditor to Ledger.
+          * See [this](https://github.com/scalar-labs/scalardl/blob/master/docs/ca/caclient-getting-started.md) for how to get a private key.
 
 ### HMAC
 
 * Client authentication
     * Client-side properties
-        * `scalar.dl.client.authentication_method` (set "hmac")
+        * `scalar.dl.client.authentication_method` (set to `hmac`)
         * `scalar.dl.client.entity.id`
             * Used for identifying a client.
         * `scalar.dl.client.entity.identity.hmac.secret_key`
             * Used for signing a request.
+            * A secret key should be a random long enough value (e.g., 32-character length hex string).
         * `scalar.dl.client.entity.identity.hmac.key_version`
     * Ledger-side properties
-      * `scalar.dl.ledger.authentication.method` (set "hmac")
+      * `scalar.dl.ledger.authentication.method` (set to `hmac`)
     * Auditor-side properties
-      * `scalar.dl.auditor.authentication.method` (set "hmac")
+      * `scalar.dl.auditor.authentication.method` (set to `hmac`)
 
 * Ledger and Auditor authentication
     * Ledger-side properties
-        * `scalar.dl.ledger.proof.enabled` (set true)
+        * `scalar.dl.ledger.proof.enabled` (set to `true`)
             * Required because Ledger authentication uses the signatures of asset proofs.
-        * `scalar.dl.ledger.authentication.hmac.cipher_key`
+        * `scalar.dl.ledger.servers.authentication.hmac.secret_key`
             * Used for signing and verifying messages and requests between Ledger and Auditor.
+            * A secret key should be a random long enough value (e.g., 32-character length hex string).
+        * `scalar.dl.ledger.authentication.hmac.cipher_key`
+            * Used for encrypting and decrypting the secret keys of clients.
+            * A cipher key should be an unpredictable and long enough value.
     * Auditor-side properties
-        * `scalar.dl.auditor.authentication.hmac.cipher_key`
+        * `scalar.dl.auditor.servers.authentication.hmac.secret_key`
             * Used for signing and verifying messages and requests between Ledger and Auditor. Must be the same key as `scalar.dl.ledger.authentication.hmac.cipher_key`.
+            * A secret key should be a random long enough value (e.g., 32-character length hex string).
+        * `scalar.dl.auditor.authentication.hmac.cipher_key`
+            * Used for encrypting and decrypting the secret keys of clients.
+            * A cipher key should be an unpredictable and long enough value.
 
- ## Prepare before executing requests
+## Prepare before executing requests
 
  After configuration, you must do the following to prepare for issuing execution requests.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -27,7 +27,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 * Advantages
   * Asset records and asset proofs have the nonrepudiation property. Specifically, a digital signature attached to a request is stored with the corresponding asset records that the request produces so that the records have the nonrepudiation property, i.e., we can ensure that the owner of the private key that signed the request created the records. Moreover, digital signatures attached to asset proofs that are returned to a client as the result of execution ensure that Ledger and Auditor created the proofs, respectively. If a client (application) keeps the proofs, the client can verify the results with the proofs as necessary.
 * Disadvantages
-  * Digital Signatures are very slow. They will add non-negligible performance overhead in exchange for the above benefits.
+  * Digital signatures are very slow. They will add nonnegligible performance overhead in exchange for the above benefits.
 
 ### HMAC
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -127,6 +127,7 @@ This section explains what variables you need to configure to use the authentica
     * Required only if Auditor is enabled.
 
 ### HMAC
+
 * Register clients' secret keys to Ledger (and Auditor).
   * Use the client library or the command-line tool (`register-secret`).
 * Register contracts to Ledger (and Auditor).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -25,7 +25,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 ### Digital signatures
 
 * Advantages
-  * Asset records and asset proofs have non-repudiation property. Specifically, a digital signature attached to a request is stored with the corresponding asset records produced by the request so that the records have non-repudiation property, i.e., we can ensure that the records are created by the owner of the private key that signed the request. Moreover, digital signatures attached to asset proofs returned to a client as the result of execution ensure that the proofs are created by Ledger and Auditor, respectively. If a client (application) keeps the proofs, the client can verify results with the proofs as necessary.
+  * Asset records and asset proofs have the nonrepudiation property. Specifically, a digital signature attached to a request is stored with the corresponding asset records that the request produces so that the records have the nonrepudiation property, i.e., we can ensure that the owner of the private key that signed the request created the records. Moreover, digital signatures attached to asset proofs that are returned to a client as the result of execution ensure that Ledger and Auditor created the proofs, respectively. If a client (application) keeps the proofs, the client can verify the results with the proofs as necessary.
 * Disadvantages
   * Digital Signatures are very slow. They will add non-negligible performance overhead in exchange for the above benefits.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -38,7 +38,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 
 ### Which should I use?
 
-If you do not require non-repudiation property, you should always use HMAC.
+If you do not require the nonrepudiation property, you should always use HMAC.
 Technically, you could mix authentication methods, e.g., use digital signatures for client authentication and use HMAC for Ledger/Auditor authentication, but it is very confusing; thus, ScalarDL prohibits such usage.
 
 Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor authentication for better performance. Similarly, we plan to unbundle Ledger (Auditor) authentication from how we sign asset proofs. With the above changes, we will be able to return digitally-signed asset proofs while using HMAC authentication between Ledger and Auditor.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -39,7 +39,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 ### Which should I use?
 
 If you do not require the nonrepudiation property, you should always use HMAC.
-Technically, you could mix authentication methods, e.g., use digital signatures for client authentication and use HMAC for Ledger/Auditor authentication, but it is very confusing; thus, ScalarDL prohibits such usage.
+Technically, you could mix authentication methods, like using digital signatures for client authentication and HMAC for Ledger/Auditor authentication. However, because mixing methods can be very confusing, ScalarDL prohibits such usage.
 
 Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor authentication for better performance. Similarly, we plan to unbundle Ledger (Auditor) authentication from how we sign asset proofs. With the above changes, we will be able to return digitally-signed asset proofs while using HMAC authentication between Ledger and Auditor.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -51,7 +51,7 @@ This section explains what variables you need to configure to use ScalarDL authe
 
 * Client authentication
     * Client-side properties
-        * `scalar.dl.client.auditor.enabled` (set true if you use Auditor)
+        * `scalar.dl.client.auditor.enabled` (set to `true` if you use Auditor)
         * `scalar.dl.client.authentication_method` (set "digital-signature")
         * `scalar.dl.client.entity.id` (or `scalar.dl.client.cert_holder_id`, which is deprecated.)
             * It is used for identifying a client.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,7 +7,7 @@ This document explains the ScalarDL authentication mechanism and how to use it p
 Authentication is one of the key roles in ScalarDL to make the protocol work as expected.
 ScalarDL uses authentication in the following three situations:
 * Client authentication (for Ledger and Auditor)
-    * Ledger and Auditor authenticates clients using client-generated signatures attached to requests from the clients.
+    * Ledger and Auditor authenticate clients by using client-generated signatures attached to requests from the clients.
 * Ledger authentication (for Auditor)
     * Auditor authenticates Ledger using Ledger-generated signatures attached to [Asset Proofs](how-to-use-proof.md).
 * Auditor authentication (for Ledger)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -53,9 +53,9 @@ This section explains what variables you need to configure to use the authentica
         * `scalar.dl.client.authentication_method` (set "digital-signature")
         * `scalar.dl.client.entity.id` (or `scalar.dl.client.cert_holder_id`, which is deprecated.)
             * It is used for identifying a client.
-        * `scalar.dl.client.entity.identity.digital_signature.cert_path` or `scalar.dl.client.entity.identity.digital_signature.cert_pem` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)
+        * `scalar.dl.client.entity.identity.digital_signature.cert_pem` or `scalar.dl.client.entity.identity.digital_signature.cert_path` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)
             * It is used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
-        * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.entity.identity.digital_signature.cert_version`, which is deprecated.)
+        * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.cert_version`, which is deprecated.)
         * `scalar.dl.client.entity.identity.digital_signature.private_key_pem` or `scalar.dl.client.entity.identity.digital_signature.private_key_path` (or `scalar.dl.client.private_key_pem` or `scalar.dl.client.private_key_path`, which are deprecated.)
             * It is used for signing a request.
     * Ledger-side properties

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -32,7 +32,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 ### HMAC
 
 * Advantages
-    * HMAC is way faster than digital signatures.
+    * HMAC is much faster than digital signatures.
 * Disadvantages
     * Asset records and asset proofs do not have non-repudiation property.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -102,7 +102,7 @@ This section explains what variables you need to configure to use ScalarDL authe
             * Used for identifying a client.
         * `scalar.dl.client.entity.identity.hmac.secret_key`
             * Used for signing a request.
-            * A secret key should be a random long enough value (e.g., 32-character length hex string).
+            * A secret key should be a random, lengthy value (e.g., 32-character length hex string).
         * `scalar.dl.client.entity.identity.hmac.key_version`
     * Ledger-side properties
       * `scalar.dl.ledger.authentication.method` (set to `hmac`)
@@ -115,17 +115,17 @@ This section explains what variables you need to configure to use ScalarDL authe
             * Required because Ledger authentication uses the signatures of asset proofs.
         * `scalar.dl.ledger.servers.authentication.hmac.secret_key`
             * Used for signing and verifying messages and requests between Ledger and Auditor.
-            * A secret key should be a random long enough value (e.g., 32-character length hex string).
+            * A secret key should be a random, lengthy value (e.g., 32-character length hex string).
         * `scalar.dl.ledger.authentication.hmac.cipher_key`
             * Used for encrypting and decrypting the secret keys of clients.
-            * A cipher key should be an unpredictable and long enough value.
+            * A cipher key should be an unpredictable, lengthy value.
     * Auditor-side properties
         * `scalar.dl.auditor.servers.authentication.hmac.secret_key`
-            * Used for signing and verifying messages and requests between Ledger and Auditor. Must be the same key as `scalar.dl.ledger.authentication.hmac.cipher_key`.
-            * A secret key should be a random long enough value (e.g., 32-character length hex string).
+            * Used for signing and verifying messages and requests between Ledger and Auditor. Must be the same key as `scalar.dl.ledger.servers.authentication.hmac.secret_key`.
+            * A secret key should be a random, lengthy value (e.g., 32-character length hex string).
         * `scalar.dl.auditor.authentication.hmac.cipher_key`
             * Used for encrypting and decrypting the secret keys of clients.
-            * A cipher key should be an unpredictable and long enough value.
+            * A cipher key should be an unpredictable, lengthy value.
 
 ## Prepare before executing requests
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -5,7 +5,7 @@ This document explains the ScalarDL authentication mechanism and how to use it p
 ## Authentication in ScalarDL
 
 Authentication is one of the key roles in ScalarDL to make the protocol work as expected.
-ScalarDL uses authentication for the following three places:
+ScalarDL uses authentication in the following three situations:
 * Client authentication (for Ledger and Auditor)
     * Ledger and Auditor authenticates clients using client-generated signatures attached to requests from the clients.
 * Ledger authentication (for Auditor)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -22,7 +22,8 @@ Also, note that we use the term `signature` here to specify a byte array used fo
 ScalarDL supports two authentication methods: digital signatures and HMAC.
 Both of these methods have advantages and disadvantages, as described below, but neither method sacrifices Byzantine fault detection capability.
 
-### Digital Signatures
+### Digital signatures
+
 * Advantages
   * Asset records and asset proofs have non-repudiation property. Specifically, a digital signature attached to a request is stored with the corresponding asset records produced by the request so that the records have non-repudiation property, i.e., we can ensure that the records are created by the owner of the private key that signed the request. Moreover, digital signatures attached to asset proofs returned to a client as the result of execution ensure that the proofs are created by Ledger and Auditor, respectively. If a client (application) keeps the proofs, the client can verify results with the proofs as necessary.
 * Disadvantages

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -41,7 +41,7 @@ Both of these methods have advantages and disadvantages, as described below, but
 If you do not require the nonrepudiation property, you should always use HMAC.
 Technically, you could mix authentication methods, like using digital signatures for client authentication and HMAC for Ledger/Auditor authentication. However, because mixing methods can be very confusing, ScalarDL prohibits such usage.
 
-Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor authentication for better performance. Similarly, we plan to unbundle Ledger (Auditor) authentication from how we sign asset proofs. With the above changes, we will be able to return digitally-signed asset proofs while using HMAC authentication between Ledger and Auditor.
+Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor authentication for better performance. Similarly, we plan to unbundle Ledger and Auditor authentication from how we sign asset proofs. With the above changes, we will be able to return digitally signed asset proofs while using HMAC authentication between Ledger and Auditor.
 
 ## Configure
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -52,7 +52,7 @@ This section explains what variables you need to configure to use ScalarDL authe
 * Client authentication
     * Client-side properties
         * `scalar.dl.client.auditor.enabled` (set to `true` if you use Auditor)
-        * `scalar.dl.client.authentication_method` (set "digital-signature")
+        * `scalar.dl.client.authentication_method` (set to `digital-signature`)
         * `scalar.dl.client.entity.id` (or `scalar.dl.client.cert_holder_id`, which is deprecated.)
             * It is used for identifying a client.
         * `scalar.dl.client.entity.identity.digital_signature.cert_pem` or `scalar.dl.client.entity.identity.digital_signature.cert_path` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -94,7 +94,7 @@ This section explains what variables you need to configure to use ScalarDL authe
     * Client-side properties
         * `scalar.dl.client.authentication_method` (set "hmac")
         * `scalar.dl.client.entity.id`
-            * It is used for identifying a client.
+            * Used for identifying a client.
         * `scalar.dl.client.entity.identity.hmac.secret_key`
             * It is used for signing a request.
         * `scalar.dl.client.entity.identity.hmac.key_version`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -9,7 +9,7 @@ ScalarDL uses authentication in the following three situations:
 * Client authentication (for Ledger and Auditor)
     * Ledger and Auditor authenticate clients by using client-generated signatures attached to requests from the clients.
 * Ledger authentication (for Auditor)
-    * Auditor authenticates Ledger using Ledger-generated signatures attached to [Asset Proofs](how-to-use-proof.md).
+    * Auditor authenticates Ledger by using Ledger-generated signatures attached to [asset proofs](how-to-use-proof.md).
 * Auditor authentication (for Ledger)
     * Ledger authenticates Auditor by using Auditor-generated signatures attached to client requests.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -79,7 +79,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.ledger.auditor.cert_holder_id`
           * Used for verifying an Auditor-generated signature attached to a client request.
         * `scalar.dl.ledger.auditor.cert_version`
-          * It is used for verifying an Auditor-generated signature attached to a client request.
+          * Used for verifying an Auditor-generated signature attached to a client request.
     * Auditor-side properties
         * `scalar.dl.auditor.cert_holder_id`
           * It is used for calling Ledger services directly using the client library.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -86,7 +86,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.auditor.cert_version`
           * Used for calling Ledger services directly by using the client library.
         * `scalar.dl.auditor.private_key_pem` or `scalar.dl.auditor.private_key_path`
-          * It is used for signing a client request and a request from Auditor to Ledger.
+          * Used for signing a client request and a request from Auditor to Ledger.
 
 ### HMAC
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -47,7 +47,7 @@ Note that we plan to update ScalarDL to use only HMAC for Ledger and Auditor aut
 
 This section explains what variables you need to configure to use ScalarDL authentication properly. For details about each variable, see [Javadoc](TODO).
 
-### Digital Signatures
+### Digital signatures
 
 * Client authentication
     * Client-side properties

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -111,7 +111,7 @@ This section explains what variables you need to configure to use ScalarDL authe
             * Used for signing and verifying messages and requests between Ledger and Auditor.
     * Auditor-side properties
         * `scalar.dl.auditor.authentication.hmac.cipher_key`
-            * It is used for signing and verifying messages/requests between Ledger and Auditor. It must be the same key as `scalar.dl.ledger.authentication.hmac.cipher_key`.
+            * Used for signing and verifying messages and requests between Ledger and Auditor. Must be the same key as `scalar.dl.ledger.authentication.hmac.cipher_key`.
 
  ## Prepare before executing requests
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -123,7 +123,7 @@ This section explains what variables you need to configure to use the authentica
 * Register Auditor's certificates to Ledger.
     * It is needed only when Auditor is enabled.
 * Register Ledger's certificates to Auditor.
-    * It is needed only when Auditor is enabled.
+    * Required only if Auditor is enabled.
 
 ### HMAC
 * Register clients' secret keys to Ledger (and Auditor).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -54,7 +54,7 @@ This section explains what variables you need to configure to use ScalarDL authe
         * `scalar.dl.client.auditor.enabled` (set to `true` if you use Auditor)
         * `scalar.dl.client.authentication_method` (set to `digital-signature`)
         * `scalar.dl.client.entity.id` (or `scalar.dl.client.cert_holder_id`, which is deprecated.)
-            * It is used for identifying a client.
+            * Used for identifying a client.
         * `scalar.dl.client.entity.identity.digital_signature.cert_pem` or `scalar.dl.client.entity.identity.digital_signature.cert_path` (or `scalar.dl.client.cert_pem` or `scalar.dl.client.cert_path`, which are deprecated.)
             * It is used for registering a certificate for Ledger and Auditor to verify a client-generated signature.
         * `scalar.dl.client.entity.identity.digital_signature.cert_version` (or `scalar.dl.client.cert_version`, which is deprecated.)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -7,13 +7,15 @@ This document explains the ScalarDL authentication mechanism and how to use it p
 Authentication is one of the key roles in ScalarDL to make the protocol work as expected.
 ScalarDL uses authentication for the following three places:
 * Client authentication (for Ledger and Auditor)
-    * Client authentication authenticates clients by Ledger and Auditor using client-generated signatures attached to requests from clients.
+    * Ledger and Auditor authenticates clients using client-generated signatures attached to requests from the clients.
 * Ledger authentication (for Auditor)
-    * Ledger authentication authenticates Ledger by Auditor using Ledger-generated signatures attached to [Asset Proofs](how-to-use-proof.md).
-* Auditor authentication (for Ledger )
-    * Auditor authentication authenticates Auditor by Ledger using  Auditor-generated signatures attached to client requests.
+    * Auditor authenticates Ledger using Ledger-generated signatures attached to [Asset Proofs](how-to-use-proof.md).
+* Auditor authentication (for Ledger)
+    * Ledger authenticates Auditor using Auditor-generated signatures attached to client requests.
 
 Note that Ledger authentication and Auditor authentication are only used in the Auditor mode. For more details about Auditor, please see the [Getting Started with ScalarDL Auditor](getting-started-auditor.md) and [ScalarDL Implementation](implementation.md).
+
+Also, note that we use the term `signature` here to specify a byte array used for authentication.
 
 ## Authentication methods
 


### PR DESCRIPTION
This PR adds documentation that explains the ScalarDL authentication mechanism and how to use it properly. 

To @reddikih,
Please take a look and try both DS and HMAC based on the doc to see if it works. 

To all,
feel free to ask questions. Based on feedback, I will update the doc.
