### PR TITLE
Fix account history contract in the simple bank account application

### DIFF
--- a/docs/applications/simple-bank-account/README.md
+++ b/docs/applications/simple-bank-account/README.md
@@ -169,7 +169,7 @@ Each successfully registered contract should return status code 200.
 
 ### Executing contracts
 
-You can now execute any registered contracts if you would like. For example, use our register contracts to create a couple of accounts, deposit funds into one of the accounts, and transfer some of these funds to the other account.
+You can now execute any registered contracts if you would like. For example, use our register contracts to create a couple of accounts, deposit funds into one of the accounts, and transfer some of these funds to the other account, check the account history.
 
 Create two accounts with ids `a111` and `b222`. (Contract ids can be any string.)
 
@@ -188,6 +188,35 @@ Finally, transfer 25 from `a111` to `b222`:
 
 ```bash
 $ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ../conf/client.properties --contract-id transfer --contract-argument '{"from": "a111", "to": "b222", "amount": 100}'
+```
+
+You can check the balance history of account `a111` as follows:
+
+```bash
+$ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ../conf/client.properties --contract-id account-history --contract-argument '{"id": "a111"}'
+Contract result:
+{
+  "status" : "succeeded",
+  "history" : [ {
+    "id" : "a111",
+    "age" : 2,
+    "data" : {
+      "balance" : 0
+    }
+  }, {
+    "id" : "a111",
+    "age" : 1,
+    "data" : {
+      "balance" : 100
+    }
+  }, {
+    "id" : "a111",
+    "age" : 0,
+    "data" : {
+      "balance" : 0
+    }
+  } ]
+}
 ```
 
 If you were running the application itself, you could execute these commands using the [API endpoints](./docs/api_endpoints.md).

--- a/docs/applications/simple-bank-account/README.md
+++ b/docs/applications/simple-bank-account/README.md
@@ -169,7 +169,7 @@ Each successfully registered contract should return status code 200.
 
 ### Executing contracts
 
-You can now execute any registered contracts if you would like. For example, use our register contracts to create a couple of accounts, deposit funds into one of the accounts, and transfer some of these funds to the other account, check the account history.
+You can now execute any registered contracts if you would like. For example, use our register contracts to create a couple of accounts, deposit funds into one of the accounts, and transfer some of these funds to the other account.
 
 Create two accounts with ids `a111` and `b222`. (Contract ids can be any string.)
 
@@ -188,35 +188,6 @@ Finally, transfer 25 from `a111` to `b222`:
 
 ```bash
 $ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ../conf/client.properties --contract-id transfer --contract-argument '{"from": "a111", "to": "b222", "amount": 100}'
-```
-
-You can check the balance history of account `a111` as follows:
-
-```bash
-$ ${SCALAR_SDK_HOME}/client/bin/scalardl execute-contract --properties ../conf/client.properties --contract-id account-history --contract-argument '{"id": "a111"}'
-Contract result:
-{
-  "status" : "succeeded",
-  "history" : [ {
-    "id" : "a111",
-    "age" : 2,
-    "data" : {
-      "balance" : 0
-    }
-  }, {
-    "id" : "a111",
-    "age" : 1,
-    "data" : {
-      "balance" : 100
-    }
-  }, {
-    "id" : "a111",
-    "age" : 0,
-    "data" : {
-      "balance" : 0
-    }
-  } ]
-}
 ```
 
 If you were running the application itself, you could execute these commands using the [API endpoints](./docs/api_endpoints.md).

--- a/docs/applications/simple-bank-account/contract/src/main/java/com/scalar/application/bankaccount/contract/AccountHistory.java
+++ b/docs/applications/simple-bank-account/contract/src/main/java/com/scalar/application/bankaccount/contract/AccountHistory.java
@@ -41,8 +41,8 @@ public class AccountHistory extends JacksonBasedContract {
               getObjectMapper()
                   .createObjectNode()
                   .put("id", asset.id())
-                  .put("data", asset.data().asText())
-                  .put("age", asset.age());
+                  .put("age", asset.age())
+                  .set("data", asset.data());
           result.add(json);
         });
 


### PR DESCRIPTION
## Description

There is a bug in the account-history contract in the simple bank account application, and it does not display the asset data as follows:

```
❯ ../scalardl-java-client-sdk/client/bin/scalardl execute-contract --properties ../conf/client.properties --contract-id account-history --contract-argument '{"id": "a111"}'
Contract result:
{
  "status" : "succeeded",
  "history" : [ {
    "id" : "a111",
    "data" : "",
    "age" : 1
  }, {
    "id" : "a111",
    "data" : "",
    "age" : 0
  } ]
}
```

When I updated the application in #64, I overlooked this bug because the document doesn't give any instructions on how to use the account-history. So I've also added the instruction for running the account-history to the document in addition to the bug fix.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/61

## Changes made

- Fix the bug in the account-history contract
- Update the document to describe how to use the account-history contract

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A