### PR TITLE
Backport to branch(3.8) : Add release workflows

### DIFF
--- a/.github/workflows/create-release-notes.yaml
+++ b/.github/workflows/create-release-notes.yaml
@@ -1,0 +1,92 @@
+name: Create release notes
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      GH_PROJECT_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK 8 and 11 (default 8)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: |
+            11
+            8
+
+      - name: Checkout release note scripts
+        uses: actions/checkout@v4
+        with:
+          repository: scalar-labs/actions
+          token: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+          path: ${{ github.workspace }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            release-note-script/src/main/java
+
+      - name: Move scripts to the working directory
+        run: cp ${{ github.workspace }}/release-note-script/src/main/java/* ${{ github.workspace }}
+
+      - name: Create release note body
+        id: rn_body
+        env:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        run: |
+          $JAVA_HOME_11_X64/bin/java ReleaseNoteCreation.java ${{ github.repository_owner }} ScalarDL ${{ steps.version.outputs.version }} ${{ github.event.repository.name }} > rnbody.md
+          cat rnbody.md
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body_path: rnbody.md
+          draft: true
+          prerelease: false
+
+      - name: Checkout the current repository
+        uses: actions/checkout@v4
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build client SDK zip
+        run: ./gradlew :client:distZip
+
+      - name: Upload client SDK zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: client/build/distributions/scalardl-java-client-sdk-${{ steps.version.outputs.version }}.zip
+          asset_name: scalardl-java-client-sdk-${{ steps.version.outputs.version }}.zip
+          asset_content_type: application/zip
+
+      - name: Build zip for generic contracts and functions
+        run: ./gradlew :generic-contracts:distZip
+
+      - name: Upload zip for generic contracts and functions
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: generic-contracts/build/distributions/scalardl-generic-contracts-${{ steps.version.outputs.version }}.zip
+          asset_name: scalardl-generic-contracts-${{ steps.version.outputs.version }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -1,0 +1,53 @@
+name: Release SNAPSHOT
+
+on:
+  push:
+    branches:
+      - master
+      - "[0-9]+"
+      - "[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(./gradlew :ledger:properties -q | grep "version:" | awk '{print $2}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Upload the SNAPSHOT versions of scalardl-ledger, scalardl-java-client-sdk, scalardl-common, and scalardl-rpc to Maven Central Repository
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > /tmp/secring.gpg
+          ./gradlew publish \
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
+          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
+          -Psigning.secretKeyRingFile="$(echo /tmp/secring.gpg)" \
+          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
+          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+
+      - name: Create SNAPSHOT container images
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: ./gradlew docker
+
+      - name: Push SNAPSHOT container images
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: |
+          docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  upload-artifacts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Upload scalardl-ledger, scalardl-java-client-sdk, scalardl-common, and scalardl-rpc to Maven Central Repository
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > /tmp/secring.gpg
+          ./gradlew publish \
+          -Pversion=${{ steps.version.outputs.version }} \
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
+          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
+          -Psigning.secretKeyRingFile="$(echo /tmp/secring.gpg)" \
+          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
+          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Create containers
+        run: ./gradlew docker
+
+      - name: Push containers to private GitHub Packages
+        run: |
+          docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}
+
+  create-release-notes:
+    needs: upload-artifacts
+    if: ${{ success() }}
+    uses: ./.github/workflows/create-release-notes.yaml
+    secrets:
+      GH_PROJECT_ACCESS_TOKEN: ${{ secrets.GH_PROJECT_ACCESS_TOKEN }}

--- a/.github/workflows/remove-untagged-images.yaml
+++ b/.github/workflows/remove-untagged-images.yaml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
 
-      - name: scalar-ledger
+      - name: scalardl-ledger
         uses: camargo/delete-untagged-action@v1
         with:
           github-token: ${{ secrets.CR_PAT }}
-          package-name: scalar-ledger
+          package-name: scalardl-ledger
 
-      - name: scalar-client
+      - name: scalardl-client
         uses: camargo/delete-untagged-action@v1
         with:
           github-token: ${{ secrets.CR_PAT }}
-          package-name: scalar-client
+          package-name: scalardl-client
 
       - name: scalardl-schema-loader
         uses: camargo/delete-untagged-action@v1

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -25,7 +25,7 @@ jobs:
     with:
       target-ref: ${{ inputs.target-ref }}
       find-latest-release: ${{ inputs.find-latest-release }}
-      images: '[["ScalarDL Ledger", "scalar-ledger"], ["ScalarDL Client", "scalar-client"]]'
+      images: '[["ScalarDL Ledger", "scalardl-ledger"], ["ScalarDL Client", "scalardl-client"]]'
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -300,7 +300,7 @@ check.dependsOn -= integrationTest  // build should not depend on the integratio
 
 // For testing only
 docker {
-    name "ghcr.io/scalar-labs/scalar-client:$dockerVersion"
+    name "ghcr.io/scalar-labs/scalardl-client:$dockerVersion"
     files tasks.distTar.outputs, 'conf/client.properties.tmpl', 'conf/log4j2.properties.tmpl'
 }
 

--- a/ledger/archive.gradle
+++ b/ledger/archive.gradle
@@ -1,0 +1,56 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'scalardl-ledger'
+            from components.java
+            artifact javadocJar
+            artifact sourcesJar
+            pom {
+                name = 'ScalarDL Ledger'
+                description = 'Ledger component of ScalarDL, scalable and practical Byzantine fault detection middleware for transactional database systems.'
+                url = 'https://github.com/scalar-labs/scalardl'
+                licenses {
+                    license {
+                        name = 'Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'hiroyuki'
+                        name = 'Hiroyuki Yamada'
+                        email = 'hiroyuki.yamada@scalar-labs.com'
+                    }
+                    developer {
+                        id = 'jnmt'
+                        name = 'Jun Nemoto'
+                        email = 'jun.nemoto@scalar-labs.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/scalar-labs/scalardl.git'
+                    developerConnection = 'scm:git:https://github.com/scalar-labs/scalardl.git'
+                    url = 'https://github.com/scalar-labs/scalardl'
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username = "${ossrhUsername}"
+                password = "${ossrhPassword}"
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}

--- a/ledger/build.gradle
+++ b/ledger/build.gradle
@@ -84,7 +84,7 @@ applicationDistribution.into('bin') {
 }
 
 docker {
-    name "ghcr.io/scalar-labs/scalar-ledger:$dockerVersion"
+    name "ghcr.io/scalar-labs/scalardl-ledger:$dockerVersion"
     files tasks.distTar.outputs, 'conf/ledger.properties.tmpl', 'conf/log4j2.properties.tmpl', 'docker-entrypoint.sh'
 }
 
@@ -172,3 +172,12 @@ task copyTestJarsToTestLib(type: Copy) {
 test.dependsOn += copyTestJarsToTestLib
 test.dependsOn += compileIntegrationTestJava
 test.dependsOn += compilePermissionTestJava
+
+archivesBaseName = "scalardl-ledger"
+
+// for archiving and uploading to maven central
+if (!project.gradle.startParameter.taskNames.isEmpty() &&
+   (project.gradle.startParameter.taskNames[0].endsWith('publish') ||
+    project.gradle.startParameter.taskNames[0].endsWith('publishToMavenLocal'))) {
+    apply from: 'archive.gradle'
+}


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/71
- **Commit to backport:** ea744ead3adddfffea3a6d16d2d517f97c8732cf

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.8-pull-71 &&
git cherry-pick --no-rerere-autoupdate -m1 ea744ead3adddfffea3a6d16d2d517f97c8732cf
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!