### PR TITLE
Remove pushing schema loader in 3.8

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -50,4 +50,3 @@ jobs:
         run: |
           docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
-          docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,6 @@ jobs:
         run: |
           docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
-          docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}
 
   create-release-notes:
     needs: upload-artifacts


### PR DESCRIPTION
This PR stops pushing the schema loader docker image since we do not have it in 3.8.