### PR TITLE
Use Cosmos DB emulator for storage comatibility check

### DIFF
--- a/.github/workflows/storage-compatibility-check.yaml
+++ b/.github/workflows/storage-compatibility-check.yaml
@@ -52,7 +52,7 @@ jobs:
 
   integration-test-with-cosmos:
     name: Integration testing with the Consensus Commit transaction manager on Cosmos DB
-    runs-on: ubuntu-latest-l
+    runs-on: windows-latest
 
     steps:
       - name: Checkout the target repository
@@ -60,40 +60,52 @@ jobs:
         with:
           ref: ${{ inputs.target-ref }}
 
-      - name: Prepare own schema.json
-        id: schema
-        run: |
-          SUFFIX=$(echo "_${{ inputs.target-ref }}" | tr '.' '_')
-          sed -i s/scalar/scalar${SUFFIX}/ ledger/scripts/create_schema.json
-          sed -i s/test/test${SUFFIX}/ ledger/scripts/create_schema_function.json
-          echo "namespace_suffix=${SUFFIX}" >> $GITHUB_OUTPUT
-
       - name: Set up JDK 1.8
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'
 
+      - name: Start Azure Cosmos DB emulator
+        run: |
+          Write-Host "Launching Cosmos DB Emulator"
+          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+          # Set startup timeout to 10min (600s), the default is 4min
+          Start-CosmosDbEmulator -Consistency Strong -Timeout 600
+
+      - name: Install TLS/SSL certificate
+        run: |
+          $cert = Get-ChildItem Cert:\LocalMachine\My | where{$_.FriendlyName -eq 'DocumentDbEmulatorCertificate'}
+          $params = @{
+            Cert = $cert
+            Type = "CERT"
+            FilePath = "$home/tmp-cert.cer"
+            NoClobber = $true
+          }
+          Export-Certificate @params
+          certutil -encode $home/tmp-cert.cer $home/cosmosdbcert.cer
+          Remove-Item $home/tmp-cert.cer
+          $keystore = "-keystore", "${env:JAVA_HOME}/jre/lib/security/cacerts"
+          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -importcert -noprompt -alias cosmos_emulator -file $home/cosmosdbcert.cer
+          & ${env:JAVA_HOME}/bin/keytool.exe $keystore -storepass 'changeit' -list -alias cosmos_emulator
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build
         run: |
-          ./gradlew assemble
-          ./gradlew testJar
+          ./gradlew.bat assemble
+          ./gradlew.bat testJar
 
       # due to a gradle bug we must run the integration test separately
       - name: Run integration tests
         working-directory: ledger
         run: |
-          java -Xmx6g -XX:MaxDirectMemorySize=4g \
-          -cp "build/test-libs/*:build/libs/*:build/classes/java/integrationTest" \
-          -Dscalardl.namespace_suffix="${{ steps.schema.outputs.namespace_suffix }}" \
-          -Dscalardb.storage=cosmos \
-          -Dscalardb.contact_points="${{ secrets.COSMOS_URI }}" \
-          -Dscalardb.password="${{ secrets.COSMOS_KEY }}" \
-          -Dscalardb.cosmos.ru=800 \
-          org.junit.platform.console.ConsoleLauncher execute -c=com.scalar.dl.ledger.service.LedgerServiceEndToEndTest
+          java -cp "build/test-libs/*;build/libs/*;build/classes/java/integrationTest" `
+          "-Dscalardb.storage=cosmos" `
+          "-Dscalardb.contact_points=https://localhost:8081/" `
+          "-Dscalardb.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" `
+          org.junit.platform.console.ConsoleLauncher execute "-c=com.scalar.dl.ledger.service.LedgerServiceEndToEndTest"
 
   integration-test-with-dynamo:
     name: Integration testing with the Consensus Commit transaction manager on DynamoDB

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
@@ -137,8 +137,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LedgerServiceEndToEndTest {
+  private static final Logger logger = LoggerFactory.getLogger(LedgerServiceEndToEndTest.class);
   private static final String NAMESPACE = "scalar";
   private static final String ASSET_TABLE = "asset";
   private static final String ASSET_METADATA_TABLE = "asset_metadata";
@@ -324,10 +327,14 @@ public class LedgerServiceEndToEndTest {
   }
 
   @AfterAll
-  public static void tearDownAfterClass() throws SchemaLoaderException {
+  public static void tearDownAfterClass() {
     storageAdmin.close();
-    SchemaLoader.unload(props, ledgerSchemaPath, true);
-    SchemaLoader.unload(props, databaseSchemaPath, true);
+    try {
+      SchemaLoader.unload(props, ledgerSchemaPath, true);
+      SchemaLoader.unload(props, databaseSchemaPath, true);
+    } catch (Exception e) {
+      logger.warn("Failed to unload table", e);
+    }
   }
 
   @BeforeEach


### PR DESCRIPTION
## Description

This PR changes integration tests on Cosmos DB to use the emulator. Previously, we used the real Comos DB service for running integration tests because the Windows-hosted runner has poor performance (for the private `scalar` repo) to run the emulator and tests. Now, we can run them using a better hosted runner in the public `scalardl` repo, and it will fix a few known issues (e.g., resources and running for multiple branches at the same time).

## Related issues and/or PRs

N/A

## Changes made

- Use the Cosmos DB emulator

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

It was tested in the forked repo [here](https://github.com/jnmt/scalardl/actions/runs/13891782608).