### PR TITLE
Add group update for Dependabot and fix old config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,76 @@
 version: 2
-registries:
-  ghcr:
-    type: docker-registry
-    url: https://ghcr.io
-    username: ${{secrets.CR_USER}}
-    password: ${{secrets.CR_PAT}}
-    replaces-base: true
 updates:
   # For Gradle, update dependencies and plugins to the latest non-major version
   - package-ecosystem: "gradle"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     directory: "/"
     schedule:
       interval: "weekly"
     reviewers:
       - "scalar-labs/scalardl"
-    labels:
-      - "improvement"
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
-  # For GitHub Actions workflows, update all actions
+
+  # For GitHub Actions, update all actions on the default, support and release branches
   - package-ecosystem: "github-actions"
+    groups:
+      actions on branch master:
+        patterns:
+          - "*"
     directory: "/"
     schedule:
       interval: "weekly"
     reviewers:
       - "scalar-labs/scalardl"
-    labels:
-      - "improvement"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3"
+    groups:
+      actions on branch 3:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardl"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.10"
+    groups:
+      actions on branch 3.10:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardl"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.9"
+    groups:
+      actions on branch 3.9:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardl"
+
+  - package-ecosystem: "github-actions"
+    target-branch: "3.8"
+    groups:
+      actions on branch 3.8:
+        patterns:
+          - "*"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "scalar-labs/scalardl"


### PR DESCRIPTION
## Description

This PR introduces group updates of Dependabot to reduce the number of PRs being created and configures Dependabot to update GitHub actions on support and release branches. Also, it fixes an unnecessary configuration that makes [CI fail](https://github.com/scalar-labs/scalardl/runs/36344801897).

Note that this change is basically the same as [the one in ScalarDB](https://github.com/scalar-labs/scalardb/pull/2220).

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2220

## Changes made

- Update the config to group updates into single PR by ecosystem and branch
- Add a config to update actions for all branches
- Remove the `registries` section that is not referred by other section

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A