### PR TITLE
Change relative docs link to docs site link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ScalarDL is a scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
 
 ## Docs
-* [Docs](docs/index.md)
+* [ScalarDL Documentation](https://scalardl.scalar-labs.com/docs/latest/)
 * [ScalarDL Technical Overview](https://speakerdeck.com/scalar/scalar-dl-technical-overview)
 * [ScalarDL Research Paper](https://dl.acm.org/doi/abs/10.14778/3523210.3523212) [VLDB'22]
 


### PR DESCRIPTION
## Description

This PR updates a link to the docs listed in the README to point to the docs site instead of GitHub.

## Related issues and/or PRs

N/A

## Changes made

- Changed a relative link to the docs on GitHub to a link to the docs site.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
