### PR TITLE
Backport to branch(3.9) : Fix CVE-2024-45337

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/busybox:1.36 AS tools
 
 ENV DOCKERIZE_VERSION v0.6.1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.35
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.37
 
 # Install dockerize
 RUN set -x && \


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/107
- **Commit to backport:** 4f4e5470cdd68c712ba244751e4a9973b0b806d9

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.9-pull-107 &&
git cherry-pick --no-rerere-autoupdate -m1 4f4e5470cdd68c712ba244751e4a9973b0b806d9
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!