### PR TITLE
Fix the sample application to build with older Java version

### DIFF
--- a/docs/applications/simple-bank-account/app/build.gradle
+++ b/docs/applications/simple-bank-account/app/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:3.3.0")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.7.18")
     }
 }
 
@@ -11,7 +11,7 @@ plugins {
     id 'java'
     id 'application'
     id 'idea'
-    id "org.springframework.boot" version "3.3.0"
+    id "org.springframework.boot" version "2.7.18"
     id "io.spring.dependency-management" version "1.1.5"
 }
 
@@ -30,7 +30,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(8)
     }
 }
 


### PR DESCRIPTION
## Description

We updated this sample application in #61. As a result, this sample application no ​​longer works on Java 8 and 11. Also, the bytecode obtained by building this sample does not work on JVM 8, 11, 17. After discussion with @brfrn169 and @feeblefakie, we realized that our real goal is to get the sample application to work on JVM 8, 11, 17, and 21.

To achieve this goal, we must write this sample application in Java 8, use libraries compatible with Java 8, and build it with Java 8. So, I downgraded the version of Spring Boot used in this sample to v2.7 in this PR, because this sample currently uses Spring Boot v3, which is not compatible with Java 8.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/61

## Changes made

- Downgrade the version of Spring  Boot used in this sample to v2.7

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A