### PR TITLE
Add generic contract for select functionality

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -2,6 +2,12 @@ package com.scalar.dl.genericcontracts.table.v1_0_0;
 
 public class Constants {
 
+  // Metadata
+  public static final String PACKAGE = "table";
+  public static final String VERSION = "v1_0_0";
+  public static final String CONTRACT_SCAN = PACKAGE + "." + VERSION + ".Scan";
+
+  // Constants
   public static final String PREFIX_TABLE = "tbl_";
   public static final String PREFIX_INDEX = "idx_";
   public static final String PREFIX_RECORD = "rec_";
@@ -15,6 +21,20 @@ public class Constants {
   public static final String INDEX_KEY_TYPE = "type";
   public static final String RECORD_TABLE = "table";
   public static final String RECORD_VALUES = "values";
+  public static final String QUERY_TABLE = "table";
+  public static final String QUERY_CONDITIONS = "conditions";
+  public static final String QUERY_PROJECTIONS = "projections";
+  public static final String CONDITION_COLUMN = "column";
+  public static final String CONDITION_VALUE = "value";
+  public static final String CONDITION_OPERATOR = "operator";
+  public static final String OPERATOR_EQ = "EQ";
+  public static final String OPERATOR_NE = "NE";
+  public static final String OPERATOR_LT = "LT";
+  public static final String OPERATOR_LTE = "LTE";
+  public static final String OPERATOR_GT = "GT";
+  public static final String OPERATOR_GTE = "GTE";
+  public static final String OPERATOR_IS_NULL = "IS_NULL";
+  public static final String OPERATOR_IS_NOT_NULL = "IS_NOT_NULL";
   public static final String ASSET_AGE = "age";
 
   // Error messages
@@ -23,10 +43,22 @@ public class Constants {
       "The specified format of the indexes is invalid.";
   public static final String INVALID_RECORD_FORMAT =
       "The specified format of the record is invalid.";
+  public static final String INVALID_QUERY_FORMAT = "The specified format of the query is invalid.";
+  public static final String INVALID_CONDITION_FORMAT =
+      "The specified format of the condition is invalid. Condition: ";
+  public static final String INVALID_PROJECTIONS_FORMAT =
+      "The specified format of the projections.";
   public static final String INVALID_KEY_TYPE = "The specified key type is invalid.";
   public static final String INVALID_INDEX_KEY_TYPE = "The specified index key type is invalid.";
+  public static final String INVALID_OPERATOR = "The specified operator is invalid. Condition: ";
+  public static final String INVALID_KEY_SPECIFICATION =
+      "At least a condition for the primary key or index key must be properly specified.";
   public static final String TABLE_ALREADY_EXISTS = "The specified table already exists.";
   public static final String TABLE_NOT_EXIST = "The specified table does not exist.";
   public static final String RECORD_KEY_NOT_EXIST = "The record values must have the key.";
   public static final String RECORD_ALREADY_EXISTS = "The specified record already exists.";
+
+  // Internal error messages due to a bug or tampering
+  public static final String ILLEGAL_INDEX_STATE = "The state of the index is illegal.";
+  public static final String ILLEGAL_ARGUMENT = "The specified argument is illegal.";
 }

--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -46,8 +46,8 @@ public class Constants {
   public static final String INVALID_QUERY_FORMAT = "The specified format of the query is invalid.";
   public static final String INVALID_CONDITION_FORMAT =
       "The specified format of the condition is invalid. Condition: ";
-  public static final String INVALID_PROJECTIONS_FORMAT =
-      "The specified format of the projections.";
+  public static final String INVALID_PROJECTION_FORMAT =
+      "The specified format of the projection is invalid. Projection: ";
   public static final String INVALID_KEY_TYPE = "The specified key type is invalid.";
   public static final String INVALID_INDEX_KEY_TYPE = "The specified index key type is invalid.";
   public static final String INVALID_OPERATOR = "The specified operator is invalid. Condition: ";

--- a/generic-contracts/conf/table-authenticity-management-contracts.toml
+++ b/generic-contracts/conf/table-authenticity-management-contracts.toml
@@ -7,3 +7,13 @@ contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/g
 contract-id = "table.v1_0_0.Insert"
 contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Insert"
 contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Insert.class"
+
+[[contracts]]
+contract-id = "table.v1_0_0.Select"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Select"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Select.class"
+
+[[contracts]]
+contract-id = "table.v1_0_0.Scan"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Scan"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.class"

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Create.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Create.java
@@ -2,6 +2,7 @@ package com.scalar.dl.genericcontracts.table.v1_0_0;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.scalar.dl.ledger.contract.JacksonBasedContract;
 import com.scalar.dl.ledger.exception.ContractContextException;
 import com.scalar.dl.ledger.statemachine.Asset;
@@ -44,8 +45,9 @@ public class Create extends JacksonBasedContract {
     }
 
     // Put the asset records
-    ledger.put(Constants.ASSET_ID_METADATA_TABLES, arguments);
-    ledger.put(assetId, arguments);
+    JsonNode tableMetadata = prepareTableMetadata(arguments);
+    ledger.put(Constants.ASSET_ID_METADATA_TABLES, tableMetadata);
+    ledger.put(assetId, tableMetadata);
 
     return null;
   }
@@ -73,6 +75,16 @@ public class Create extends JacksonBasedContract {
       if (!isSupportedKeyType(index.get(Constants.INDEX_KEY_TYPE).asText())) {
         throw new ContractContextException(Constants.INVALID_KEY_TYPE);
       }
+    }
+  }
+
+  private JsonNode prepareTableMetadata(JsonNode arguments) {
+    if (arguments.has(Constants.TABLE_INDEXES)) {
+      return arguments;
+    } else {
+      ObjectNode tableMetadata = arguments.deepCopy();
+      tableMetadata.set(Constants.TABLE_INDEXES, getObjectMapper().createArrayNode());
+      return tableMetadata;
     }
   }
 

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.java
@@ -1,0 +1,310 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.database.AssetFilter;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+public class Scan extends JacksonBasedContract {
+
+  @Nullable
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+
+    // Get the table information
+    String tableName = arguments.get(Constants.QUERY_TABLE).asText();
+    String tableAssetId = getAssetIdForTable(tableName);
+    JsonNode table =
+        ledger
+            .get(tableAssetId)
+            .orElseThrow(() -> new ContractContextException(Constants.TABLE_NOT_EXIST))
+            .data();
+
+    // Scan records
+    ListMultimap<String, JsonNode> conditionsMap =
+        Multimaps.index(
+            arguments.get(Constants.QUERY_CONDITIONS),
+            condition -> condition.get(Constants.CONDITION_COLUMN).textValue());
+    if (isGetAvailable(table, conditionsMap)) {
+      return get(ledger, table, conditionsMap);
+    } else if (isIndexScanAvailable(table, conditionsMap)) {
+      return scan(ledger, table, conditionsMap);
+    } else {
+      throw new ContractContextException(Constants.INVALID_KEY_SPECIFICATION);
+    }
+  }
+
+  private boolean isGetAvailable(JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+    String key = table.get(Constants.TABLE_KEY).textValue();
+    String keyType = table.get(Constants.TABLE_KEY_TYPE).textValue();
+    return conditionsMap.containsKey(key)
+        && conditionsMap.get(key).stream()
+            .anyMatch(condition -> isPrimaryKeyCondition(condition, keyType));
+  }
+
+  private boolean isIndexScanAvailable(
+      JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+    for (JsonNode index : table.get(Constants.TABLE_INDEXES)) {
+      String indexKey = index.get(Constants.INDEX_KEY).asText();
+      String indexKeyType = index.get(Constants.INDEX_KEY_TYPE).asText();
+      if (conditionsMap.containsKey(indexKey)
+          && conditionsMap.get(indexKey).stream()
+              .anyMatch(condition -> isIndexKeyCondition(condition, indexKeyType))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isPrimaryKeyCondition(JsonNode condition, String keyType) {
+    if (!condition.get(Constants.CONDITION_VALUE).getNodeType().name().equalsIgnoreCase(keyType)) {
+      throw new ContractContextException(Constants.INVALID_KEY_TYPE);
+    }
+
+    return condition
+        .get(Constants.CONDITION_OPERATOR)
+        .textValue()
+        .equalsIgnoreCase(Constants.OPERATOR_EQ);
+  }
+
+  private boolean isIndexKeyCondition(JsonNode condition, String keyType) {
+    String operator = condition.get(Constants.CONDITION_OPERATOR).textValue().toUpperCase();
+    if (operator.equals(Constants.OPERATOR_IS_NULL)) {
+      return true;
+    }
+
+    if (!condition.get(Constants.CONDITION_VALUE).getNodeType().name().equalsIgnoreCase(keyType)) {
+      throw new ContractContextException(Constants.INVALID_INDEX_KEY_TYPE);
+    }
+
+    return operator.equals(Constants.OPERATOR_EQ);
+  }
+
+  private JsonNode getKeyColumnCondition(
+      JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+    String keyColumnName = table.get(Constants.TABLE_KEY).textValue();
+    String keyColumnType = table.get(Constants.TABLE_KEY_TYPE).textValue();
+    for (JsonNode condition : conditionsMap.get(keyColumnName)) {
+      if (isPrimaryKeyCondition(condition, keyColumnType)) {
+        return condition;
+      }
+    }
+
+    throw new ContractContextException(Constants.INVALID_KEY_SPECIFICATION);
+  }
+
+  private JsonNode getIndexColumnCondition(
+      JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+    for (JsonNode index : table.get(Constants.TABLE_INDEXES)) {
+      String indexKey = index.get(Constants.INDEX_KEY).asText();
+      String indexKeyType = index.get(Constants.INDEX_KEY_TYPE).asText();
+      for (JsonNode condition : conditionsMap.get(indexKey)) {
+        if (isIndexKeyCondition(condition, indexKeyType)) {
+          return condition;
+        }
+      }
+    }
+
+    throw new ContractContextException(Constants.INVALID_KEY_SPECIFICATION);
+  }
+
+  private List<String> getRecordAssetIdsFromIndex(
+      Ledger<JsonNode> ledger, String tableName, String indexAssetId, String keyColumnName) {
+    List<Asset<JsonNode>> indexEntries = ledger.scan(new AssetFilter(indexAssetId));
+    List<String> assetIds = new ArrayList<>();
+
+    for (Asset<JsonNode> indexEntry : indexEntries) {
+      if (!indexEntry.data().has(keyColumnName)) {
+        throw new ContractContextException(Constants.ILLEGAL_INDEX_STATE);
+      }
+      assetIds.add(
+          getAssetIdForRecord(
+              tableName, keyColumnName, indexEntry.data().get(keyColumnName).asText()));
+    }
+
+    return assetIds;
+  }
+
+  private ArrayNode get(
+      Ledger<JsonNode> ledger, JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+    String tableName = table.get(Constants.TABLE_NAME).textValue();
+    JsonNode condition = getKeyColumnCondition(table, conditionsMap);
+    String assetId =
+        getAssetIdForRecord(
+            tableName,
+            condition.get(Constants.CONDITION_COLUMN).textValue(),
+            condition.get(Constants.CONDITION_VALUE).asText());
+    ArrayNode results = getObjectMapper().createArrayNode();
+
+    ledger.get(assetId).ifPresent(asset -> results.add(asset.data()));
+
+    return filter(
+        results,
+        conditionsMap.values().stream()
+            .filter(c -> !c.equals(condition))
+            .collect(Collectors.toList()));
+  }
+
+  private ArrayNode scan(
+      Ledger<JsonNode> ledger, JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+    String tableName = table.get(Constants.TABLE_NAME).textValue();
+    String keyColumnName = table.get(Constants.TABLE_KEY).textValue();
+    JsonNode condition = getIndexColumnCondition(table, conditionsMap);
+    String indexAssetId = getAssetIdForIndex(tableName, condition);
+    ArrayNode results = getObjectMapper().createArrayNode();
+
+    for (String recordAssetId :
+        getRecordAssetIdsFromIndex(ledger, tableName, indexAssetId, keyColumnName)) {
+      Optional<Asset<JsonNode>> asset = ledger.get(recordAssetId);
+      if (!asset.isPresent()) {
+        throw new ContractContextException(Constants.ILLEGAL_INDEX_STATE);
+      }
+      results.add(asset.get().data());
+    }
+
+    return filter(
+        results,
+        conditionsMap.values().stream()
+            .filter(c -> !c.equals(condition))
+            .collect(Collectors.toList()));
+  }
+
+  private ArrayNode filter(ArrayNode records, List<JsonNode> conditions) {
+    ArrayNode results = getObjectMapper().createArrayNode();
+
+    for (JsonNode record : records) {
+      boolean allMatched = true;
+      for (JsonNode condition : conditions) {
+        if (!match(record, condition)) {
+          allMatched = false;
+          break;
+        }
+      }
+      if (allMatched) {
+        results.add(record);
+      }
+    }
+
+    return results;
+  }
+
+  private boolean match(JsonNode record, JsonNode condition) {
+    String column = condition.get(Constants.CONDITION_COLUMN).textValue();
+    String operator = condition.get(Constants.CONDITION_OPERATOR).textValue().toUpperCase();
+    JsonNode value = condition.get(Constants.CONDITION_VALUE);
+
+    if (!operator.equals(Constants.OPERATOR_IS_NULL)
+        && !operator.equals(Constants.OPERATOR_IS_NOT_NULL)
+        && (!record.has(column) || !record.get(column).getNodeType().equals(value.getNodeType()))) {
+      return false;
+    }
+
+    switch (operator) {
+      case Constants.OPERATOR_EQ:
+        return isEqual(record.get(column), value);
+      case Constants.OPERATOR_NE:
+        return !isEqual(record.get(column), value);
+      case Constants.OPERATOR_LT:
+        return isLessThan(record.get(column), value);
+      case Constants.OPERATOR_LTE:
+        return !isGreaterThan(record.get(column), value);
+      case Constants.OPERATOR_GT:
+        return isGreaterThan(record.get(column), value);
+      case Constants.OPERATOR_GTE:
+        return !isLessThan(record.get(column), value);
+      case Constants.OPERATOR_IS_NULL:
+        return isNull(record, column);
+      case Constants.OPERATOR_IS_NOT_NULL:
+        return !isNull(record, column);
+      default:
+        throw new ContractContextException(Constants.ILLEGAL_ARGUMENT);
+    }
+  }
+
+  private boolean isEqual(JsonNode leftValue, JsonNode rightValue) {
+    JsonNodeType type = leftValue.getNodeType();
+    if (type == JsonNodeType.STRING) {
+      return leftValue.asText().equals(rightValue.asText());
+    } else if (type == JsonNodeType.NUMBER) {
+      return leftValue.decimalValue().compareTo(rightValue.decimalValue()) == 0;
+    } else {
+      return leftValue.equals(rightValue);
+    }
+  }
+
+  private boolean isLessThan(JsonNode leftValue, JsonNode rightValue) {
+    JsonNodeType type = leftValue.getNodeType();
+    if (type == JsonNodeType.STRING) {
+      return leftValue.asText().compareTo(rightValue.asText()) < 0;
+    } else if (type == JsonNodeType.NUMBER) {
+      return leftValue.decimalValue().compareTo(rightValue.decimalValue()) < 0;
+    } else {
+      throw new ContractContextException(Constants.ILLEGAL_ARGUMENT);
+    }
+  }
+
+  private boolean isGreaterThan(JsonNode leftValue, JsonNode rightValue) {
+    JsonNodeType type = leftValue.getNodeType();
+    if (type == JsonNodeType.STRING) {
+      return leftValue.asText().compareTo(rightValue.asText()) > 0;
+    } else if (type == JsonNodeType.NUMBER) {
+      return leftValue.decimalValue().compareTo(rightValue.decimalValue()) > 0;
+    } else {
+      throw new ContractContextException(Constants.ILLEGAL_ARGUMENT);
+    }
+  }
+
+  private boolean isNull(JsonNode record, String column) {
+    return !record.has(column) || record.get(column).isNull();
+  }
+
+  private String getAssetIdForTable(String tableName) {
+    return Constants.PREFIX_TABLE + tableName;
+  }
+
+  private String getAssetIdForRecord(String tableName, String keyColumnName, String key) {
+    return Constants.PREFIX_RECORD
+        + tableName
+        + Constants.ASSET_ID_SEPARATOR
+        + keyColumnName
+        + Constants.ASSET_ID_SEPARATOR
+        + key;
+  }
+
+  private String getAssetIdForIndex(String tableName, JsonNode condition) {
+    String indexKey = condition.get(Constants.CONDITION_COLUMN).textValue();
+    JsonNode indexValue = condition.get(Constants.CONDITION_VALUE);
+    String operator = condition.get(Constants.CONDITION_OPERATOR).textValue().toUpperCase();
+
+    if (operator.equals(Constants.OPERATOR_IS_NULL)) {
+      return getAssetIdForNullIndex(tableName, indexKey);
+    } else {
+      return getAssetIdForIndex(tableName, indexKey, indexValue.asText());
+    }
+  }
+
+  private String getAssetIdForIndex(String tableName, String indexKey, String value) {
+    return Constants.PREFIX_INDEX
+        + tableName
+        + Constants.ASSET_ID_SEPARATOR
+        + indexKey
+        + Constants.ASSET_ID_SEPARATOR
+        + value;
+  }
+
+  private String getAssetIdForNullIndex(String tableName, String indexKey) {
+    return Constants.PREFIX_INDEX + tableName + Constants.ASSET_ID_SEPARATOR + indexKey;
+  }
+}

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.java
@@ -36,9 +36,9 @@ public class Scan extends JacksonBasedContract {
         Multimaps.index(
             arguments.get(Constants.QUERY_CONDITIONS),
             condition -> condition.get(Constants.CONDITION_COLUMN).textValue());
-    if (isGetAvailable(table, conditionsMap)) {
+    if (hasPrimaryKeyCondition(table, conditionsMap)) {
       return get(ledger, table, conditionsMap);
-    } else if (isIndexScanAvailable(table, conditionsMap)) {
+    } else if (hasIndexKeyCondition(table, conditionsMap)) {
       return scan(ledger, table, conditionsMap);
     } else {
       throw new ContractContextException(Constants.INVALID_KEY_SPECIFICATION);
@@ -46,14 +46,16 @@ public class Scan extends JacksonBasedContract {
   }
 
   /**
-   * Returns true if the get operation is available. The get operation gets a single record based on
-   * the primary key. It must include an equality (EQ) condition for the primary key.
+   * Returns true if the conditions map has a primary key condition, which means the get operation
+   * can be executed. The get operation gets a single record based on the primary key. It must
+   * include an equality (EQ) condition for the primary key.
    *
    * @param table a table metadata object
    * @param conditionsMap a map of condition objects
    * @return boolean
    */
-  private boolean isGetAvailable(JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
+  private boolean hasPrimaryKeyCondition(
+      JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
     String key = table.get(Constants.TABLE_KEY).textValue();
     String keyType = table.get(Constants.TABLE_KEY_TYPE).textValue();
     return conditionsMap.containsKey(key)
@@ -62,15 +64,15 @@ public class Scan extends JacksonBasedContract {
   }
 
   /**
-   * Returns true if the index scan operation is available. The index scan operation gets multiple
-   * records that the specified index key matches. It must include an equality condition or IS_NULL
-   * condition for an index key.
+   * Returns true if the conditions map has an index key condition, which means the index scan
+   * operation can be executed. The index scan operation gets multiple records that the specified
+   * index key matches. It must include an equality condition or IS_NULL condition for an index key.
    *
    * @param table a table metadata object
    * @param conditionsMap a map of condition objects
    * @return boolean
    */
-  private boolean isIndexScanAvailable(
+  private boolean hasIndexKeyCondition(
       JsonNode table, ListMultimap<String, JsonNode> conditionsMap) {
     for (JsonNode index : table.get(Constants.TABLE_INDEXES)) {
       String indexKey = index.get(Constants.INDEX_KEY).asText();

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
@@ -2,6 +2,7 @@ package com.scalar.dl.genericcontracts.table.v1_0_0;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.dl.ledger.contract.JacksonBasedContract;
@@ -88,7 +89,8 @@ public class Select extends JacksonBasedContract {
         // For other operators
         if (condition.size() != 3
             || !condition.has(Constants.CONDITION_VALUE)
-            || condition.get(Constants.CONDITION_VALUE).isNull()) {
+            || !isSupportedDataTypeForComparisonOperators(
+                condition.get(Constants.CONDITION_VALUE).getNodeType().name())) {
           throw new ContractContextException(Constants.INVALID_CONDITION_FORMAT + condition);
         }
         if (condition.get(Constants.CONDITION_VALUE).isBoolean()
@@ -100,25 +102,31 @@ public class Select extends JacksonBasedContract {
     }
   }
 
-  private boolean isSupportedOperator(String type) {
-    return type.equalsIgnoreCase(Constants.OPERATOR_EQ)
-        || type.equalsIgnoreCase(Constants.OPERATOR_NE)
-        || type.equalsIgnoreCase(Constants.OPERATOR_LT)
-        || type.equalsIgnoreCase(Constants.OPERATOR_LTE)
-        || type.equalsIgnoreCase(Constants.OPERATOR_GT)
-        || type.equalsIgnoreCase(Constants.OPERATOR_GTE)
-        || type.equalsIgnoreCase(Constants.OPERATOR_IS_NULL)
-        || type.equalsIgnoreCase(Constants.OPERATOR_IS_NOT_NULL);
+  private boolean isSupportedDataTypeForComparisonOperators(String type) {
+    return type.toUpperCase().equals(JsonNodeType.BOOLEAN.name())
+        || type.toUpperCase().equals(JsonNodeType.NUMBER.name())
+        || type.toUpperCase().equals(JsonNodeType.STRING.name());
+  }
+
+  private boolean isSupportedOperator(String operator) {
+    return operator.equalsIgnoreCase(Constants.OPERATOR_EQ)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_NE)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_LT)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_LTE)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_GT)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_GTE)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_IS_NULL)
+        || operator.equalsIgnoreCase(Constants.OPERATOR_IS_NOT_NULL);
   }
 
   private void validateProjections(JsonNode projections) {
     if (!projections.isArray()) {
-      throw new ContractContextException(Constants.INVALID_PROJECTIONS_FORMAT);
+      throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
     }
 
     for (JsonNode projection : projections) {
       if (!projection.isTextual()) {
-        throw new ContractContextException(Constants.INVALID_PROJECTIONS_FORMAT);
+        throw new ContractContextException(Constants.INVALID_PROJECTION_FORMAT + projection);
       }
     }
   }

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
@@ -1,0 +1,130 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import javax.annotation.Nullable;
+
+public class Select extends JacksonBasedContract {
+
+  @Nullable
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+
+    // Check the arguments
+    if ((arguments.size() != 2 && arguments.size() != 3)
+        || !arguments.has(Constants.QUERY_TABLE)
+        || !arguments.get(Constants.QUERY_TABLE).isTextual()
+        || !arguments.has(Constants.QUERY_CONDITIONS)
+        || !arguments.get(Constants.QUERY_CONDITIONS).isArray()) {
+      throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
+    }
+
+    // Check the format of each condition
+    JsonNode conditions = arguments.get(Constants.QUERY_CONDITIONS);
+    validateConditions(conditions);
+
+    // Check projections
+    JsonNode projections = getObjectMapper().createArrayNode();
+    if (arguments.has(Constants.QUERY_PROJECTIONS)) {
+      projections = arguments.get(Constants.QUERY_PROJECTIONS);
+      validateProjections(projections);
+    }
+
+    // Scan and project records
+    return project(invokeSubContract(Constants.CONTRACT_SCAN, ledger, arguments), projections);
+  }
+
+  private JsonNode project(JsonNode records, JsonNode projections) {
+    if (projections.isEmpty()) {
+      return records;
+    } else {
+      ArrayNode projectedResults = getObjectMapper().createArrayNode();
+      for (JsonNode record : records) {
+        projectedResults.add(projectRecord(record, projections));
+      }
+      return projectedResults;
+    }
+  }
+
+  private JsonNode projectRecord(JsonNode record, JsonNode projections) {
+    ObjectNode newRecord = getObjectMapper().createObjectNode();
+    for (JsonNode projection : projections) {
+      String column = projection.asText();
+      if (record.has(column)) {
+        newRecord.set(column, record.get(column));
+      }
+    }
+    return newRecord;
+  }
+
+  private void validateConditions(JsonNode conditions) {
+    for (JsonNode condition : conditions) {
+      if (!condition.isObject()
+          || !condition.has(Constants.CONDITION_COLUMN)
+          || !condition.get(Constants.CONDITION_COLUMN).isTextual()
+          || !condition.has(Constants.CONDITION_OPERATOR)
+          || !condition.get(Constants.CONDITION_OPERATOR).isTextual()) {
+        throw new ContractContextException(Constants.INVALID_CONDITION_FORMAT + condition);
+      }
+
+      String operator = condition.get(Constants.CONDITION_OPERATOR).asText();
+      if (!isSupportedOperator(operator)) {
+        throw new ContractContextException(Constants.INVALID_OPERATOR + condition);
+      }
+
+      if (operator.equalsIgnoreCase(Constants.OPERATOR_IS_NULL)
+          || operator.equalsIgnoreCase(Constants.OPERATOR_IS_NOT_NULL)) {
+        // For IS_NULL or IS_NOT_NULL
+        if (condition.size() != 2) {
+          throw new ContractContextException(Constants.INVALID_CONDITION_FORMAT + condition);
+        }
+      } else {
+        // For other operators
+        if (condition.size() != 3
+            || !condition.has(Constants.CONDITION_VALUE)
+            || condition.get(Constants.CONDITION_VALUE).isNull()) {
+          throw new ContractContextException(Constants.INVALID_CONDITION_FORMAT + condition);
+        }
+        if (condition.get(Constants.CONDITION_VALUE).isBoolean()
+            && (!operator.equalsIgnoreCase(Constants.OPERATOR_EQ)
+                && !operator.equalsIgnoreCase(Constants.OPERATOR_NE))) {
+          throw new ContractContextException(Constants.INVALID_OPERATOR + condition);
+        }
+      }
+    }
+  }
+
+  private boolean isSupportedOperator(String type) {
+    return type.equalsIgnoreCase(Constants.OPERATOR_EQ)
+        || type.equalsIgnoreCase(Constants.OPERATOR_NE)
+        || type.equalsIgnoreCase(Constants.OPERATOR_LT)
+        || type.equalsIgnoreCase(Constants.OPERATOR_LTE)
+        || type.equalsIgnoreCase(Constants.OPERATOR_GT)
+        || type.equalsIgnoreCase(Constants.OPERATOR_GTE)
+        || type.equalsIgnoreCase(Constants.OPERATOR_IS_NULL)
+        || type.equalsIgnoreCase(Constants.OPERATOR_IS_NOT_NULL);
+  }
+
+  private void validateProjections(JsonNode projections) {
+    if (!projections.isArray()) {
+      throw new ContractContextException(Constants.INVALID_PROJECTIONS_FORMAT);
+    }
+
+    for (JsonNode projection : projections) {
+      if (!projection.isTextual()) {
+        throw new ContractContextException(Constants.INVALID_PROJECTIONS_FORMAT);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  JsonNode invokeSubContract(String contractId, Ledger<JsonNode> ledger, JsonNode arguments) {
+    return invoke(contractId, ledger, arguments);
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/CreateTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/CreateTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.scalar.dl.ledger.exception.ContractContextException;
 import com.scalar.dl.ledger.statemachine.Asset;
 import com.scalar.dl.ledger.statemachine.Ledger;
@@ -77,6 +78,29 @@ public class CreateTest {
     verify(ledger).get(SOME_TABLE_ASSET_ID);
     verify(ledger).put(SOME_TABLE_ASSET_ID, argument);
     verify(ledger).put(Constants.ASSET_ID_METADATA_TABLES, argument);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithoutIndexesGiven_ShouldCreateTableWithEmptyIndexes() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
+    ObjectNode expected = argument.deepCopy();
+    expected.set(Constants.TABLE_INDEXES, mapper.createArrayNode());
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.empty());
+
+    // Act
+    JsonNode actual = create.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNull();
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).put(SOME_TABLE_ASSET_ID, expected);
+    verify(ledger).put(Constants.ASSET_ID_METADATA_TABLES, expected);
   }
 
   @Test

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/ScanTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/ScanTest.java
@@ -1,0 +1,766 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.scalar.dl.ledger.database.AssetFilter;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ScanTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String SOME_TABLE_NAME = "Person";
+  private static final String SOME_TABLE_ASSET_ID = Constants.PREFIX_TABLE + SOME_TABLE_NAME;
+  private static final String SOME_KEY_TYPE_STRING = "string";
+  private static final String SOME_KEY_TYPE_NUMBER = "number";
+  private static final String SOME_KEY_TYPE_BOOLEAN = "boolean";
+  private static final String SOME_PRIMARY_KEY_COLUMN = "GovId";
+  private static final String SOME_PRIMARY_KEY_VALUE_1 = "001";
+  private static final String SOME_PRIMARY_KEY_VALUE_2 = "002";
+  private static final String SOME_INDEX_KEY_COLUMN_1 = "lastName";
+  private static final String SOME_INDEX_KEY_COLUMN_VALUE_1 = "Doe";
+  private static final String SOME_INDEX_KEY_COLUMN_2 = "amount";
+  private static final double SOME_INDEX_KEY_COLUMN_VALUE_2 = 130.75;
+  private static final String SOME_INDEX_KEY_COLUMN_3 = "indexFlag";
+  private static final boolean SOME_INDEX_KEY_COLUMN_VALUE_3 = true;
+  private static final String SOME_COLUMN_STRING = "firstName";
+  private static final String SOME_COLUMN_STRING_VALUE_1 = "John";
+  private static final String SOME_COLUMN_STRING_VALUE_2 = "Joe";
+  private static final String SOME_COLUMN_NUMBER = "balance";
+  private static final String SOME_COLUMN_NULLABLE = "nullable";
+  private static final int SOME_COLUMN_NUMBER_VALUE = 10;
+  private static final String SOME_COLUMN_BOOLEAN = "flag";
+  private static final boolean SOME_COLUMN_BOOLEAN_VALUE = false;
+  private static final String SOME_INDEX_ASSET_ID_1 =
+      getIndexAssetId(SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1);
+  private static final String SOME_INDEX_ASSET_ID_3 =
+      getIndexAssetId(SOME_INDEX_KEY_COLUMN_3, String.valueOf(SOME_INDEX_KEY_COLUMN_VALUE_3));
+  private static final String SOME_RECORD_ASSET_ID_1 =
+      getRecordAssetId(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1);
+  private static final String SOME_RECORD_ASSET_ID_2 =
+      getRecordAssetId(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_2);
+  private static final JsonNode SOME_TABLE =
+      mapper
+          .createObjectNode()
+          .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+          .put(Constants.TABLE_KEY, SOME_PRIMARY_KEY_COLUMN)
+          .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+          .set(
+              Constants.TABLE_INDEXES,
+              mapper
+                  .createArrayNode()
+                  .add(createIndexNode(SOME_INDEX_KEY_COLUMN_1, SOME_KEY_TYPE_STRING))
+                  .add(createIndexNode(SOME_INDEX_KEY_COLUMN_2, SOME_KEY_TYPE_NUMBER))
+                  .add(createIndexNode(SOME_INDEX_KEY_COLUMN_3, SOME_KEY_TYPE_BOOLEAN)));
+
+  private final Scan scan = new Scan();
+
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private static String getRecordAssetId(String key, String value) {
+    return Constants.PREFIX_RECORD
+        + SOME_TABLE_NAME
+        + Constants.ASSET_ID_SEPARATOR
+        + key
+        + Constants.ASSET_ID_SEPARATOR
+        + value;
+  }
+
+  private static String getIndexAssetId(String key, String value) {
+    return Constants.PREFIX_INDEX
+        + SOME_TABLE_NAME
+        + Constants.ASSET_ID_SEPARATOR
+        + key
+        + Constants.ASSET_ID_SEPARATOR
+        + value;
+  }
+
+  private static ObjectNode createIndexNode(String key, String type) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.INDEX_KEY, key)
+        .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  private static ObjectNode createRecord(String primaryKey, String indexKey, String stringValue) {
+    return mapper
+        .createObjectNode()
+        .put(SOME_PRIMARY_KEY_COLUMN, primaryKey)
+        .put(SOME_INDEX_KEY_COLUMN_1, indexKey)
+        .put(SOME_COLUMN_STRING, stringValue)
+        .set(SOME_COLUMN_NULLABLE, null);
+  }
+
+  private static ObjectNode createRecord(String primaryKey, String indexKey, int numberValue) {
+    return mapper
+        .createObjectNode()
+        .put(SOME_PRIMARY_KEY_COLUMN, primaryKey)
+        .put(SOME_INDEX_KEY_COLUMN_1, indexKey)
+        .put(SOME_COLUMN_NUMBER, numberValue)
+        .set(SOME_COLUMN_NULLABLE, null);
+  }
+
+  private static ObjectNode createRecord(String primaryKey, String indexKey, boolean flag) {
+    return mapper
+        .createObjectNode()
+        .put(SOME_PRIMARY_KEY_COLUMN, primaryKey)
+        .put(SOME_INDEX_KEY_COLUMN_1, indexKey)
+        .put(SOME_COLUMN_BOOLEAN, flag)
+        .set(SOME_COLUMN_NULLABLE, null);
+  }
+
+  private Asset<JsonNode> createAsset(JsonNode data) {
+    Asset<JsonNode> asset = (Asset<JsonNode>) mock(Asset.class);
+    when(asset.data()).thenReturn(data);
+    return asset;
+  }
+
+  private static JsonNode createCondition(String column, String value, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_VALUE, value)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private static JsonNode createCondition(String column, int value, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_VALUE, value)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private static JsonNode createCondition(String column, double value, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_VALUE, value)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private static JsonNode createCondition(String column, boolean value, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_VALUE, value)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private static JsonNode createCondition(String column, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private ArrayNode createConditions(String column, String value, String operator) {
+    return mapper
+        .createArrayNode()
+        .add(
+            createCondition(
+                SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ))
+        .add(createCondition(column, value, operator));
+  }
+
+  private ArrayNode createConditions(String column, String operator) {
+    return mapper
+        .createArrayNode()
+        .add(
+            createCondition(
+                SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ))
+        .add(createCondition(column, operator));
+  }
+
+  private ArrayNode createConditions(String column, int value, String operator) {
+    return mapper
+        .createArrayNode()
+        .add(
+            createCondition(
+                SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ))
+        .add(createCondition(column, value, operator));
+  }
+
+  private ArrayNode createConditions(String column, boolean value, String operator) {
+    return mapper
+        .createArrayNode()
+        .add(
+            createCondition(
+                SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ))
+        .add(createCondition(column, value, operator));
+  }
+
+  private JsonNode createQueryArguments(ArrayNode conditions) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+        .set(Constants.QUERY_CONDITIONS, conditions);
+  }
+
+  private void assertMatchedRecordExists(JsonNode actual, JsonNode expected) {
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+  }
+
+  private void assertMatchedRecordNotExist(JsonNode actual) {
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithStringPrimaryKeyGiven_ShouldReturnRecords() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected =
+        mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> record = createAsset(expected);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(record));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithNumberPrimaryKeyGiven_ShouldReturnRecords() {
+    // Arrange
+    JsonNode table =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_PRIMARY_KEY_COLUMN)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_NUMBER);
+    double primaryKey = 1.234;
+    String recordAssetId = getRecordAssetId(SOME_PRIMARY_KEY_COLUMN, String.valueOf(primaryKey));
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(createCondition(SOME_PRIMARY_KEY_COLUMN, primaryKey, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected = mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, primaryKey);
+    Asset<JsonNode> tableAsset = createAsset(table);
+    Asset<JsonNode> recordAsset = createAsset(expected);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+    when(ledger.get(recordAssetId)).thenReturn(Optional.of(recordAsset));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(recordAssetId);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithBooleanPrimaryKeyGiven_ShouldReturnRecords() {
+    // Arrange
+    JsonNode table =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME)
+            .put(Constants.TABLE_KEY, SOME_PRIMARY_KEY_COLUMN)
+            .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_BOOLEAN);
+    boolean primaryKey = true;
+    String recordAssetId = getRecordAssetId(SOME_PRIMARY_KEY_COLUMN, String.valueOf(primaryKey));
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(createCondition(SOME_PRIMARY_KEY_COLUMN, primaryKey, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected = mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, primaryKey);
+    Asset<JsonNode> tableAsset = createAsset(table);
+    Asset<JsonNode> recordAsset = createAsset(expected);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(tableAsset));
+    when(ledger.get(recordAssetId)).thenReturn(Optional.of(recordAsset));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(recordAssetId);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithStringIndexKeyGiven_ShouldReturnRecords() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected1 =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_1);
+    JsonNode expected2 =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_2, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_2);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index1 =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    Asset<JsonNode> index2 =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_2));
+    Asset<JsonNode> record1 = createAsset(expected1);
+    Asset<JsonNode> record2 = createAsset(expected2);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(record1));
+    when(ledger.get(SOME_RECORD_ASSET_ID_2)).thenReturn(Optional.of(record2));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1)))
+        .thenReturn(ImmutableList.of(index1, index2));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual.get(0)).isEqualTo(expected1);
+    assertThat(actual.get(1)).isEqualTo(expected2);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithNumberIndexKeyGiven_ShouldReturnRecords() {
+    // Arrange
+    String indexAssetId =
+        getIndexAssetId(SOME_INDEX_KEY_COLUMN_2, String.valueOf(SOME_INDEX_KEY_COLUMN_VALUE_2));
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_GTE))
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_2, SOME_INDEX_KEY_COLUMN_VALUE_2, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected =
+        createRecord(
+                SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_1)
+            .put(SOME_INDEX_KEY_COLUMN_2, SOME_INDEX_KEY_COLUMN_VALUE_2);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    Asset<JsonNode> record = createAsset(expected);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(record));
+    when(ledger.scan(new AssetFilter(indexAssetId))).thenReturn(ImmutableList.of(index));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithBooleanIndexKeyGiven_ShouldReturnRecords() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_3, SOME_INDEX_KEY_COLUMN_VALUE_3, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected =
+        createRecord(
+                SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_1)
+            .put(SOME_INDEX_KEY_COLUMN_3, SOME_INDEX_KEY_COLUMN_VALUE_3);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    Asset<JsonNode> record = createAsset(expected);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(record));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_3))).thenReturn(ImmutableList.of(index));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithNullIndexKeyGiven_ShouldReturnEmptyArray() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_INDEX_KEY_COLUMN_1)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_IS_NULL));
+    JsonNode argument = createQueryArguments(conditions);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of());
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(0);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithIndexKeyAndConditionGiven_ShouldReturnCorrectRecords() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ))
+            .add(
+                createCondition(
+                    SOME_COLUMN_STRING, SOME_COLUMN_STRING_VALUE_2, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    JsonNode expected =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_2, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_2);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index1 =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    Asset<JsonNode> index2 =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_2));
+    Asset<JsonNode> record1 =
+        createAsset(
+            createRecord(
+                SOME_PRIMARY_KEY_VALUE_1,
+                SOME_INDEX_KEY_COLUMN_VALUE_1,
+                SOME_COLUMN_STRING_VALUE_1));
+    Asset<JsonNode> record2 = createAsset(expected);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(record1));
+    when(ledger.get(SOME_RECORD_ASSET_ID_2)).thenReturn(Optional.of(record2));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1)))
+        .thenReturn(ImmutableList.of(index1, index2));
+
+    // Act
+    JsonNode actual = scan.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsGivenButMalformedIndexAssetFound_ShouldThrowException() {
+    // Arrange
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index = createAsset(mapper.createObjectNode());
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of(index));
+
+    // Act Assert
+    assertThatThrownBy(() -> scan.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.ILLEGAL_INDEX_STATE);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).scan(new AssetFilter(SOME_INDEX_ASSET_ID_1));
+    verify(ledger, never()).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsGivenButAssetNotFoundByIndex_ShouldThrowException() {
+    // Arrange
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_EQ));
+    JsonNode argument = createQueryArguments(conditions);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.empty());
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of(index));
+
+    // Act Assert
+    assertThatThrownBy(() -> scan.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.ILLEGAL_INDEX_STATE);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+    verify(ledger).scan(new AssetFilter(SOME_INDEX_ASSET_ID_1));
+    verify(ledger).get(SOME_RECORD_ASSET_ID_1);
+  }
+
+  @Test
+  public void invoke_ArgumentsWithoutPrimaryKeyAndIndexKeyConditionsGiven_ShouldThrowException() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(
+                createCondition(
+                    SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1, Constants.OPERATOR_GT))
+            .add(
+                createCondition(
+                    SOME_INDEX_KEY_COLUMN_1, SOME_INDEX_KEY_COLUMN_VALUE_1, Constants.OPERATOR_LT))
+            .add(
+                createCondition(
+                    SOME_COLUMN_STRING, SOME_COLUMN_STRING_VALUE_1, Constants.OPERATOR_EQ));
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+            .set(Constants.QUERY_CONDITIONS, conditions);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+
+    // Act Assert
+    assertThatThrownBy(() -> scan.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_KEY_SPECIFICATION);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+  }
+
+  @Test
+  public void invoke_ArgumentsWithInvalidPrimaryKeyConditionGiven_ShouldThrowException() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(createCondition(SOME_PRIMARY_KEY_COLUMN, 0, Constants.OPERATOR_EQ));
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+            .set(Constants.QUERY_CONDITIONS, conditions);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+
+    // Act Assert
+    assertThatThrownBy(() -> scan.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_KEY_TYPE);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+  }
+
+  @Test
+  public void invoke_ArgumentsWithInvalidIndexKeyConditionGiven_ShouldThrowException() {
+    // Arrange
+    ArrayNode conditions =
+        mapper
+            .createArrayNode()
+            .add(createCondition(SOME_INDEX_KEY_COLUMN_1, 0, Constants.OPERATOR_EQ));
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+            .set(Constants.QUERY_CONDITIONS, conditions);
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+
+    // Act Assert
+    assertThatThrownBy(() -> scan.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_INDEX_KEY_TYPE);
+    verify(ledger).get(SOME_TABLE_ASSET_ID);
+  }
+
+  @Test
+  public void match_CorrectArgumentsWithConditionForStringColumnGiven_ShouldReturnCorrectResults() {
+    // Arrange
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    JsonNode record =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_1);
+    Asset<JsonNode> asset = createAsset(record);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of(index));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(asset));
+    ArrayNode conditions1 = createConditions(SOME_COLUMN_STRING, "John", Constants.OPERATOR_EQ);
+    ArrayNode conditions2 = createConditions(SOME_COLUMN_STRING, "", Constants.OPERATOR_NE);
+    ArrayNode conditions3 = createConditions(SOME_COLUMN_STRING, "I", Constants.OPERATOR_GT);
+    ArrayNode conditions4 = createConditions(SOME_COLUMN_STRING, "I", Constants.OPERATOR_GTE);
+    ArrayNode conditions5 = createConditions(SOME_COLUMN_STRING, "K", Constants.OPERATOR_LT);
+    ArrayNode conditions6 = createConditions(SOME_COLUMN_STRING, "K", Constants.OPERATOR_LTE);
+
+    // Act Assert
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions1), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions2), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions3), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions4), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions5), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions6), null), record);
+  }
+
+  @Test
+  public void match_CorrectArgumentsWithConditionForNumberColumnGiven_ShouldReturnCorrectResults() {
+    // Arrange
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    JsonNode record =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_NUMBER_VALUE);
+    Asset<JsonNode> asset = createAsset(record);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of(index));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(asset));
+    ArrayNode conditions1 = createConditions(SOME_COLUMN_NUMBER, 10, Constants.OPERATOR_EQ);
+    ArrayNode conditions2 = createConditions(SOME_COLUMN_NUMBER, 20, Constants.OPERATOR_NE);
+    ArrayNode conditions3 = createConditions(SOME_COLUMN_NUMBER, 5, Constants.OPERATOR_GT);
+    ArrayNode conditions4 = createConditions(SOME_COLUMN_NUMBER, 10, Constants.OPERATOR_GTE);
+    ArrayNode conditions5 = createConditions(SOME_COLUMN_NUMBER, 20, Constants.OPERATOR_LT);
+    ArrayNode conditions6 = createConditions(SOME_COLUMN_NUMBER, 10, Constants.OPERATOR_LTE);
+    ArrayNode conditions7 = createConditions(SOME_COLUMN_NUMBER, 10, Constants.OPERATOR_NE);
+    ArrayNode conditions8 = createConditions(SOME_COLUMN_NUMBER, 20, Constants.OPERATOR_GTE);
+    ArrayNode conditions9 = createConditions(SOME_COLUMN_NUMBER, 5, Constants.OPERATOR_LTE);
+    ArrayNode conditions10 = createConditions(SOME_COLUMN_NUMBER, "10", Constants.OPERATOR_EQ);
+
+    // Act Assert
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions1), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions2), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions3), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions4), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions5), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions6), null), record);
+    assertMatchedRecordNotExist(scan.invoke(ledger, createQueryArguments(conditions7), null));
+    assertMatchedRecordNotExist(scan.invoke(ledger, createQueryArguments(conditions8), null));
+    assertMatchedRecordNotExist(scan.invoke(ledger, createQueryArguments(conditions9), null));
+    assertMatchedRecordNotExist(scan.invoke(ledger, createQueryArguments(conditions10), null));
+  }
+
+  @Test
+  public void
+      match_CorrectArgumentsWithConditionForBooleanColumnGiven_ShouldReturnCorrectResults() {
+    // Arrange
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    JsonNode record =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_BOOLEAN_VALUE);
+    Asset<JsonNode> asset = createAsset(record);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of(index));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(asset));
+    ArrayNode conditions1 = createConditions(SOME_COLUMN_BOOLEAN, false, Constants.OPERATOR_EQ);
+    ArrayNode conditions2 = createConditions(SOME_COLUMN_BOOLEAN, false, Constants.OPERATOR_NE);
+
+    // Act Assert
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions1), null), record);
+    assertMatchedRecordNotExist(scan.invoke(ledger, createQueryArguments(conditions2), null));
+  }
+
+  @Test
+  public void match_CorrectArgumentsWithConditionForNullColumnGiven_ShouldReturnCorrectResults() {
+    // Arrange
+    Asset<JsonNode> table = createAsset(SOME_TABLE);
+    Asset<JsonNode> index =
+        createAsset(
+            mapper.createObjectNode().put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE_1));
+    JsonNode record =
+        createRecord(
+            SOME_PRIMARY_KEY_VALUE_1, SOME_INDEX_KEY_COLUMN_VALUE_1, SOME_COLUMN_STRING_VALUE_1);
+    Asset<JsonNode> asset = createAsset(record);
+    when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(table));
+    when(ledger.scan(new AssetFilter(SOME_INDEX_ASSET_ID_1))).thenReturn(ImmutableList.of(index));
+    when(ledger.get(SOME_RECORD_ASSET_ID_1)).thenReturn(Optional.of(asset));
+    ArrayNode conditions1 = createConditions(SOME_COLUMN_NULLABLE, Constants.OPERATOR_IS_NULL);
+    ArrayNode conditions2 = createConditions(SOME_COLUMN_BOOLEAN, Constants.OPERATOR_IS_NULL);
+    ArrayNode conditions3 = createConditions(SOME_COLUMN_STRING, Constants.OPERATOR_IS_NOT_NULL);
+    ArrayNode conditions4 = createConditions(SOME_COLUMN_NULLABLE, Constants.OPERATOR_IS_NOT_NULL);
+
+    // Act Assert
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions1), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions2), null), record);
+    assertMatchedRecordExists(scan.invoke(ledger, createQueryArguments(conditions3), null), record);
+    assertMatchedRecordNotExist(scan.invoke(ledger, createQueryArguments(conditions4), null));
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/SelectTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/SelectTest.java
@@ -1,0 +1,258 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class SelectTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String SOME_TABLE_NAME = "Person";
+  private static final String SOME_PRIMARY_KEY_COLUMN = "GovId";
+  private static final String SOME_PRIMARY_KEY_VALUE = "001";
+  private static final String SOME_INDEX_KEY_COLUMN = "lastName";
+  private static final String SOME_INDEX_KEY_COLUMN_VALUE = "Doe";
+  private static final String SOME_COLUMN_STRING = "firstName";
+  private static final String SOME_COLUMN_STRING_VALUE = "John";
+  private static final String SOME_NON_EXISTING_FIELD = "field";
+  private static final String SOME_INVALID_FIELD = "field";
+  private static final String SOME_INVALID_VALUE = "value";
+  private static final String SOME_INVALID_OPERATOR = "op";
+
+  @Spy private Select select = new Select();
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private JsonNode createQueryArguments(ArrayNode conditions) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+        .set(Constants.QUERY_CONDITIONS, conditions);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsGiven_ShouldReturnRecords() {
+    // Arrange
+    ObjectNode argument = mapper.createObjectNode();
+    argument.put(Constants.QUERY_TABLE, SOME_TABLE_NAME);
+    argument.set(
+        Constants.QUERY_CONDITIONS,
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_INDEX_KEY_COLUMN)
+                    .put(Constants.CONDITION_VALUE, SOME_INDEX_KEY_COLUMN_VALUE)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ)));
+    argument.set(
+        Constants.QUERY_PROJECTIONS,
+        mapper
+            .createArrayNode()
+            .add(SOME_INDEX_KEY_COLUMN)
+            .add(SOME_COLUMN_STRING)
+            .add(SOME_NON_EXISTING_FIELD));
+    JsonNode records =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE)
+                    .put(SOME_INDEX_KEY_COLUMN, SOME_INDEX_KEY_COLUMN_VALUE)
+                    .put(SOME_COLUMN_STRING, SOME_COLUMN_STRING_VALUE));
+    JsonNode expected =
+        mapper
+            .createObjectNode()
+            .put(SOME_INDEX_KEY_COLUMN, SOME_INDEX_KEY_COLUMN_VALUE)
+            .put(SOME_COLUMN_STRING, SOME_COLUMN_STRING_VALUE);
+    doReturn(records).when(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, argument);
+
+    // Act
+    JsonNode actual = select.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_InvalidArgumentsGiven_ShouldThrowException() {
+    // Arrange
+    JsonNode argument1 = mapper.createObjectNode().put(Constants.QUERY_TABLE, SOME_TABLE_NAME);
+    JsonNode argument2 =
+        mapper
+            .createObjectNode()
+            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+            .put(Constants.QUERY_CONDITIONS, SOME_TABLE_NAME);
+    JsonNode argument3 =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, 0)
+            .put(Constants.QUERY_CONDITIONS, SOME_TABLE_NAME);
+    JsonNode argument4 =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE);
+    JsonNode argument5 =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+            .put(Constants.QUERY_CONDITIONS, SOME_TABLE_NAME);
+
+    // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    assertThatThrownBy(() -> select.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    assertThatThrownBy(() -> select.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    assertThatThrownBy(() -> select.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    assertThatThrownBy(() -> select.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    verify(ledger, never()).get(anyString());
+  }
+
+  @Test
+  public void invoke_InvalidArgumentsWithInvalidConditions_ShouldThrowException() {
+    // Arrange
+    ArrayNode conditions1 = mapper.createArrayNode().add(0);
+    ArrayNode conditions2 = mapper.createArrayNode().add(mapper.createObjectNode());
+    ArrayNode conditions3 =
+        mapper.createArrayNode().add(mapper.createObjectNode().put(Constants.CONDITION_COLUMN, 0));
+    ArrayNode conditions4 =
+        mapper
+            .createArrayNode()
+            .add(mapper.createObjectNode().put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING));
+    ArrayNode conditions5 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_OPERATOR, 0));
+    ArrayNode conditions6 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_OPERATOR, SOME_INVALID_OPERATOR));
+    ArrayNode conditions7 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_IS_NULL))
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_VALUE, SOME_COLUMN_STRING_VALUE)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_IS_NOT_NULL));
+    ArrayNode conditions8 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_VALUE, SOME_COLUMN_STRING_VALUE)
+                    .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ));
+    ArrayNode conditions9 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ));
+    ArrayNode conditions10 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ)
+                    .set(Constants.CONDITION_VALUE, null));
+    ArrayNode conditions11 =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
+                    .put(Constants.CONDITION_VALUE, true)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_GTE));
+
+    // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions1), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions1.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions2), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions2.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions3), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions3.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions4), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions4.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions5), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions5.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions6), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_OPERATOR + conditions6.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions7), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions7.get(1));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions8), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions8.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions9), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions9.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions10), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions10.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions11), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_OPERATOR + conditions11.get(0));
+    verify(ledger, never()).get(anyString());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds generic contracts for the select functionality. For details about detailed specifications, see also the [design doc](https://docs.google.com/document/d/1lrpOKbVedrIVcee5kkiR2MItmNlEEDO_CLw7FfbS4uo/edit?tab=t.0#heading=h.pr0ibayfnmin). Note that the join functionality will be added by another PR to make the PRs small for the easy reviews.

## Related issues and/or PRs

- #108

## Changes made

- Add the Select contract with the single table scan and projection capability

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes. **Integration tests will be added later.**
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

More strict checks for table and column names (e.g., to make sure that they don’t include unexpected symbol characters) will also be introduced by another PR since it’s independent of the selection functionality itself and must also be done in several places of Create and Insert contracts.

## Release notes

Added generic contracts for select records from a table.