### PR TITLE
Fix the sample application to build with Java 8 and Java 11.

### DIFF
--- a/docs/applications/simple-bank-account/app/build.gradle
+++ b/docs/applications/simple-bank-account/app/build.gradle
@@ -2,26 +2,16 @@ buildscript {
     repositories {
         mavenCentral()
     }
-    dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:3.3.0")
-    }
 }
 
 plugins {
     id 'java'
     id 'application'
     id 'idea'
-    id "org.springframework.boot" version "3.3.0"
-    id "io.spring.dependency-management" version "1.1.5"
 }
 
 application {
     mainClass = 'com.scalar.application.bankaccount.Application'
-}
-
-bootJar {
-    archiveBaseName = 'gs-rest-service'
-    archiveVersion =  '0.1.0'
 }
 
 repositories {
@@ -42,10 +32,10 @@ group = 'com.scalar.application.simple-bank-account'
 version = '0.1'
 
 dependencies {
-    implementation('org.springframework.boot:spring-boot-starter-web') {
+    implementation('org.springframework.boot:spring-boot-starter-web:3.3.0') {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
-    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2:3.3.0'
     implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.9.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## Description

We should be able to build our samples with Java 8, 11, 17, and 21. 

However, as a result of #61, the sample application cannot be built with Java 8 and Java 11 with the following error:

```
❯ ./gradlew build

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> Could not resolve all artifacts for configuration ':app:classpath'.
   > Could not resolve org.springframework.boot:spring-boot-gradle-plugin:3.3.0.
     Required by:
         project :app
         project :app > org.springframework.boot:org.springframework.boot.gradle.plugin:3.3.0
      > Dependency requires at least JVM runtime version 17. This build uses a Java 8 JVM.
```

The cause of this error is the use of the Gradle Spring Boot Plugin, so I made the change to not use it.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/61

## Changes made

- Remove Gradle Spring Boot Plugin and related configurations from the `build.gradle`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

We found this issue during a meeting with Yamada-san, Suzuki-san, and Yokoyama-san, so I added Suzuki-san to the list of reviewers.

## Release notes

N/A