### PR TITLE
Update properties file name

### DIFF
--- a/docs/getting-started-auditor.md
+++ b/docs/getting-started-auditor.md
@@ -66,7 +66,7 @@ By default, Auditor assumes Ledger registers its certificate with a name `ledger
 
 Other values are optional here but they need to be updated depending on an environment.
 For example, if you place Ledger and Auditor in different hosts, you need to update `scalar.dl.auditor.ledger.host` for Auditor to be able to access Ledger.
-Please check [the configuration file](https://github.com/scalar-labs/scalar/blob/master/auditor/conf/auditor.properties.tmpl) for more detail.
+Please check [the configuration file](https://github.com/scalar-labs/scalar/blob/master/auditor/conf/auditor.properties) for more detail.
 
 
 ## Start Ledger and Auditor

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -30,7 +30,7 @@ docker run --rm [--env SCHEMA_TYPE=auditor] ghcr.io/scalar-labs/scalardl-schema-
 * For Ledger
   ```console
   docker run --rm \
-    -v <PROPERTIES_FILE_PATH>:/scalardl-schema-loader/database.properties.tmpl \
+    -v <PROPERTIES_FILE_PATH>:/scalardl-schema-loader/database.properties \
     ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
     --config database.properties --coordinator [<SOME_OPTIONS> [, ...]]
   ```
@@ -38,7 +38,7 @@ docker run --rm [--env SCHEMA_TYPE=auditor] ghcr.io/scalar-labs/scalardl-schema-
 * For Auditor
   ```console
   docker run --rm --env SCHEMA_TYPE=auditor \
-    -v <PROPERTIES_FILE_PATH>:/scalardl-schema-loader/database.properties.tmpl \
+    -v <PROPERTIES_FILE_PATH>:/scalardl-schema-loader/database.properties \
     ghcr.io/scalar-labs/scalardl-schema-loader:<version> \
     --config database.properties [<SOME_OPTIONS> [, ...]]
   ```


### PR DESCRIPTION
This PR updates the properties file name. Now, we use `*.properties` file instead of `*.properties.tmpl` file.
This is because we removed the `dockerize` command from each container image.

https://github.com/scalar-labs/scalar/pull/942
https://github.com/scalar-labs/scalar/pull/947

Please take a look!
