### PR TITLE
Fix releasing snapshot container images

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -41,6 +41,13 @@ jobs:
           -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
           -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
       - name: Create SNAPSHOT container images
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: ./gradlew docker


### PR DESCRIPTION
## Description

This PR includes a fix to release snapshot container images. [It failed](https://github.com/scalar-labs/scalardl/actions/runs/13627107402/job/38086602054) because I probably forgot to add the login step.

## Related issues and/or PRs

- #71

## Changes made

- Add the login settings for ghcr.io

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
