### PR TITLE
Exclude dependencies from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "com.diffplug.spotless"
+      - dependency-name: "com.google.errorprone:*"
+      - dependency-name: "com.github.spotbugs:*"
+      - dependency-name: "com.palantir.docker"
 
   # For GitHub Actions, update all actions on the default, support and release branches
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

This PR excludes some dependencies from dependabot. We do not update them for some reason, e.g., Java 8 support. It's troublesome to ignore them by talking with @depdabot since it cannot ignore multiple dependencies at once, and it's hard to see the list of the ignored dependencies. So, let's exclude them in the config file.

## Related issues and/or PRs

- #88

## Changes made

- Excludes some dependencies from dependabot

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A