### PR TITLE
Remove notice about relocation of docs from Javadoc index page

### DIFF
--- a/docs/javadoc/index.md
+++ b/docs/javadoc/index.md
@@ -1,9 +1,3 @@
-> [!CAUTION]
-> 
-> The `docs` folder has been moved to the centralized documentation repository, [docs-internal](https://github.com/scalar-labs/docs-internal). Please update this documentation in that repository instead.
-> 
-> To view the ScalarDL documentation, visit [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/).
-
 # ScalarDL Javadoc
 
 * [latest](./latest/index.md)


### PR DESCRIPTION
## Description

This PR removes the notice about the relocation of docs from the Javadoc index page. The notice shouldn't have been added to that page since it's actively hosted on GitHub.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/53

## Changes made

- Removed notice from the Javadoc index page.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A