### PR TITLE
Fix index page in 3.9.0

### DIFF
--- a/docs/javadoc/3.9.0/index.md
+++ b/docs/javadoc/3.9.0/index.md
@@ -1,0 +1,7 @@
+* [auditor](./auditor)
+* [client](./client)
+* [common](./common)
+* [e2e](./e2e)
+* [gateway](./gateway)
+* [ledger](./ledger)
+* [rpc](./rpc)


### PR DESCRIPTION
## Description

This PR adds an index page for the modules in 3.9.0 to fix the unreachable link.
https://scalar-labs.github.io/scalardl/javadoc/3.9.0/index.md

## Related issues and/or PRs

N/A

## Changes made

- Added an index page in 3.9.0

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
