### PR TITLE
Add notice about the relocation of docs

### DIFF
--- a/docs/applications/escrow-payment/README.md
+++ b/docs/applications/escrow-payment/README.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Escrow payment CLI
 

--- a/docs/applications/escrow-payment/README.md
+++ b/docs/applications/escrow-payment/README.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Escrow payment CLI
 
 The following is a simple Java CLI application to try out and test [ScalarDL](https://github.com/scalar-labs/scalardl). PicoCLI is used as a CLI framework.

--- a/docs/applications/escrow-payment/README.md
+++ b/docs/applications/escrow-payment/README.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/applications/simple-bank-account/README.md
+++ b/docs/applications/simple-bank-account/README.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # A simple bank account application
 
 ## Overview

--- a/docs/applications/simple-bank-account/README.md
+++ b/docs/applications/simple-bank-account/README.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/applications/simple-bank-account/README.md
+++ b/docs/applications/simple-bank-account/README.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # A simple bank account application
 

--- a/docs/applications/simple-bank-account/docs/api_endpoints.md
+++ b/docs/applications/simple-bank-account/docs/api_endpoints.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # API endpoints
 
 ## `GET v1/accounts`

--- a/docs/applications/simple-bank-account/docs/api_endpoints.md
+++ b/docs/applications/simple-bank-account/docs/api_endpoints.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/applications/simple-bank-account/docs/api_endpoints.md
+++ b/docs/applications/simple-bank-account/docs/api_endpoints.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # API endpoints
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Authentication Guide
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Authentication Guide
 
 This document explains the ScalarDL authentication mechanism and how to use it properly. 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # A Guide on How to Backup and Restore Data in ScalarDL
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # A Guide on How to Backup and Restore Data in ScalarDL
 
 Since ScalarDL uses ScalarDB that provides transaction capability on top of non-transactional (possibly transactional) databases non-invasively,

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/ca/caclient-getting-started.md
+++ b/docs/ca/caclient-getting-started.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/ca/caclient-getting-started.md
+++ b/docs/ca/caclient-getting-started.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # How to get a certificate
 
 This document describes how to get a certificate to enroll in ScalarDL network.

--- a/docs/ca/caclient-getting-started.md
+++ b/docs/ca/caclient-getting-started.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # How to get a certificate
 

--- a/docs/ca/caserver-getting-started.md
+++ b/docs/ca/caserver-getting-started.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # How to start CA sever with CFSSL
 

--- a/docs/ca/caserver-getting-started.md
+++ b/docs/ca/caserver-getting-started.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/ca/caserver-getting-started.md
+++ b/docs/ca/caserver-getting-started.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # How to start CA sever with CFSSL
 
 This document describes how to start CA server with CFSSL.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Compatibility Matrix
 
 This document shows ScalarDL Ledger and Auditor compatibility with the ScalarDL Java Client SDK.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Compatibility Matrix
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL design document
 
 Please take a look at the following paper.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL design document
 

--- a/docs/getting-started-auditor.md
+++ b/docs/getting-started-auditor.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # Getting Started with ScalarDL Auditor
 

--- a/docs/getting-started-auditor.md
+++ b/docs/getting-started-auditor.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # Getting Started with ScalarDL Auditor
 
 This document explains how to get started with ScalarDL Auditor.

--- a/docs/getting-started-auditor.md
+++ b/docs/getting-started-auditor.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # Getting Started with ScalarDL
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # Getting Started with ScalarDL
 
 This document explains how to get started with ScalarDL by running your first simple contract using the Client SDK.

--- a/docs/how-to-handle-errors.md
+++ b/docs/how-to-handle-errors.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # A Guide on How to Handle Errors in ScalarDL
 

--- a/docs/how-to-handle-errors.md
+++ b/docs/how-to-handle-errors.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/how-to-handle-errors.md
+++ b/docs/how-to-handle-errors.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # A Guide on How to Handle Errors in ScalarDL
 
 This document sets out some guidelines for handling errors in ScalarDL.

--- a/docs/how-to-use-proof.md
+++ b/docs/how-to-use-proof.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # A Guide on How to Use Asset Proofs in ScalarDL
 

--- a/docs/how-to-use-proof.md
+++ b/docs/how-to-use-proof.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/how-to-use-proof.md
+++ b/docs/how-to-use-proof.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # A Guide on How to Use Asset Proofs in ScalarDL
 
 This document sets out some guidelines for using Asset Proofs in ScalarDL.

--- a/docs/how-to-write-contract.md
+++ b/docs/how-to-write-contract.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # A Guide on How to Write a Good Contract for ScalarDL
 

--- a/docs/how-to-write-contract.md
+++ b/docs/how-to-write-contract.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/how-to-write-contract.md
+++ b/docs/how-to-write-contract.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # A Guide on How to Write a Good Contract for ScalarDL
 
 This document sets out some guidelines for writing contracts for ScalarDL.

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # A Guide on How to Write Function for ScalarDL
 
 This document sets out some guidelines for writing functions for ScalarDL.

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # A Guide on How to Write Function for ScalarDL
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Implementation
 
 ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems, which achieves correctness, scalability, and database agnosticism.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Implementation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Docs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Docs
 
 ## Design and Implementation

--- a/docs/installation-with-docker.md
+++ b/docs/installation-with-docker.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # How to install ScalarDL in your local environment with Docker
 
 This document shows how to set up a local environment that runs ScalarDL

--- a/docs/installation-with-docker.md
+++ b/docs/installation-with-docker.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # How to install ScalarDL in your local environment with Docker
 

--- a/docs/installation-with-docker.md
+++ b/docs/installation-with-docker.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/javadoc/index.md
+++ b/docs/javadoc/index.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Javadoc
 

--- a/docs/javadoc/index.md
+++ b/docs/javadoc/index.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/javadoc/index.md
+++ b/docs/javadoc/index.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Javadoc
 
 * [latest](./latest/index.md)

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # ScalarDL Schema Loader
 
 A Docker image that loads the database schemas of ScalarDL using [Schema Tool for Scalar DB](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/).

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/schema-loader.md
+++ b/docs/schema-loader.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # ScalarDL Schema Loader
 

--- a/docs/trouble-shooting-guide.md
+++ b/docs/trouble-shooting-guide.md
@@ -1,3 +1,7 @@
+> [!ATTENTION]
+> 
+> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+
 # Trouble-shooting Guilde
 
 - [Introduction](#introduction)

--- a/docs/trouble-shooting-guide.md
+++ b/docs/trouble-shooting-guide.md
@@ -1,4 +1,4 @@
-> [!ATTENTION]
+> [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
 

--- a/docs/trouble-shooting-guide.md
+++ b/docs/trouble-shooting-guide.md
@@ -1,6 +1,8 @@
 > [!CAUTION]
 > 
 > The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
+> 
+> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
 
 # Trouble-shooting Guilde
 


### PR DESCRIPTION
## Description

This PR adds a cautionary notice to the top of docs in the `docs` folder. Since those docs should now be updated in the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository, the cautionary notice that I've added here is to provide guidance for those who may not know where to update the docs.

> [!NOTE]
>
> If the cautionary notice that I've added in this PR looks OK, I'll submit a similar PR that includes adding the same cautionary notice to docs in other ScalarDL-related repositories.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made

- Added a cautionary notice to the top of each doc in the `docs` folder, stating that the doc should be updated in the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `docs` folder in this repository can be deleted after we have moved all product docs to the [scalar-labs/docs-internal](https://github.com/scalar-labs/docs-internal) repository and confirmed that the migration was a success.

## Release notes

N/A