### PR TITLE
Update old ScalarDL cli commands with new subcommands for v3.9.0

### DIFF
--- a/docs/applications/escrow-payment/Makefile
+++ b/docs/applications/escrow-payment/Makefile
@@ -13,7 +13,7 @@ register-all: register-cert register-contracts
 
 register-cert:
 	@echo "Registering certificate ..."
-	@client/bin/register-cert --properties client.properties
+	@client/bin/scalardl register-cert --properties client.properties
 
 assemble: clear
 	@echo "Building contracts ..."
@@ -21,21 +21,21 @@ assemble: clear
 
 register-contracts: assemble
 	@echo "Registering contracts ..."
-	@client/bin/register-contract --properties client.properties --contract-id AddAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.AddAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/AddAccount.class
-	@client/bin/register-contract --properties client.properties --contract-id AddItem_foo --contract-binary-name com.ypeckstadt.escrow.contract.item.AddItem --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/item/AddItem.class
-	@client/bin/register-contract --properties client.properties --contract-id AddOrder_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.AddOrder --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/AddOrder.class
-	@client/bin/register-contract --properties client.properties --contract-id CancelOrder_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.CancelOrder --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/CancelOrder.class
-	@client/bin/register-contract --properties client.properties --contract-id ChargeAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.ChargeAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/ChargeAccount.class
-	@client/bin/register-contract --properties client.properties --contract-id SetOrderToReceivedStatus_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.SetOrderToReceivedStatus --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/SetOrderToReceivedStatus.class
-	@client/bin/register-contract --properties client.properties --contract-id SetOrderToShippedStatus_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.SetOrderToShippedStatus --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/SetOrderToShippedStatus.class
-	@client/bin/register-contract --properties client.properties --contract-id ViewAccountHistory_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.ViewAccountHistory --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/ViewAccountHistory.class
-	@client/bin/register-contract --properties client.properties --contract-id ViewItem_foo --contract-binary-name com.ypeckstadt.escrow.contract.item.ViewItem --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/item/ViewItem.class
-	@client/bin/register-contract --properties client.properties --contract-id DebitEscrowAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.DebitEscrowAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/DebitEscrowAccount.class
-	@client/bin/register-contract --properties client.properties --contract-id CreditEscrowAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.CreditEscrowAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/CreditEscrowAccount.class
-	@client/bin/register-contract --properties client.properties --contract-id CreditAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.CreditAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/CreditAccount.class
-	@client/bin/register-contract --properties client.properties --contract-id DebitAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.DebitAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/DebitAccount.class
-	@client/bin/register-contract --properties client.properties --contract-id ViewOrderHistory_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.ViewOrderHistory --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/ViewOrderHistory.class
-	@client/bin/register-contract --properties client.properties --contract-id ViewEscrowAccountHistory_foo --contract-binary-name com.ypeckstadt.escrow.contract.escrowAccount.ViewEscrowAccountHistory --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/escrowAccount/ViewEscrowAccountHistory.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id AddAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.AddAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/AddAccount.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id AddItem_foo --contract-binary-name com.ypeckstadt.escrow.contract.item.AddItem --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/item/AddItem.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id AddOrder_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.AddOrder --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/AddOrder.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id CancelOrder_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.CancelOrder --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/CancelOrder.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id ChargeAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.ChargeAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/ChargeAccount.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id SetOrderToReceivedStatus_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.SetOrderToReceivedStatus --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/SetOrderToReceivedStatus.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id SetOrderToShippedStatus_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.SetOrderToShippedStatus --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/SetOrderToShippedStatus.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id ViewAccountHistory_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.ViewAccountHistory --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/ViewAccountHistory.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id ViewItem_foo --contract-binary-name com.ypeckstadt.escrow.contract.item.ViewItem --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/item/ViewItem.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id DebitEscrowAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.DebitEscrowAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/DebitEscrowAccount.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id CreditEscrowAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.CreditEscrowAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/CreditEscrowAccount.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id CreditAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.CreditAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/CreditAccount.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id DebitAccount_foo --contract-binary-name com.ypeckstadt.escrow.contract.account.DebitAccount --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/account/DebitAccount.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id ViewOrderHistory_foo --contract-binary-name com.ypeckstadt.escrow.contract.order.ViewOrderHistory --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/order/ViewOrderHistory.class
+	@client/bin/scalardl register-contract --properties client.properties --contract-id ViewEscrowAccountHistory_foo --contract-binary-name com.ypeckstadt.escrow.contract.escrowAccount.ViewEscrowAccountHistory --contract-class-file build/classes/java/main/com/ypeckstadt/escrow/contract/escrowAccount/ViewEscrowAccountHistory.class
 
 clear:
 	@rm -rf build

--- a/docs/applications/simple-bank-account/README.md
+++ b/docs/applications/simple-bank-account/README.md
@@ -128,7 +128,7 @@ scalar.dl.client.private_key_path=conf/client-key.pem
 If everything is set up properly you should be able to register your certificate on the ScalarDL network as
 
 ```bash
-$ ${SCALAR_SDK_HOME}/client/bin/register-cert --properties ./conf/client.properties
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl register-cert --properties ./conf/client.properties
 ```
 
 You should receive status code 200 if successful.
@@ -157,7 +157,7 @@ In this example we will register three contracts: `CreateAccount.java`, `Deposit
 Once your toml file is written you can register all the specified contracts as
 
 ```bash
-$ ${SCALAR_SDK_HOME}/client/bin/register-contracts --properties ./conf/client.properties --contracts-file ./conf/contracts.toml
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl register-contracts --properties ./conf/client.properties --contracts-file ./conf/contracts.toml
 ```
 
 Each successfully registered contract should return status code 200.
@@ -169,20 +169,20 @@ You can now execute any registered contracts if you would like. For example, use
 Create two accounts with ids `a111` and `b222`. (Contract ids can be any string.)
 
 ```bash
-$ ${SCALAR_SDK_HOME}/client/bin/execute-contract --properties ./conf/client.properties --contract-id create-account --contract-argument '{"id": "a111"}'
-$ ${SCALAR_SDK_HOME}/client/bin/execute-contract --properties ./conf/client.properties --contract-id create-account --contract-argument '{"id": "b222"}'
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ./conf/client.properties --contract-id create-account --contract-argument '{"id": "a111"}'
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ./conf/client.properties --contract-id create-account --contract-argument '{"id": "b222"}'
 ```
 
 Now, deposit 100 into account `a111`:
 
 ```bash
-$ ${SCALAR_SDK_HOME}/client/bin/execute-contract --properties ./conf/client.properties --contract-id deposit --contract-argument '{"id": "a111", "amount": 100}'
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ./conf/client.properties --contract-id deposit --contract-argument '{"id": "a111", "amount": 100}'
 ```
 
 Finally, transfer 25 from `a111` to `b222`:
 
 ```bash
-$ ${SCALAR_SDK_HOME}/client/bin/execute-contract --properties ./conf/client.properties --contract-id transfer --contract-argument '{"from": "a111", "to": "b222", "amount": 100}'
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ./conf/client.properties --contract-id transfer --contract-argument '{"from": "a111", "to": "b222", "amount": 100}'
 ```
 
 If you were running the application itself, you could execute these commands using the [API endpoints](./docs/api_endpoints.md).

--- a/docs/applications/simple-bank-account/register
+++ b/docs/applications/simple-bank-account/register
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-${SCALAR_SDK_HOME}/client/bin/register-cert -properties ./conf/client.properties
-${SCALAR_SDK_HOME}/client/bin/register-contracts -properties ./conf/client.properties -contracts-toml-file ./conf/contracts.toml
+${SCALAR_SDK_HOME}/client/bin/scalardl register-cert -properties ./conf/client.properties
+${SCALAR_SDK_HOME}/client/bin/scalardl register-contracts -properties ./conf/client.properties -contracts-toml-file ./conf/contracts.toml

--- a/docs/getting-started-auditor.md
+++ b/docs/getting-started-auditor.md
@@ -99,12 +99,12 @@ As we explained, Ledger needs to register its certificate to Auditor, and Audito
 
 Ledger registers its certificate to Auditor
 ```shell
-client/bin/register-cert --properties client.properties.ledger
+client/bin/scalardl register-cert --properties client.properties.ledger
 ```
 
 Auditor registers its certificate to Ledger
 ```shell
-client/bin/register-cert --properties client.properties.auditor
+client/bin/scalardl register-cert --properties client.properties.auditor
 ```
 
 Please configure `client.properties.ledger` and `client.properties.auditor` properly.
@@ -124,7 +124,7 @@ scalar.dl.client.auditor.host=localhost
 Then, you can register your certificate just like you have been doing usually (without Auditor).
 
 ```shell
-client/bin/register-cert --properties client.properties
+client/bin/scalardl register-cert --properties client.properties
 ```
 
 Note that this registers the certificate to both Ledger and Auditor.
@@ -134,7 +134,7 @@ Note that this registers the certificate to both Ledger and Auditor.
 For registering contracts, you can also do as usual.
 
 ```shell
-client/bin/register-contract --properties client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file build/classes/java/main/com/org1/contract/StateUpdater.class
+client/bin/scalardl register-contract --properties client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file build/classes/java/main/com/org1/contract/StateUpdater.class
 ```
 
 Note that this registers the contract to both Ledger and Auditor.
@@ -144,7 +144,7 @@ Note that this registers the contract to both Ledger and Auditor.
 Now you are ready to execute the contract with the following command as usual.
 
 ```shell
-client/bin/execute-contract --properties client.properties --contract-id StateUpdater --contract-argument '{"asset_id":"some_asset", "state":3}'
+client/bin/scalardl execute-contract --properties client.properties --contract-id StateUpdater --contract-argument '{"asset_id":"some_asset", "state":3}'
 ```
 
 Note that this triggers a little complex protocol between Ledger and Auditor to make them go to the same states without trusting each other.
@@ -156,13 +156,13 @@ You can also always validate the states of Ledger and Auditor to see if they are
 However, validating the states in the Auditor mode uses contract execution; thus, you first need to register [ValidateLedger](https://github.com/scalar-labs/scalardl-java-client-sdk/blob/master/src/main/java/com/scalar/dl/client/contract/ValidateLedger.java) contract as follows. Note that `validate-ledger` is the default contract ID that the client specifies when doing validation.
 
 ```shell
-client/bin/register-contract --properties client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file /path/to/ValdateLedger.class
+client/bin/scalardl register-contract --properties client.properties --contract-id validate-ledger --contract-binary-name com.scalar.dl.client.contract.ValidateLedger --contract-class-file /path/to/ValdateLedger.class
 ```
 
 Then, you can issue the `validate-ledger` command just like as usually you do.
 
 ```shell
-client/bin/validate-ledger --properties client.properties --asset-id="some_asset"
+client/bin/scalardl validate-ledger --properties client.properties --asset-id="some_asset"
 ```
 
 If you want to change the contract ID of `ValidateLedger`, you need to change the following configuration to let the client know about it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ Next, let's register your certificate to ScalarDL Ledger. Please check [caclient
 This time, let's use a simple tool to register your certificate as follows.
 
 ```shell
-client/bin/register-cert --properties client.properties
+client/bin/scalardl register-cert --properties client.properties
 ```
 
 The registered certificate will allow you to register and execute contracts and will also be used for detecting Byzantine faults in databases.
@@ -144,7 +144,7 @@ This will generate `build/classes/java/main/com/org1/contract/StateUpdater.class
 Let's register your contract. Here again we use a simple tool.
 
 ```shell
-client/bin/register-contract --properties client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file build/classes/java/main/com/org1/contract/StateUpdater.class
+client/bin/scalardl register-contract --properties client.properties --contract-id StateUpdater --contract-binary-name com.org1.contract.StateUpdater --contract-class-file build/classes/java/main/com/org1/contract/StateUpdater.class
 ```
 
 Please set a globally unique ID for the contract ID (e.g. `StateUpdater` in the above command).
@@ -157,7 +157,7 @@ For example, let's think about a voting application. In the application, anyone 
 Now you are ready to execute the contract with the following command.
 
 ```shell
-client/bin/execute-contract --properties client.properties --contract-id StateUpdater --contract-argument '{"asset_id":"some_asset", "state":3}'
+client/bin/scalardl execute-contract --properties client.properties --contract-id StateUpdater --contract-argument '{"asset_id":"some_asset", "state":3}'
 ```
 
 In the contract argument, the value specified with the key `asset_id` must be unique globally for each asset.
@@ -167,7 +167,7 @@ In the contract argument, the value specified with the key `asset_id` must be un
 You can validate the states of Ledger by executing the following command.
 
 ```shell
-client/bin/validate-ledger --properties client.properties --asset-id="some_asset"
+client/bin/scalardl validate-ledger --properties client.properties --asset-id="some_asset"
 ```
 
 What the validation does is depending on how you set up and configure ScalarDL.

--- a/docs/how-to-write-function.md
+++ b/docs/how-to-write-function.md
@@ -137,7 +137,7 @@ Since Functions can read and write arbitrary records through the ScalarDB CRUD i
 You then need to register a Function to Ledger before used like you register a Contract.
 
 ```
-client/bin/register-function --properties client.properties --function-id test-function --function-binary-name com.example.function.TestFunction --function-class-file /path/to/TestFunction.class
+client/bin/scalardl register-function --properties client.properties --function-id test-function --function-binary-name com.example.function.TestFunction --function-class-file /path/to/TestFunction.class
 ```
 
 #### Execute a Function
@@ -146,7 +146,7 @@ You can specify a Function to execute along with a Contract to execute.
 For example, you can execute a function as follows with the command-line tool.
 
 ```
-client/bin/execute-contract --properties client.properties --contract-id test-contract --contract-argument '{...}' --function-id test-function --function-argument '{...}'
+client/bin/scalardl execute-contract --properties client.properties --contract-id test-contract --contract-argument '{...}' --function-id test-function --function-argument '{...}'
 ```
 
 You can also do it with the [ClientService](https://scalar-labs.github.io/scalardl/javadoc/latest/client/com/scalar/dl/client/service/ClientService.html) as follows.


### PR DESCRIPTION
## Description

Since the new ScalarDL cli subcommands are available from `v3.9.0`, we'll update the corresponding old commands.

## Related issues and/or PRs

N/A

## Changes made

- `scalardl` is used as the top-level executable command.
- The old commands are used as subcommands, e.g., `scalardl register-function`.

To update the documentation properly, we replaced `/client/bin/${COMMAND}` with `/client/bin/scalardl ${COMMAND}` by executing the following command on Mac terminal.

```terminal
git grep -Il '.' | xargs -n 10 sed -i '' "s/client\/bin\//client\/bin\/scalardl /g"
```
## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A