### PR TITLE
Update scheduled vulnerability check versions

### DIFF
--- a/.github/workflows/scheduled-vuln-check.yaml
+++ b/.github/workflows/scheduled-vuln-check.yaml
@@ -3,7 +3,7 @@ name: Scheduled Vulnerability Check
 on:
   schedule:
     # UTC
-    - cron: '0 19 * * WED,SAT'
+    - cron: '0 18 * * WED,SAT'
 
 jobs:
   call-vuln-check-for-master:
@@ -14,20 +14,11 @@ jobs:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
 
-  call-vuln-check-for-v3_8:
-    uses: ./.github/workflows/vuln-check.yaml
-    with:
-      target-ref: 3.8
-      find-latest-release: false
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
-
   call-vuln-check-for-v3_9:
     uses: ./.github/workflows/vuln-check.yaml
     with:
-      target-ref: 3.9
-      find-latest-release: false
+      target-ref: v3.9
+      find-latest-release: true
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
@@ -35,8 +26,8 @@ jobs:
   call-vuln-check-for-v3_10:
     uses: ./.github/workflows/vuln-check.yaml
     with:
-      target-ref: 3.10
-      find-latest-release: false
+      target-ref: v3.10
+      find-latest-release: true
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

This PR updates the target versions of the scheduled vulnerability check because the version `3.8` will be the maintenance support end this weekend, and we no longer have to check it. Also, it changes to start using the tagged versions (e.g., `v3.10.1` and `v3.9.5`) instead of using the branches, the same as the other repositories. Previously, we didn't have the tagged versions in the `scalardl` repo since we migrated the codes from `scalar` repo for the open-sourcing (cf. #77).

## Related issues and/or PRs

- scalar-labs/scalar#1403
- #77

## Changes made

- Remove the scheduled vulnerability check for `3.8`
- Change to use the tagged (latest) versions

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
