### PR TITLE
Add a redirect from the docs site hosted in this repository to the new docs site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,9 @@
+# Note: This file is used only for redirecting visitors from the old ScalarDL docs site hosted in this repository to the new ScalarDL docs site. This file can be deleted after the old ScalarDL docs site hosted in this repository is no longer deployed.
+google_analytics: "G-Q4TKS77KCP"
+
+defaults:
+  - scope:
+      path: "docs" # Specifies where the docs are located.
+      type: "default" # Defines the type for docs.
+    values:
+      layout: default # Defines the template type used for docs (templates are located in the "_layouts" folder). 

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,11 @@
+<!-- 
+  Note: This file is used only for checking traffic when redirecting visitors from the old ScalarDL docs site hosted in this repository to the new ScalarDL docs site. This file can be deleted after the old ScalarDL docs site hosted in this repository is no longer deployed.
+-->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,13 @@
+<!-- 
+  Note: This file is used only for redirecting visitors from the old ScalarDL docs site hosted in this repository to the new ScalarDL docs site. This file can be deleted after the old ScalarDL docs site hosted in this repository is no longer deployed.
+-->
+---
+---
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://scalardl.scalar-labs.com/docs?utm_source=old-docs-site&utm_medium=github&utm_campaign=redirect" />
+    {% if site.google_analytics and jekyll.environment == 'production' %}
+    {% include analytics.html %}
+    {% endif %}
+  </head>
+</html>


### PR DESCRIPTION
This PR adds files related to Jekyll (static site generator) to add the following functionality:

- Automatically redirect visitors from the previous ScalarDL docs site (hosted in this repository) to the [new ScalarDL docs site](https://scalardl.scalar-labs.com/docs).
- Track visits to the previous ScalarDL docs site (hosted in this repository) so that we can decommission it in the future (after confirming minimal or no impact on visitors).

I have tested the redirect (with different URLs) in my personal repository. In my test, I confirmed the redirect works as expected. Regardless of the page the visitor lands on on the previous docs site, they will be redirected to the new ScalarDL docs home page.