### PR TITLE
Change HTML syntax to Markdown for images

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,9 +10,7 @@ ScalarDL is scalable and practical Byzantine fault detection middleware for tran
 ScalarDL is composed of Ledger, Auditor, and Client SDK as shown in the following figure. ScalarDL Ledger manages application data in its own unique way using hash-chain and digital signature. ScalarDL Auditor is an optional component and manages a copy of Ledger data without depending on Ledger to identify the discrepancy between Ledger and Auditor data.
 The Client SDK is a set of user-facing programs to interact with Ledger and Auditor. For more details, please read the [design doc](design.md) and [implementation details](implementation.md).
 
-<p align="center">
-<img src="images/scalardl.png" width="480" />
-</p>
+![](images/scalardl.png)
 
 ScalarDL (Ledger and Auditor) abstracts data as a set of assets, where each asset is composed of the history of a record identified by a key called `asset_id` and a historical version number called `age`.
 In this document, you will create a very simple application to manage an asset's status using ScalarDL Client SDK.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -8,9 +8,7 @@ For the architecture, novelty and Byzantine fault detection protocol of ScalarDL
 
 ScalarDL is middleware that runs on top of databases and is mainly written in Java. ScalarDL is composed of Ledger, Auditor, and Client SDK. Let's look at each component.
 
-<p align="center">
-<img src="images/scalardl.png" width="480" />
-</p>
+![](images/scalardl.png)
 
 ### Ledger
 

--- a/docs/trouble-shooting-guide.md
+++ b/docs/trouble-shooting-guide.md
@@ -210,17 +210,13 @@ There are mainly two inconsistent cases. The first case is when a transaction lo
 
 In the first case, after a transaction has read, inserted or updated some records and has committed them successfully, the following transaction can't get the inserted records or can get the values on the records which are the old values before the transaction. For example, on the right side of the below figure, transaction `TX 2` has transferred 100 coins from the balance of A to that of B, but the balance of A hasn't updated. You might see the success log about `TX 2` in logs of your application, but the record hasn't been updated.
 
-<p align="center">
-<img src="https://github.com/scalar-labs/scalardl/raw/master/docs/images/inconsistency_committed.png" width="480" />
-</p>
+![](images/inconsistency_committed.png)
 
 If you find this just after this committed transaction, it is easy to identify the transaction. However, the following transactions might update the record since it didn't alert you. In this case, you need to trace logs related to the record one by one.
 
 In the second case, after a transaction has failed, other transactions get the inserted or updated values on the records which the transaction tried to update. For example, on the right side of the below figure, transaction `TX 4` has been aborted, but the balance of B has been updated unexpectedly.
 
-<p align="center">
-<img src="https://github.com/scalar-labs/scalardl/raw/master/docs/images/inconsistency_aborted.png" width="480" />
-</p>
+![](images/inconsistency_aborted.png)
 
 As the previous case, it is easy to see that just after the transaction. If not, you need to trace logs and find the suspicious transaction.
 


### PR DESCRIPTION
This PR changes how images are inserted into documentation. 

Previously, the docs used HTML syntax to add images. However, Jekyll, the static site generator that [our docs site](https://developers.scalar-labs.com/docs) is based on, cannot render those images because we have `permalink: pretty` enabled in the configuration.

> **Note**
> 
> `permalink: pretty` makes URLs a bit easier to read. For more information, see [Built-in formats | Permalinks](https://jekyllrb.com/docs/permalinks/#built-in-formats) and [Permalinks | Jekyll Style Guide](https://ben.balter.com/jekyll-style-guide/permalinks/).

Markdown syntax supports adding images, so I've updated the docs to follow that standard.