### PR TITLE
Add generic contracts for creating tables and inserting records

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -1,0 +1,32 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+public class Constants {
+
+  public static final String PREFIX_TABLE = "tbl_";
+  public static final String PREFIX_INDEX = "idx_";
+  public static final String PREFIX_RECORD = "rec_";
+  public static final String ASSET_ID_METADATA_TABLES = "metadata_tables";
+  public static final String ASSET_ID_SEPARATOR = "_";
+  public static final String TABLE_NAME = "name";
+  public static final String TABLE_KEY = "key";
+  public static final String TABLE_KEY_TYPE = "type";
+  public static final String TABLE_INDEXES = "indexes";
+  public static final String INDEX_KEY = "key";
+  public static final String INDEX_KEY_TYPE = "type";
+  public static final String RECORD_TABLE = "table";
+  public static final String RECORD_VALUES = "values";
+  public static final String ASSET_AGE = "age";
+
+  // Error messages
+  public static final String INVALID_TABLE_FORMAT = "The specified format of the table is invalid.";
+  public static final String INVALID_INDEX_FORMAT =
+      "The specified format of the indexes is invalid.";
+  public static final String INVALID_RECORD_FORMAT =
+      "The specified format of the record is invalid.";
+  public static final String INVALID_KEY_TYPE = "The specified key type is invalid.";
+  public static final String INVALID_INDEX_KEY_TYPE = "The specified index key type is invalid.";
+  public static final String TABLE_ALREADY_EXISTS = "The specified table already exists.";
+  public static final String TABLE_NOT_EXIST = "The specified table does not exist.";
+  public static final String RECORD_KEY_NOT_EXIST = "The record values must have the key.";
+  public static final String RECORD_ALREADY_EXISTS = "The specified record already exists.";
+}

--- a/generic-contracts/conf/table-authenticity-management-contracts.toml
+++ b/generic-contracts/conf/table-authenticity-management-contracts.toml
@@ -1,0 +1,9 @@
+[[contracts]]
+contract-id = "table.v1_0_0.Create"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Create"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Create.class"
+
+[[contracts]]
+contract-id = "table.v1_0_0.Insert"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Insert"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Insert.class"

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Create.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Create.java
@@ -1,0 +1,82 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class Create extends JacksonBasedContract {
+
+  @Nullable
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+
+    // Check the arguments
+    if (arguments.size() < 3
+        || arguments.size() > 4
+        || !arguments.has(Constants.TABLE_NAME)
+        || !arguments.get(Constants.TABLE_NAME).isTextual()
+        || !arguments.has(Constants.TABLE_KEY)
+        || !arguments.get(Constants.TABLE_KEY).isTextual()
+        || !arguments.has(Constants.TABLE_KEY_TYPE)
+        || !arguments.get(Constants.TABLE_KEY_TYPE).isTextual()) {
+      throw new ContractContextException(Constants.INVALID_TABLE_FORMAT);
+    }
+
+    if (!isSupportedKeyType(arguments.get(Constants.TABLE_KEY_TYPE).asText())) {
+      throw new ContractContextException(Constants.INVALID_KEY_TYPE);
+    }
+
+    if (arguments.has(Constants.TABLE_INDEXES)) {
+      validateIndexes(arguments.get(Constants.TABLE_INDEXES));
+    }
+
+    // Get the table existence
+    String assetId = getAssetIdForTable(arguments.get(Constants.TABLE_NAME).asText());
+    Optional<Asset<JsonNode>> asset = ledger.get(assetId);
+    if (asset.isPresent()) {
+      throw new ContractContextException(Constants.TABLE_ALREADY_EXISTS);
+    }
+
+    // Put the asset records
+    ledger.put(Constants.ASSET_ID_METADATA_TABLES, arguments);
+    ledger.put(assetId, arguments);
+
+    return null;
+  }
+
+  private boolean isSupportedKeyType(String type) {
+    return type.toUpperCase().equals(JsonNodeType.BOOLEAN.name())
+        || type.toUpperCase().equals(JsonNodeType.NUMBER.name())
+        || type.toUpperCase().equals(JsonNodeType.STRING.name());
+  }
+
+  private void validateIndexes(JsonNode indexes) {
+    if (!indexes.isArray()) {
+      throw new ContractContextException(Constants.INVALID_INDEX_FORMAT);
+    }
+
+    for (JsonNode index : indexes) {
+      if (!index.isObject()
+          || index.size() != 2
+          || !index.has(Constants.INDEX_KEY)
+          || !index.get(Constants.INDEX_KEY).isTextual()
+          || !index.has(Constants.INDEX_KEY_TYPE)
+          || !index.get(Constants.INDEX_KEY_TYPE).isTextual()) {
+        throw new ContractContextException(Constants.INVALID_INDEX_FORMAT);
+      }
+      if (!isSupportedKeyType(index.get(Constants.INDEX_KEY_TYPE).asText())) {
+        throw new ContractContextException(Constants.INVALID_KEY_TYPE);
+      }
+    }
+  }
+
+  private String getAssetIdForTable(String tableName) {
+    return Constants.PREFIX_TABLE + tableName;
+  }
+}

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Insert.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Insert.java
@@ -1,0 +1,115 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class Insert extends JacksonBasedContract {
+
+  @Nullable
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+
+    // Check the arguments
+    if (arguments.size() != 2
+        || !arguments.has(Constants.RECORD_TABLE)
+        || !arguments.get(Constants.RECORD_TABLE).isTextual()
+        || !arguments.has(Constants.RECORD_VALUES)
+        || !arguments.get(Constants.RECORD_VALUES).isObject()) {
+      throw new ContractContextException(Constants.INVALID_RECORD_FORMAT);
+    }
+
+    // Get the table information
+    String tableName = arguments.get(Constants.RECORD_TABLE).asText();
+    String tableAssetId = getAssetIdForTable(tableName);
+    Optional<Asset<JsonNode>> tableAsset = ledger.get(tableAssetId);
+    if (!tableAsset.isPresent()) {
+      throw new ContractContextException(Constants.TABLE_NOT_EXIST);
+    }
+
+    // Check the key existence and type in the argument
+    String key = tableAsset.get().data().get(Constants.TABLE_KEY).textValue();
+    String keyType = tableAsset.get().data().get(Constants.TABLE_KEY_TYPE).textValue();
+    JsonNode values = arguments.get(Constants.RECORD_VALUES);
+    if (!values.has(key)) {
+      throw new ContractContextException(Constants.RECORD_KEY_NOT_EXIST);
+    }
+    if (!keyType.toUpperCase().equals(values.get(key).getNodeType().name())) {
+      throw new ContractContextException(Constants.INVALID_KEY_TYPE);
+    }
+
+    // Check the record existence
+    String recordAssetId = getAssetIdForRecord(tableName, key, values.get(key).asText());
+    Optional<Asset<JsonNode>> recordAsset = ledger.get(recordAssetId);
+    if (recordAsset.isPresent()) {
+      throw new ContractContextException(Constants.RECORD_ALREADY_EXISTS);
+    }
+
+    // Put the asset records
+    putIndexAssets(
+        ledger,
+        tableName,
+        key,
+        arguments.get(Constants.RECORD_VALUES),
+        tableAsset.get().data().get(Constants.TABLE_INDEXES));
+    ledger.put(recordAssetId, arguments.get(Constants.RECORD_VALUES));
+
+    return null;
+  }
+
+  private void putIndexAssets(
+      Ledger<JsonNode> ledger, String tableName, String key, JsonNode values, JsonNode indexes) {
+    for (JsonNode index : indexes) {
+      String indexKey = index.get(Constants.INDEX_KEY).asText();
+      String indexKeyType = index.get(Constants.INDEX_KEY_TYPE).asText();
+      String assetId;
+
+      if (values.has(indexKey) && !values.get(indexKey).isNull()) {
+        if (!indexKeyType.toUpperCase().equals(values.get(indexKey).getNodeType().name())) {
+          throw new ContractContextException(Constants.INVALID_INDEX_KEY_TYPE);
+        }
+        assetId = getAssetIdForIndex(tableName, indexKey, values.get(indexKey).asText());
+      } else {
+        assetId = getAssetIdForNullIndex(tableName, indexKey);
+      }
+
+      ObjectNode node = getObjectMapper().createObjectNode();
+      node.set(key, values.get(key));
+      node.put(Constants.ASSET_AGE, 0);
+
+      ledger.put(assetId, node);
+    }
+  }
+
+  private String getAssetIdForTable(String tableName) {
+    return Constants.PREFIX_TABLE + tableName;
+  }
+
+  private String getAssetIdForRecord(String tableName, String keyColumnName, String key) {
+    return Constants.PREFIX_RECORD
+        + tableName
+        + Constants.ASSET_ID_SEPARATOR
+        + keyColumnName
+        + Constants.ASSET_ID_SEPARATOR
+        + key;
+  }
+
+  private String getAssetIdForIndex(String tableName, String indexKey, String value) {
+    return Constants.PREFIX_INDEX
+        + tableName
+        + Constants.ASSET_ID_SEPARATOR
+        + indexKey
+        + Constants.ASSET_ID_SEPARATOR
+        + value;
+  }
+
+  private String getAssetIdForNullIndex(String tableName, String indexKey) {
+    return Constants.PREFIX_INDEX + tableName + Constants.ASSET_ID_SEPARATOR + indexKey;
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/CreateTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/CreateTest.java
@@ -1,0 +1,339 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CreateTest {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String SOME_TABLE_NAME = "table";
+  private static final String SOME_TABLE_ASSET_ID = Constants.PREFIX_TABLE + SOME_TABLE_NAME;
+  private static final String SOME_TABLE_KEY = "key";
+  private static final String SOME_INVALID_FIELD = "field";
+  private static final String SOME_INVALID_VALUE = "value";
+  private static final String SOME_KEY_TYPE_STRING = "string";
+  private static final String SOME_KEY_TYPE_BOOLEAN = "boolean";
+  private static final String SOME_KEY_TYPE_NUMBER = "number";
+  private static final String SOME_KEY_TYPE_INVALID = "invalid";
+  private static final String SOME_INDEX_KEY_1 = "key1";
+  private static final String SOME_INDEX_KEY_2 = "key2";
+  private static final ArrayNode SOME_INDEXES =
+      mapper
+          .createArrayNode()
+          .add(createIndexNode(SOME_INDEX_KEY_1, SOME_KEY_TYPE_BOOLEAN))
+          .add(createIndexNode(SOME_INDEX_KEY_2, SOME_KEY_TYPE_NUMBER));
+
+  private final Create create = new Create();
+
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private static JsonNode createIndexNode(String key, String type) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.INDEX_KEY, key)
+        .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsGiven_ShouldCreateTable() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(Constants.TABLE_INDEXES, SOME_INDEXES);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.empty());
+
+    // Act
+    JsonNode actual = create.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNull();
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).put(SOME_TABLE_ASSET_ID, argument);
+    verify(ledger).put(Constants.ASSET_ID_METADATA_TABLES, argument);
+  }
+
+  @Test
+  public void invoke_InvalidArgumentsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument1 = mapper.createObjectNode();
+    JsonNode argument2 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+            .set(Constants.TABLE_INDEXES, SOME_INDEXES);
+    JsonNode argument3 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(Constants.TABLE_INDEXES, SOME_INDEXES);
+    JsonNode argument4 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(Constants.TABLE_INDEXES, SOME_INDEXES);
+    JsonNode argument5 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .set(Constants.TABLE_INDEXES, SOME_INDEXES);
+    JsonNode argument6 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, 0)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
+    JsonNode argument7 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, 0)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
+    JsonNode argument8 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, 0);
+
+    // Act Assert
+    assertThatThrownBy(() -> create.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument6, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument7, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument8, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_TABLE_FORMAT);
+    verify(ledger, never()).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).put(eq(SOME_TABLE_ASSET_ID), any(JsonNode.class));
+  }
+
+  @Test
+  public void invoke_InvalidIndexArgumentsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument1 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .put(Constants.TABLE_INDEXES, SOME_INVALID_VALUE);
+    JsonNode argument2 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(Constants.TABLE_INDEXES, mapper.createArrayNode().add(SOME_INDEX_KEY_1));
+    JsonNode argument3 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(
+                Constants.TABLE_INDEXES,
+                mapper
+                    .createArrayNode()
+                    .add(mapper.createObjectNode().put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)));
+    JsonNode argument4 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(
+                Constants.TABLE_INDEXES,
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createObjectNode()
+                            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+                            .put(Constants.INDEX_KEY, SOME_INDEX_KEY_1)));
+    JsonNode argument5 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(
+                Constants.TABLE_INDEXES,
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createObjectNode()
+                            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+                            .put(Constants.INDEX_KEY_TYPE, SOME_KEY_TYPE_NUMBER)));
+    JsonNode argument6 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(
+                Constants.TABLE_INDEXES,
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createObjectNode()
+                            .put(Constants.INDEX_KEY_TYPE, SOME_KEY_TYPE_NUMBER)
+                            .set(Constants.INDEX_KEY, null)));
+    JsonNode argument7 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(
+                Constants.TABLE_INDEXES,
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createObjectNode()
+                            .put(Constants.INDEX_KEY, SOME_INDEX_KEY_1)
+                            .set(Constants.INDEX_KEY_TYPE, null)));
+
+    // Act Assert
+    assertThatThrownBy(() -> create.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument6, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    assertThatThrownBy(() -> create.invoke(ledger, argument7, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_FORMAT);
+    verify(ledger, never()).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).put(eq(SOME_TABLE_ASSET_ID), any(JsonNode.class));
+  }
+
+  @Test
+  public void invoke_UnsupportedKeyTypeGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_INVALID);
+
+    // Act Assert
+    assertThatThrownBy(() -> create.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_KEY_TYPE);
+    verify(ledger, never()).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).put(eq(SOME_TABLE_ASSET_ID), any(JsonNode.class));
+  }
+
+  @Test
+  public void invoke_UnsupportedIndexKeyTypeGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+            .set(
+                Constants.TABLE_INDEXES,
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createObjectNode()
+                            .put(Constants.INDEX_KEY, SOME_INDEX_KEY_1)
+                            .put(Constants.INDEX_KEY_TYPE, SOME_KEY_TYPE_INVALID)));
+
+    // Act Assert
+    assertThatThrownBy(() -> create.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_KEY_TYPE);
+    verify(ledger, never()).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).put(eq(SOME_TABLE_ASSET_ID), any(JsonNode.class));
+  }
+
+  @Test
+  public void invoke_ExistingTableGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
+    Asset<JsonNode> asset = (Asset<JsonNode>) mock(Asset.class);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(asset));
+
+    // Act Assert
+    assertThatThrownBy(() -> create.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.TABLE_ALREADY_EXISTS);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).put(eq(SOME_TABLE_ASSET_ID), any(JsonNode.class));
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/InsertTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/InsertTest.java
@@ -1,0 +1,355 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class InsertTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String SOME_TABLE_NAME = "Person";
+  private static final String SOME_TABLE_ASSET_ID = Constants.PREFIX_TABLE + SOME_TABLE_NAME;
+  private static final String SOME_TABLE_KEY = "GovId";
+  private static final String SOME_INVALID_FIELD = "field";
+  private static final String SOME_INVALID_VALUE = "value";
+  private static final String SOME_KEY_TYPE_STRING = "string";
+  private static final String SOME_KEY_TYPE_BOOLEAN = "boolean";
+  private static final String SOME_KEY_TYPE_NUMBER = "number";
+  private static final String SOME_INDEX_KEY_1 = "firstName";
+  private static final String SOME_INDEX_KEY_2 = "lastName";
+  private static final String SOME_INDEX_KEY_3 = "boolean_column";
+  private static final String SOME_RECORD_KEY = "001";
+  private static final double SOME_RECORD_NUMBER_KEY = 0.01;
+  private static final String SOME_RECORD_ASSET_ID =
+      Constants.PREFIX_RECORD
+          + SOME_TABLE_NAME
+          + Constants.ASSET_ID_SEPARATOR
+          + SOME_TABLE_KEY
+          + Constants.ASSET_ID_SEPARATOR
+          + SOME_RECORD_KEY;
+  private static final String SOME_RECORD_ASSET_ID_WITH_NUMBER_KEY =
+      Constants.PREFIX_RECORD
+          + SOME_TABLE_NAME
+          + Constants.ASSET_ID_SEPARATOR
+          + SOME_TABLE_KEY
+          + Constants.ASSET_ID_SEPARATOR
+          + "0.01";
+  private static final String SOME_RECORD_COLUMN = "address";
+  private static final String SOME_RECORD_COLUMN_VALUE = "Tokyo";
+  private static final boolean SOME_RECORD_COLUMN_VALUE_BOOLEAN = false;
+  private static final String SOME_INDEX_COLUMN_VALUE = "John";
+  private static final String SOME_INDEX_ASSET_ID_1 =
+      Constants.PREFIX_INDEX
+          + SOME_TABLE_NAME
+          + Constants.ASSET_ID_SEPARATOR
+          + SOME_INDEX_KEY_1
+          + Constants.ASSET_ID_SEPARATOR
+          + SOME_INDEX_COLUMN_VALUE;
+  private static final String SOME_INDEX_ASSET_ID_2 =
+      Constants.PREFIX_INDEX + SOME_TABLE_NAME + Constants.ASSET_ID_SEPARATOR + SOME_INDEX_KEY_2;
+  private static final String SOME_INDEX_ASSET_ID_3 =
+      Constants.PREFIX_INDEX
+          + SOME_TABLE_NAME
+          + Constants.ASSET_ID_SEPARATOR
+          + SOME_INDEX_KEY_3
+          + Constants.ASSET_ID_SEPARATOR
+          + "false";
+  private static final ObjectNode SOME_INDEX_ASSET =
+      mapper.createObjectNode().put(SOME_TABLE_KEY, SOME_RECORD_KEY).put(Constants.ASSET_AGE, 0);
+  private static final ObjectNode SOME_INDEX_ASSET_WITH_NUMBER_KEY =
+      mapper
+          .createObjectNode()
+          .put(SOME_TABLE_KEY, SOME_RECORD_NUMBER_KEY)
+          .put(Constants.ASSET_AGE, 0);
+  private static final ObjectNode SOME_TABLE =
+      mapper
+          .createObjectNode()
+          .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+          .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+          .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+          .set(
+              Constants.TABLE_INDEXES,
+              mapper
+                  .createArrayNode()
+                  .add(createIndexNode(SOME_INDEX_KEY_1, SOME_KEY_TYPE_STRING))
+                  .add(createIndexNode(SOME_INDEX_KEY_2, SOME_KEY_TYPE_STRING)));
+  private static final ObjectNode SOME_TABLE_WITH_NUMBER_KEY =
+      mapper
+          .createObjectNode()
+          .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+          .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+          .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_NUMBER)
+          .set(
+              Constants.TABLE_INDEXES,
+              mapper
+                  .createArrayNode()
+                  .add(createIndexNode(SOME_INDEX_KEY_2, SOME_KEY_TYPE_STRING))
+                  .add(createIndexNode(SOME_INDEX_KEY_3, SOME_KEY_TYPE_BOOLEAN)));
+  private static final ObjectNode SOME_RECORD_VALUES =
+      mapper
+          .createObjectNode()
+          .put(SOME_TABLE_KEY, SOME_RECORD_KEY)
+          .put(SOME_INDEX_KEY_1, SOME_INDEX_COLUMN_VALUE)
+          .put(SOME_RECORD_COLUMN, SOME_RECORD_COLUMN_VALUE);
+
+  private final Insert insert = new Insert();
+
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private static JsonNode createIndexNode(String key, String type) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.INDEX_KEY, key)
+        .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsGiven_ShouldInsertRecord() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, SOME_RECORD_VALUES);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+    when(ledger.get(SOME_RECORD_ASSET_ID)).thenReturn(Optional.empty());
+
+    // Act
+    JsonNode actual = insert.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNull();
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID);
+    verify(ledger).put(SOME_RECORD_ASSET_ID, SOME_RECORD_VALUES);
+    verify(ledger).put(SOME_INDEX_ASSET_ID_1, SOME_INDEX_ASSET);
+    verify(ledger).put(SOME_INDEX_ASSET_ID_2, SOME_INDEX_ASSET);
+    verify(ledger, times(3)).put(any(), any());
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithNumberKeyGiven_ShouldInsertRecord() {
+    // Arrange
+    ObjectNode recordValuesWithNumberKey =
+        mapper
+            .createObjectNode()
+            .put(SOME_TABLE_KEY, SOME_RECORD_NUMBER_KEY)
+            .put(SOME_INDEX_KEY_3, SOME_RECORD_COLUMN_VALUE_BOOLEAN)
+            .set(SOME_INDEX_KEY_2, null);
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, recordValuesWithNumberKey);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE_WITH_NUMBER_KEY);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+    when(ledger.get(SOME_RECORD_ASSET_ID_WITH_NUMBER_KEY)).thenReturn(Optional.empty());
+
+    // Act
+    JsonNode actual = insert.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNull();
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID_WITH_NUMBER_KEY);
+    verify(ledger).put(SOME_RECORD_ASSET_ID_WITH_NUMBER_KEY, recordValuesWithNumberKey);
+    verify(ledger).put(SOME_INDEX_ASSET_ID_2, SOME_INDEX_ASSET_WITH_NUMBER_KEY);
+    verify(ledger).put(SOME_INDEX_ASSET_ID_3, SOME_INDEX_ASSET_WITH_NUMBER_KEY);
+    verify(ledger, times(3)).put(any(), any());
+  }
+
+  @Test
+  public void invoke_InvalidArgumentsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument1 = mapper.createObjectNode();
+    JsonNode argument2 =
+        mapper
+            .createObjectNode()
+            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+            .set(Constants.RECORD_VALUES, SOME_RECORD_VALUES);
+    JsonNode argument3 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE);
+    JsonNode argument4 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, 0)
+            .set(Constants.RECORD_VALUES, SOME_RECORD_VALUES);
+    JsonNode argument5 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_VALUES, SOME_INVALID_VALUE);
+
+    // Act Assert
+    assertThatThrownBy(() -> insert.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_RECORD_FORMAT);
+    assertThatThrownBy(() -> insert.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_RECORD_FORMAT);
+    assertThatThrownBy(() -> insert.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_RECORD_FORMAT);
+    assertThatThrownBy(() -> insert.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_RECORD_FORMAT);
+    assertThatThrownBy(() -> insert.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_RECORD_FORMAT);
+    verify(ledger, never()).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).put(any(), any());
+  }
+
+  @Test
+  public void invoke_NonExistingTableGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, SOME_RECORD_VALUES);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.empty());
+
+    // Act Assert
+    assertThatThrownBy(() -> insert.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.TABLE_NOT_EXIST);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).get(SOME_RECORD_ASSET_ID);
+    verify(ledger, never()).put(any(), any());
+  }
+
+  @Test
+  public void invoke_ArgumentWithoutRecordKeyGiven_ShouldThrowContractContextException() {
+    // Arrange
+    ObjectNode recordValuesWithoutKey =
+        mapper
+            .createObjectNode()
+            .put(SOME_INDEX_KEY_1, SOME_INDEX_COLUMN_VALUE)
+            .put(SOME_RECORD_COLUMN, SOME_RECORD_COLUMN_VALUE);
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, recordValuesWithoutKey);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+
+    // Act Assert
+    assertThatThrownBy(() -> insert.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.RECORD_KEY_NOT_EXIST);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).get(SOME_RECORD_ASSET_ID);
+    verify(ledger, never()).put(any(), any());
+  }
+
+  @Test
+  public void invoke_ArgumentWithInvalidRecordKeyGiven_ShouldThrowContractContextException() {
+    // Arrange
+    ObjectNode recordValuesWithInvalidKey =
+        mapper
+            .createObjectNode()
+            .put(SOME_TABLE_KEY, 0)
+            .put(SOME_INDEX_KEY_1, SOME_INDEX_COLUMN_VALUE)
+            .put(SOME_RECORD_COLUMN, SOME_RECORD_COLUMN_VALUE);
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, recordValuesWithInvalidKey);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+
+    // Act Assert
+    assertThatThrownBy(() -> insert.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_KEY_TYPE);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger, never()).get(SOME_RECORD_ASSET_ID);
+    verify(ledger, never()).put(any(), any());
+  }
+
+  @Test
+  public void invoke_UnsupportedIndexKeyTypeGiven_ShouldThrowContractContextException() {
+    // Arrange
+    ObjectNode recordValuesWithInvalidIndexKey =
+        mapper
+            .createObjectNode()
+            .put(SOME_TABLE_KEY, SOME_RECORD_KEY)
+            .put(SOME_INDEX_KEY_1, SOME_INDEX_COLUMN_VALUE)
+            .put(SOME_INDEX_KEY_2, 0)
+            .put(SOME_RECORD_COLUMN, SOME_RECORD_COLUMN_VALUE);
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, recordValuesWithInvalidIndexKey);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+    when(ledger.get(SOME_RECORD_ASSET_ID)).thenReturn(Optional.empty());
+
+    // Act Assert
+    assertThatThrownBy(() -> insert.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_KEY_TYPE);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID);
+    verify(ledger).put(SOME_INDEX_ASSET_ID_1, SOME_INDEX_ASSET);
+    verify(ledger, times(1)).put(any(), any());
+  }
+
+  @Test
+  public void invoke_ExistingRecordGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .set(Constants.RECORD_VALUES, SOME_RECORD_VALUES);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    Asset<JsonNode> recordAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+    when(ledger.get(SOME_RECORD_ASSET_ID)).thenReturn(Optional.of(recordAsset));
+
+    // Act Assert
+    assertThatThrownBy(() -> insert.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.RECORD_ALREADY_EXISTS);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID);
+    verify(ledger, never()).put(eq(SOME_RECORD_ASSET_ID), any(JsonNode.class));
+  }
+}


### PR DESCRIPTION
## Description

This PR adds new generic contracts for table-based record access. As the first step, this PR adds contracts for table creation and record insertion. I will add select/update contracts in other PRs.

For details about detailed specifications, see also the [design doc](https://docs.google.com/document/d/1lrpOKbVedrIVcee5kkiR2MItmNlEEDO_CLw7FfbS4uo/edit?usp=sharing).

## Related issues and/or PRs

N/A

## Changes made

- Add generic contracts for creating tables and inserting records

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes. *Will do after all table-based generic contracts are merged*
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

An example of the expected results is as follows.

1. Setup
   ```console
   ./client/build/install/client/bin/scalardl generic-contracts register-contracts --config ~/work/scalar-labs/conf/client.single.properties --contracts-file generic-contracts/conf/table-authenticity-management-contracts.toml
   ```

2. Create tables
   ```console
   ./client/build/install/client/bin/scalardl generic-contracts execute-contract --config ~/work/scalar-labs/conf/client.single.properties --contract-id table.v1_0_0.Create --contract-argument '{ "name": "VehicleRegistration", "key": "VIN", "type": "string", "indexes": [ {"key": "State", "type": "string"}, {"key": "PendingPenaltyTicketAmount", "type": "number"} ] }'
   ./client/build/install/client/bin/scalardl generic-contracts execute-contract --config ~/work/scalar-labs/conf/client.single.properties --contract-id table.v1_0_0.Create --contract-argument '{ "name": "Person", "key": "GovId", "type": "string", "indexes": [ {"key": "FirstName", "type": "string"}, {"key": "LastName", "type": "string"} ] }'
   ```

3. Insert records
   ```console
   ./client/build/install/client/bin/scalardl generic-contracts execute-contract --config ~/work/scalar-labs/conf/client.single.properties --contract-id table.v1_0_0.Insert --contract-argument '{ "table": "VehicleRegistration", "values": {"VIN": "1N4AL11D75C109151", "LicensePlateNumber": "LEWISR261LL",  "State": "WA", "City": "Seattle", "PendingPenaltyTicketAmount": 90.25, "ValidFromDate": "2017-08-21T", "Owners": { "PrimaryOwner" : { "PersonId": "" }, "SecondaryOwners" : [] }}}'
   ./client/build/install/client/bin/scalardl generic-contracts execute-contract --config ~/work/scalar-labs/conf/client.single.properties --contract-id table.v1_0_0.Insert --contract-argument '{ "table": "VehicleRegistration", "values": {"VIN": "KM8SRDHF6EU074761", "LicensePlateNumber": "CA762X",  "State": "WA", "City": "Kent", "PendingPenaltyTicketAmount": 130.75, "ValidFromDate": "2017-08-21T", "Owners": { "PrimaryOwner" : { "PersonId": "" }, "SecondaryOwners" : [] }}}'
   ```

4. Created assets

   ```
   mysql> select id, age, left(output, 80) from asset;
   +-----------------------------------------------------------+-----+----------------------------------------------------------------------------------+
   | id                                                        | age | left(output, 80)                                                                 |
   +-----------------------------------------------------------+-----+----------------------------------------------------------------------------------+
   | idx_VehicleRegistration_PendingPenaltyTicketAmount_130.75 |   0 | {"VIN":"KM8SRDHF6EU074761","age":0}                                              |
   | idx_VehicleRegistration_PendingPenaltyTicketAmount_90.25  |   0 | {"VIN":"1N4AL11D75C109151","age":0}                                              |
   | idx_VehicleRegistration_State_WA                          |   0 | {"VIN":"1N4AL11D75C109151","age":0}                                              |
   | idx_VehicleRegistration_State_WA                          |   1 | {"VIN":"KM8SRDHF6EU074761","age":0}                                              |
   | metadata_tables                                           |   0 | {"name":"VehicleRegistration","key":"VIN","type":"string","indexes":[{"key":"Sta |
   | metadata_tables                                           |   1 | {"name":"Person","key":"GovId","type":"string","indexes":[{"key":"FirstName","ty |
   | rec_VehicleRegistration_VIN_1N4AL11D75C109151             |   0 | {"VIN":"1N4AL11D75C109151","LicensePlateNumber":"LEWISR261LL","State":"WA","City |
   | rec_VehicleRegistration_VIN_KM8SRDHF6EU074761             |   0 | {"VIN":"KM8SRDHF6EU074761","LicensePlateNumber":"CA762X","State":"WA","City":"Ke |
   | tbl_Person                                                |   0 | {"name":"Person","key":"GovId","type":"string","indexes":[{"key":"FirstName","ty |
   | tbl_VehicleRegistration                                   |   0 | {"name":"VehicleRegistration","key":"VIN","type":"string","indexes":[{"key":"Sta |
   +-----------------------------------------------------------+-----+----------------------------------------------------------------------------------+
   ```

## Release notes

Added generic contracts for creating tables and inserting records.