### PR TITLE
Add join functionality in select contract

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -22,11 +22,18 @@ public class Constants {
   public static final String RECORD_TABLE = "table";
   public static final String RECORD_VALUES = "values";
   public static final String QUERY_TABLE = "table";
+  public static final String QUERY_JOINS = "joins";
   public static final String QUERY_CONDITIONS = "conditions";
   public static final String QUERY_PROJECTIONS = "projections";
+  public static final String JOIN_TABLE = "table";
+  public static final String JOIN_LEFT_KEY = "left";
+  public static final String JOIN_RIGHT_KEY = "right";
+  public static final String ALIAS_NAME = "name";
+  public static final String ALIAS_AS = "alias";
   public static final String CONDITION_COLUMN = "column";
   public static final String CONDITION_VALUE = "value";
   public static final String CONDITION_OPERATOR = "operator";
+  public static final String COLUMN_SEPARATOR = ".";
   public static final String OPERATOR_EQ = "EQ";
   public static final String OPERATOR_NE = "NE";
   public static final String OPERATOR_LT = "LT";
@@ -44,19 +51,30 @@ public class Constants {
   public static final String INVALID_RECORD_FORMAT =
       "The specified format of the record is invalid.";
   public static final String INVALID_QUERY_FORMAT = "The specified format of the query is invalid.";
+  public static final String INVALID_QUERY_TABLE_FORMAT =
+      "The specified format of the query table is invalid. Table: ";
+  public static final String INVALID_COLUMN_FORMAT =
+      "The specified format of the column is invalid. Column: ";
   public static final String INVALID_CONDITION_FORMAT =
       "The specified format of the condition is invalid. Condition: ";
   public static final String INVALID_PROJECTION_FORMAT =
       "The specified format of the projection is invalid. Projection: ";
+  public static final String INVALID_JOIN_FORMAT =
+      "The specified format of the join is invalid. Join: ";
   public static final String INVALID_KEY_TYPE = "The specified key type is invalid.";
   public static final String INVALID_INDEX_KEY_TYPE = "The specified index key type is invalid.";
   public static final String INVALID_OPERATOR = "The specified operator is invalid. Condition: ";
   public static final String INVALID_KEY_SPECIFICATION =
       "At least a condition for the primary key or index key must be properly specified.";
+  public static final String INVALID_JOIN_COLUMN =
+      "The join column in the right table must be the primary key or index key. Column: ";
   public static final String TABLE_ALREADY_EXISTS = "The specified table already exists.";
   public static final String TABLE_NOT_EXIST = "The specified table does not exist.";
+  public static final String TABLE_AMBIGUOUS =
+      "The specified table name or alias must be unique. Table: ";
   public static final String RECORD_KEY_NOT_EXIST = "The record values must have the key.";
   public static final String RECORD_ALREADY_EXISTS = "The specified record already exists.";
+  public static final String UNKNOWN_TABLE = "The specified table is unknown. Table: ";
 
   // Internal error messages due to a bug or tampering
   public static final String ILLEGAL_INDEX_STATE = "The state of the index is illegal.";

--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -1,5 +1,7 @@
 package com.scalar.dl.genericcontracts.table.v1_0_0;
 
+import java.util.regex.Pattern;
+
 public class Constants {
 
   // Metadata
@@ -43,6 +45,12 @@ public class Constants {
   public static final String OPERATOR_IS_NULL = "IS_NULL";
   public static final String OPERATOR_IS_NOT_NULL = "IS_NOT_NULL";
   public static final String ASSET_AGE = "age";
+
+  // Patterns
+  public static final String OBJECT_NAME_PATTERN = "[a-zA-Z][A-Za-z0-9_]*";
+  public static final Pattern COLUMN_NAME = Pattern.compile(OBJECT_NAME_PATTERN);
+  public static final Pattern COLUMN_REFERENCE =
+      Pattern.compile(OBJECT_NAME_PATTERN + "\\." + OBJECT_NAME_PATTERN);
 
   // Error messages
   public static final String INVALID_TABLE_FORMAT = "The specified format of the table is invalid.";

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
@@ -5,9 +5,18 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.scalar.dl.ledger.contract.JacksonBasedContract;
 import com.scalar.dl.ledger.exception.ContractContextException;
 import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 public class Select extends JacksonBasedContract {
@@ -18,30 +27,128 @@ public class Select extends JacksonBasedContract {
       Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
 
     // Check the arguments
-    if ((arguments.size() != 2 && arguments.size() != 3)
-        || !arguments.has(Constants.QUERY_TABLE)
-        || !arguments.get(Constants.QUERY_TABLE).isTextual()
-        || !arguments.has(Constants.QUERY_CONDITIONS)
-        || !arguments.get(Constants.QUERY_CONDITIONS).isArray()) {
-      throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
+    validateQuery(arguments);
+
+    // Prepare conditions for each table
+    JsonNode firstTable = arguments.get(Constants.QUERY_TABLE);
+    String firstTableReference = getTableReference(firstTable);
+    ListMultimap<String, JsonNode> conditionsMap =
+        prepareConditionsMap(arguments.get(Constants.QUERY_CONDITIONS), firstTableReference);
+
+    // Prepare joins
+    List<JsonNode> joins = new ArrayList<>();
+    if (arguments.has(Constants.QUERY_JOINS)) {
+      arguments.get(Constants.QUERY_JOINS).forEach(joins::add);
     }
 
-    // Check the format of each condition
-    JsonNode conditions = arguments.get(Constants.QUERY_CONDITIONS);
-    validateConditions(conditions);
-
-    // Check projections
-    JsonNode projections = getObjectMapper().createArrayNode();
+    // Prepare projections
+    List<String> projections = new ArrayList<>();
     if (arguments.has(Constants.QUERY_PROJECTIONS)) {
-      projections = arguments.get(Constants.QUERY_PROJECTIONS);
-      validateProjections(projections);
+      arguments
+          .get(Constants.QUERY_PROJECTIONS)
+          .forEach(
+              projection -> {
+                if (joins.isEmpty()) {
+                  // Remove the table reference if it exists in a non-join query
+                  projections.add(getColumnName(projection.asText()));
+                } else {
+                  // Projection columns in a join query should always have the table reference
+                  projections.add(projection.asText());
+                }
+              });
     }
 
-    // Scan and project records
-    return project(invokeSubContract(Constants.CONTRACT_SCAN, ledger, arguments), projections);
+    // Scan the first table
+    JsonNode records =
+        invokeSubContract(
+            Constants.CONTRACT_SCAN,
+            ledger,
+            prepareScanArguments(getTableName(firstTable), firstTableReference, conditionsMap));
+
+    // Join tables
+    boolean isFirstJoin = true;
+    for (JsonNode join : joins) {
+      ArrayNode joinedRecords = getObjectMapper().createArrayNode();
+
+      for (JsonNode leftRecord : records) {
+        if (isFirstJoin) {
+          leftRecord = addTableReferenceForColumns(leftRecord, firstTableReference);
+        }
+
+        // Get right records whose join key matches that of the left record
+        JsonNode rightTable = join.get(Constants.JOIN_TABLE);
+        JsonNode rightRecords = scanRightTable(ledger, join, leftRecord, rightTable, conditionsMap);
+        String rightTableReference = getTableReference(rightTable);
+        for (JsonNode rightRecord : rightRecords) {
+          rightRecord = addTableReferenceForColumns(rightRecord, rightTableReference);
+          joinedRecords.add(join(leftRecord, rightRecord));
+        }
+      }
+
+      if (isFirstJoin) {
+        isFirstJoin = false;
+      }
+
+      records = joinedRecords;
+    }
+
+    // Project records
+    return project(records, projections);
   }
 
-  private JsonNode project(JsonNode records, JsonNode projections) {
+  private JsonNode scanRightTable(
+      Ledger<JsonNode> ledger,
+      JsonNode join,
+      JsonNode leftRecord,
+      JsonNode rightTable,
+      ListMultimap<String, JsonNode> conditionsMap) {
+    String leftKey = join.get(Constants.JOIN_LEFT_KEY).asText();
+    String rightTableName = getTableName(rightTable);
+    String rightTableReference = getTableReference(rightTable);
+    JsonNode rightTableMetadata = getTableMetadata(ledger, rightTableName);
+    String rightKey = join.get(Constants.JOIN_RIGHT_KEY).asText();
+    String rightKeyColumnName = getColumnName(rightKey);
+    String rightKeyColumnType = getColumnType(rightTableMetadata, rightKeyColumnName);
+
+    if (!leftRecord.has(leftKey)
+        || leftRecord.get(leftKey).isNull()
+        || !leftRecord.get(leftKey).getNodeType().name().equalsIgnoreCase(rightKeyColumnType)) {
+      return getObjectMapper().createArrayNode();
+    }
+
+    // Prepare scan arguments
+    JsonNode joinCondition =
+        getObjectMapper()
+            .createObjectNode()
+            .put(Constants.CONDITION_COLUMN, rightKeyColumnName)
+            .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ)
+            .set(Constants.CONDITION_VALUE, leftRecord.get(leftKey));
+
+    return invokeSubContract(
+        Constants.CONTRACT_SCAN,
+        ledger,
+        prepareScanArguments(rightTableName, rightTableReference, conditionsMap, joinCondition));
+  }
+
+  private JsonNode join(JsonNode leftRecord, JsonNode rightRecord) {
+    ObjectNode joinedRecord = getObjectMapper().createObjectNode();
+    Iterator<Entry<String, JsonNode>> leftColumns = leftRecord.fields();
+    Iterator<Entry<String, JsonNode>> rightColumns = rightRecord.fields();
+
+    while (leftColumns.hasNext()) {
+      Map.Entry<String, JsonNode> column = leftColumns.next();
+      joinedRecord.set(column.getKey(), column.getValue());
+    }
+
+    while (rightColumns.hasNext()) {
+      Map.Entry<String, JsonNode> column = rightColumns.next();
+      joinedRecord.set(column.getKey(), column.getValue());
+    }
+
+    return joinedRecord;
+  }
+
+  private JsonNode project(JsonNode records, List<String> projections) {
     if (projections.isEmpty()) {
       return records;
     } else {
@@ -53,18 +160,249 @@ public class Select extends JacksonBasedContract {
     }
   }
 
-  private JsonNode projectRecord(JsonNode record, JsonNode projections) {
+  private JsonNode projectRecord(JsonNode record, List<String> projections) {
     ObjectNode newRecord = getObjectMapper().createObjectNode();
-    for (JsonNode projection : projections) {
-      String column = projection.asText();
-      if (record.has(column)) {
-        newRecord.set(column, record.get(column));
+    for (String projection : projections) {
+      if (record.has(projection)) {
+        newRecord.set(projection, record.get(projection));
       }
     }
     return newRecord;
   }
 
-  private void validateConditions(JsonNode conditions) {
+  private ListMultimap<String, JsonNode> prepareConditionsMap(
+      JsonNode conditions, String defaultTableReference) {
+    ListMultimap<String, JsonNode> conditionsMap = ArrayListMultimap.create();
+    conditions.forEach(
+        condition -> {
+          String column = condition.get(Constants.CONDITION_COLUMN).asText();
+          if (isColumnNameWithTableReference(column)) {
+            String tableReference = getTableReference(column);
+            String columnName = getColumnName(column);
+            ObjectNode newCondition = getObjectMapper().createObjectNode();
+            newCondition.put(Constants.CONDITION_COLUMN, columnName);
+            newCondition.set(Constants.CONDITION_VALUE, condition.get(Constants.CONDITION_VALUE));
+            newCondition.set(
+                Constants.CONDITION_OPERATOR, condition.get(Constants.CONDITION_OPERATOR));
+            conditionsMap.put(tableReference, newCondition);
+          } else {
+            conditionsMap.put(defaultTableReference, condition);
+          }
+        });
+    return conditionsMap;
+  }
+
+  private JsonNode prepareScanArguments(
+      String tableName, String tableReference, ListMultimap<String, JsonNode> conditionsMap) {
+    return prepareScanArguments(tableName, tableReference, conditionsMap, null);
+  }
+
+  private JsonNode prepareScanArguments(
+      String tableName,
+      String tableReference,
+      ListMultimap<String, JsonNode> conditionsMap,
+      JsonNode joinCondition) {
+    ArrayNode conditionArray = getObjectMapper().createArrayNode();
+    if (joinCondition != null) {
+      conditionArray.add(joinCondition);
+    }
+    conditionsMap.get(tableReference).forEach(conditionArray::add);
+    return getObjectMapper()
+        .createObjectNode()
+        .put(Constants.QUERY_TABLE, tableName)
+        .set(Constants.QUERY_CONDITIONS, conditionArray);
+  }
+
+  private JsonNode getTableMetadata(Ledger<JsonNode> ledger, String tableName) {
+    String tableAssetId = getAssetIdForTable(tableName);
+    return ledger
+        .get(tableAssetId)
+        .orElseThrow(() -> new ContractContextException(Constants.TABLE_NOT_EXIST))
+        .data();
+  }
+
+  private String addTableReference(String tableReference, String columnName) {
+    return tableReference + Constants.COLUMN_SEPARATOR + columnName;
+  }
+
+  private JsonNode addTableReferenceForColumns(JsonNode record, String tableReference) {
+    ObjectNode renamed = getObjectMapper().createObjectNode();
+    Iterator<Entry<String, JsonNode>> columns = record.fields();
+
+    while (columns.hasNext()) {
+      Map.Entry<String, JsonNode> column = columns.next();
+      renamed.set(addTableReference(tableReference, column.getKey()), column.getValue());
+    }
+
+    return renamed;
+  }
+
+  private Set<String> getJoinTableReferences(JsonNode joins) {
+    Set<String> tables = new HashSet<>();
+
+    for (JsonNode join : joins) {
+      JsonNode table = join.get(Constants.JOIN_TABLE);
+      tables.add(getTableReference(table));
+    }
+
+    return tables;
+  }
+
+  private boolean isColumnName(String columnName) {
+    return columnName.matches("[a-zA-Z][A-Za-z0-9_]*");
+  }
+
+  private boolean isColumnNameWithTableReference(String column) {
+    return column.matches("[a-zA-Z][A-Za-z0-9_]*\\.[a-zA-Z][A-Za-z0-9_]*");
+  }
+
+  private String getTableName(JsonNode table) {
+    return table.isTextual() ? table.asText() : table.get(Constants.ALIAS_NAME).asText();
+  }
+
+  private String getTableReference(JsonNode table) {
+    return table.isTextual() ? table.asText() : table.get(Constants.ALIAS_AS).asText();
+  }
+
+  private String getTableReference(String column) {
+    return column.substring(0, column.indexOf(Constants.COLUMN_SEPARATOR));
+  }
+
+  private String getColumnName(String column) {
+    return isColumnNameWithTableReference(column)
+        ? column.substring(column.indexOf(Constants.COLUMN_SEPARATOR) + 1)
+        : column;
+  }
+
+  private String getColumnType(JsonNode tableMetadata, String columnName) {
+    if (tableMetadata.get(Constants.TABLE_KEY).asText().equals(columnName)) {
+      return tableMetadata.get(Constants.TABLE_KEY_TYPE).asText();
+    }
+
+    for (JsonNode index : tableMetadata.get(Constants.TABLE_INDEXES)) {
+      if (index.get(Constants.INDEX_KEY).asText().equals(columnName)) {
+        return index.get(Constants.INDEX_KEY_TYPE).asText();
+      }
+    }
+
+    throw new ContractContextException(Constants.INVALID_JOIN_COLUMN + columnName);
+  }
+
+  private String getAssetIdForTable(String tableName) {
+    return Constants.PREFIX_TABLE + tableName;
+  }
+
+  private void validateQuery(JsonNode arguments) {
+    // Check the required fields
+    if (!(arguments.size() >= 2 && arguments.size() <= 4)
+        || !arguments.has(Constants.QUERY_TABLE)
+        || !arguments.has(Constants.QUERY_CONDITIONS)) {
+      throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
+    }
+
+    // Check the first table
+    validateTable(arguments.get(Constants.QUERY_TABLE));
+    Set<String> tablesReferences = new HashSet<>();
+    String firstTableReference = getTableReference(arguments.get(Constants.QUERY_TABLE));
+    tablesReferences.add(firstTableReference);
+
+    // Check joins
+    if (arguments.has(Constants.QUERY_JOINS)) {
+      validateJoins(firstTableReference, arguments.get(Constants.QUERY_JOINS));
+      tablesReferences.addAll(getJoinTableReferences(arguments.get(Constants.QUERY_JOINS)));
+    }
+
+    // Check conditions
+    validateConditions(arguments.get(Constants.QUERY_CONDITIONS), tablesReferences);
+
+    // Check projections
+    if (arguments.has(Constants.QUERY_PROJECTIONS)) {
+      validateProjections(arguments.get(Constants.QUERY_PROJECTIONS), tablesReferences);
+    }
+  }
+
+  private void validateColumn(String column, Set<String> tableReferences) {
+    boolean hasTableReference = isColumnNameWithTableReference(column);
+
+    if (!hasTableReference) {
+      // Join queries must have a table reference
+      if ((tableReferences.size() == 1 && !isColumnName(column)) || tableReferences.size() > 1) {
+        throw new ContractContextException(Constants.INVALID_COLUMN_FORMAT + column);
+      }
+      return;
+    }
+
+    // Check if the table of the column is appeared in the query
+    String tableReference = getTableReference(column);
+    if (!tableReferences.contains(tableReference)) {
+      throw new ContractContextException(Constants.UNKNOWN_TABLE + tableReference);
+    }
+  }
+
+  private void validateTable(JsonNode table) {
+    if ((!table.isTextual() && !table.isObject())
+        || (table.isObject()
+            && (table.size() != 2
+                || !table.has(Constants.ALIAS_NAME)
+                || !table.get(Constants.ALIAS_NAME).isTextual()
+                || !table.has(Constants.ALIAS_AS)
+                || !table.get(Constants.ALIAS_AS).isTextual()))) {
+      throw new ContractContextException(Constants.INVALID_QUERY_TABLE_FORMAT + table);
+    }
+  }
+
+  private void validateJoins(String firstTableReference, JsonNode joins) {
+    Set<String> seenTables = new HashSet<>();
+    seenTables.add(firstTableReference);
+
+    if (!joins.isArray()) {
+      throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
+    }
+
+    for (JsonNode join : joins) {
+      // Check the join object format
+      if (!join.isObject()
+          || join.size() != 3
+          || !join.has(Constants.JOIN_TABLE)
+          || !join.has(Constants.JOIN_LEFT_KEY)
+          || !join.has(Constants.JOIN_RIGHT_KEY)) {
+        throw new ContractContextException(Constants.INVALID_JOIN_FORMAT + join);
+      }
+
+      // Check the join table format
+      JsonNode table = join.get(Constants.JOIN_TABLE);
+      validateTable(table);
+      String tableReference = getTableReference(table);
+      if (seenTables.contains(tableReference)) {
+        throw new ContractContextException(Constants.TABLE_AMBIGUOUS + tableReference);
+      }
+
+      // Check the join key format
+      JsonNode leftKey = join.get(Constants.JOIN_LEFT_KEY);
+      JsonNode rightKey = join.get(Constants.JOIN_RIGHT_KEY);
+      if (!leftKey.isTextual()
+          || !rightKey.isTextual()
+          || !isColumnNameWithTableReference(leftKey.asText())
+          || !isColumnNameWithTableReference(rightKey.asText())) {
+        throw new ContractContextException(Constants.INVALID_JOIN_FORMAT + join);
+      }
+
+      // Check the table existence for the join key
+      String leftTable = getTableReference(leftKey.asText());
+      String rightTable = getTableReference(rightKey.asText());
+      if (!seenTables.contains(leftTable) || !tableReference.equals(rightTable)) {
+        throw new ContractContextException(Constants.INVALID_JOIN_FORMAT + join);
+      }
+
+      seenTables.add(tableReference);
+    }
+  }
+
+  private void validateConditions(JsonNode conditions, Set<String> tableReferences) {
+    if (!conditions.isArray()) {
+      throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
+    }
+
     for (JsonNode condition : conditions) {
       if (!condition.isObject()
           || !condition.has(Constants.CONDITION_COLUMN)
@@ -74,6 +412,10 @@ public class Select extends JacksonBasedContract {
         throw new ContractContextException(Constants.INVALID_CONDITION_FORMAT + condition);
       }
 
+      // Check the column
+      validateColumn(condition.get(Constants.CONDITION_COLUMN).asText(), tableReferences);
+
+      // Check the operator
       String operator = condition.get(Constants.CONDITION_OPERATOR).asText();
       if (!isSupportedOperator(operator)) {
         throw new ContractContextException(Constants.INVALID_OPERATOR + condition);
@@ -119,7 +461,7 @@ public class Select extends JacksonBasedContract {
         || operator.equalsIgnoreCase(Constants.OPERATOR_IS_NOT_NULL);
   }
 
-  private void validateProjections(JsonNode projections) {
+  private void validateProjections(JsonNode projections, Set<String> tableReferences) {
     if (!projections.isArray()) {
       throw new ContractContextException(Constants.INVALID_QUERY_FORMAT);
     }
@@ -128,6 +470,8 @@ public class Select extends JacksonBasedContract {
       if (!projection.isTextual()) {
         throw new ContractContextException(Constants.INVALID_PROJECTION_FORMAT + projection);
       }
+
+      validateColumn(projection.asText(), tableReferences);
     }
   }
 

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Select.java
@@ -30,8 +30,8 @@ public class Select extends JacksonBasedContract {
     validateQuery(arguments);
 
     // Prepare conditions for each table
-    JsonNode firstTable = arguments.get(Constants.QUERY_TABLE);
-    String firstTableReference = getTableReference(firstTable);
+    JsonNode leftmostTable = arguments.get(Constants.QUERY_TABLE);
+    String leftmostTableReference = getTableReference(firstTable);
     ListMultimap<String, JsonNode> conditionsMap =
         prepareConditionsMap(arguments.get(Constants.QUERY_CONDITIONS), firstTableReference);
 

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/SelectTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/SelectTest.java
@@ -2,17 +2,27 @@ package com.scalar.dl.genericcontracts.table.v1_0_0;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
 import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Arrays;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -22,10 +32,17 @@ import org.mockito.Spy;
 public class SelectTest {
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final String SOME_TABLE_NAME = "Person";
+  private static final String SOME_TABLE_NAME_1 = "table1";
+  private static final String SOME_TABLE_NAME_2 = "table2";
+  private static final String SOME_TABLE_NAME_3 = "table3";
+  private static final String SOME_TABLE_PREFIX_1 = "table1.";
+  private static final String SOME_TABLE_PREFIX_2 = "table2.";
+  private static final String SOME_TABLE_PREFIX_3 = "table3.";
   private static final String SOME_PRIMARY_KEY_COLUMN = "GovId";
   private static final String SOME_PRIMARY_KEY_VALUE = "001";
   private static final String SOME_INDEX_KEY_COLUMN = "lastName";
   private static final String SOME_INDEX_KEY_COLUMN_VALUE = "Doe";
+  private static final String SOME_KEY_TYPE_STRING = "string";
   private static final String SOME_COLUMN_STRING = "firstName";
   private static final String SOME_COLUMN_STRING_VALUE = "John";
   private static final String SOME_NON_EXISTING_FIELD = "field";
@@ -41,6 +58,69 @@ public class SelectTest {
     MockitoAnnotations.openMocks(this).close();
   }
 
+  private ObjectNode createQueryArguments(JsonNode conditions) {
+    return createQueryArguments(SOME_TABLE_NAME, conditions);
+  }
+
+  private ObjectNode createQueryArguments(String tableName, JsonNode conditions) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.QUERY_TABLE, tableName)
+        .set(Constants.QUERY_CONDITIONS, conditions);
+  }
+
+  private ArrayNode createArrayNode(JsonNode... jsonNodes) {
+    ArrayNode result = mapper.createArrayNode();
+    Arrays.stream(jsonNodes).forEach(result::add);
+    return result;
+  }
+
+  private static JsonNode createCondition(String column, String value, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_VALUE, value)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private ArrayNode createConditions(String column, String value) {
+    return mapper.createArrayNode().add(createCondition(column, value, Constants.OPERATOR_EQ));
+  }
+
+  private static ObjectNode createIndexNode(String key, String type) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.INDEX_KEY, key)
+        .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  private static ObjectNode createTable(String tableName) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.TABLE_NAME, tableName)
+        .put(Constants.TABLE_KEY, SOME_PRIMARY_KEY_COLUMN)
+        .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+        .set(
+            Constants.TABLE_INDEXES,
+            mapper
+                .createArrayNode()
+                .add(createIndexNode(SOME_INDEX_KEY_COLUMN, SOME_KEY_TYPE_STRING)));
+  }
+
+  private static ObjectNode createRecord(String primaryKey, String indexKey, String stringValue) {
+    return mapper
+        .createObjectNode()
+        .put(SOME_PRIMARY_KEY_COLUMN, primaryKey)
+        .put(SOME_INDEX_KEY_COLUMN, indexKey)
+        .put(SOME_COLUMN_STRING, stringValue);
+  }
+
+  private Asset<JsonNode> createAsset(JsonNode data) {
+    Asset<JsonNode> asset = (Asset<JsonNode>) mock(Asset.class);
+    when(asset.data()).thenReturn(data);
+    return asset;
+  }
+
   private JsonNode createQueryArguments(ArrayNode conditions) {
     return mapper
         .createObjectNode()
@@ -49,7 +129,7 @@ public class SelectTest {
   }
 
   @Test
-  public void invoke_CorrectArgumentsGiven_ShouldReturnRecords() {
+  public void invoke_CorrectArgumentsWithoutJoinsGiven_ShouldReturnRecords() {
     // Arrange
     ObjectNode argument = mapper.createObjectNode();
     argument.put(Constants.QUERY_TABLE, SOME_TABLE_NAME);
@@ -68,8 +148,10 @@ public class SelectTest {
         mapper
             .createArrayNode()
             .add(SOME_INDEX_KEY_COLUMN)
-            .add(SOME_COLUMN_STRING)
+            .add(SOME_TABLE_NAME + Constants.COLUMN_SEPARATOR + SOME_COLUMN_STRING)
             .add(SOME_NON_EXISTING_FIELD));
+    ObjectNode scan = argument.deepCopy();
+    scan.remove(Constants.QUERY_PROJECTIONS);
     JsonNode records =
         mapper
             .createArrayNode()
@@ -84,7 +166,7 @@ public class SelectTest {
             .createObjectNode()
             .put(SOME_INDEX_KEY_COLUMN, SOME_INDEX_KEY_COLUMN_VALUE)
             .put(SOME_COLUMN_STRING, SOME_COLUMN_STRING_VALUE);
-    doReturn(records).when(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, argument);
+    doReturn(records).when(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, scan);
 
     // Act
     JsonNode actual = select.invoke(ledger, argument, null);
@@ -94,6 +176,44 @@ public class SelectTest {
     assertThat(actual.isArray()).isTrue();
     assertThat(actual.size()).isEqualTo(1);
     assertThat(actual.get(0)).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithoutJoinsAndProjectionsGiven_ShouldReturnRecords() {
+    // Arrange
+    ObjectNode argument = mapper.createObjectNode();
+    argument.put(Constants.QUERY_TABLE, SOME_TABLE_NAME);
+    argument.set(
+        Constants.QUERY_CONDITIONS,
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.CONDITION_COLUMN, SOME_INDEX_KEY_COLUMN)
+                    .put(Constants.CONDITION_VALUE, SOME_INDEX_KEY_COLUMN_VALUE)
+                    .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ)));
+    ObjectNode scan = argument.deepCopy();
+    scan.remove(Constants.QUERY_PROJECTIONS);
+    JsonNode records =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(SOME_PRIMARY_KEY_COLUMN, SOME_PRIMARY_KEY_VALUE)
+                    .put(SOME_INDEX_KEY_COLUMN, SOME_INDEX_KEY_COLUMN_VALUE)
+                    .put(SOME_COLUMN_STRING, SOME_COLUMN_STRING_VALUE));
+    doReturn(records).when(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, scan);
+
+    // Act
+    JsonNode actual = select.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isArray()).isTrue();
+    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.get(0)).isEqualTo(records.get(0));
   }
 
   @Test
@@ -108,33 +228,8 @@ public class SelectTest {
     JsonNode argument3 =
         mapper
             .createObjectNode()
-            .put(Constants.QUERY_TABLE, 0)
-            .put(Constants.QUERY_CONDITIONS, SOME_TABLE_NAME);
-    JsonNode argument4 =
-        mapper
-            .createObjectNode()
             .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
             .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE);
-    JsonNode argument5 =
-        mapper
-            .createObjectNode()
-            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
-            .put(Constants.QUERY_CONDITIONS, SOME_INVALID_VALUE);
-    JsonNode argument6 =
-        mapper
-            .createObjectNode()
-            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
-            .put(Constants.QUERY_PROJECTIONS, SOME_INVALID_VALUE)
-            .set(
-                Constants.QUERY_CONDITIONS,
-                mapper
-                    .createArrayNode()
-                    .add(
-                        mapper
-                            .createObjectNode()
-                            .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
-                            .put(Constants.CONDITION_VALUE, "aaa")
-                            .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ)));
 
     // Act Assert
     assertThatThrownBy(() -> select.invoke(ledger, argument1, null))
@@ -146,20 +241,180 @@ public class SelectTest {
     assertThatThrownBy(() -> select.invoke(ledger, argument3, null))
         .isExactlyInstanceOf(ContractContextException.class)
         .hasMessage(Constants.INVALID_QUERY_FORMAT);
-    assertThatThrownBy(() -> select.invoke(ledger, argument4, null))
-        .isExactlyInstanceOf(ContractContextException.class)
-        .hasMessage(Constants.INVALID_QUERY_FORMAT);
-    assertThatThrownBy(() -> select.invoke(ledger, argument5, null))
-        .isExactlyInstanceOf(ContractContextException.class)
-        .hasMessage(Constants.INVALID_QUERY_FORMAT);
-    assertThatThrownBy(() -> select.invoke(ledger, argument6, null))
-        .isExactlyInstanceOf(ContractContextException.class)
-        .hasMessage(Constants.INVALID_QUERY_FORMAT);
     verify(ledger, never()).get(anyString());
   }
 
   @Test
-  public void invoke_InvalidArgumentsWithInvalidConditions_ShouldThrowException() {
+  public void invoke_InvalidTableArgumentsGiven_ShouldThrowException() {
+    // Arrange
+    ObjectNode baseArgument =
+        mapper
+            .createObjectNode()
+            .set(Constants.QUERY_CONDITIONS, createConditions(SOME_INDEX_KEY_COLUMN, "val"));
+    JsonNode empty = mapper.createObjectNode();
+    JsonNode noName =
+        mapper.createObjectNode().put(Constants.ALIAS_AS, "").put(SOME_INVALID_FIELD, "");
+    JsonNode nonTextName =
+        mapper.createObjectNode().put(Constants.ALIAS_AS, "").put(Constants.ALIAS_NAME, 0);
+    JsonNode noAlias =
+        mapper.createObjectNode().put(Constants.ALIAS_NAME, "").put(SOME_INVALID_FIELD, "");
+    JsonNode nonTextAlias =
+        mapper.createObjectNode().put(Constants.ALIAS_NAME, "").put(Constants.ALIAS_AS, 0);
+    JsonNode argument1 = baseArgument.deepCopy().set(Constants.QUERY_TABLE, empty);
+    JsonNode argument2 = baseArgument.deepCopy().set(Constants.QUERY_TABLE, noName);
+    JsonNode argument3 = baseArgument.deepCopy().set(Constants.QUERY_TABLE, nonTextName);
+    JsonNode argument4 = baseArgument.deepCopy().set(Constants.QUERY_TABLE, noAlias);
+    JsonNode argument5 = baseArgument.deepCopy().set(Constants.QUERY_TABLE, nonTextAlias);
+
+    // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_TABLE_FORMAT + empty);
+    assertThatThrownBy(() -> select.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_TABLE_FORMAT + noName);
+    assertThatThrownBy(() -> select.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_TABLE_FORMAT + nonTextName);
+    assertThatThrownBy(() -> select.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_TABLE_FORMAT + noAlias);
+    assertThatThrownBy(() -> select.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_TABLE_FORMAT + nonTextAlias);
+    verify(ledger, never()).get(anyString());
+  }
+
+  @Test
+  public void invoke_InvalidJoinsGiven_ShouldThrowException() {
+    // Arrange
+    ObjectNode baseArgument =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, SOME_TABLE_NAME)
+            .set(Constants.QUERY_CONDITIONS, createConditions(SOME_INDEX_KEY_COLUMN, "val"));
+    JsonNode noRequiredFields =
+        createArrayNode(mapper.createObjectNode().put(SOME_INVALID_FIELD, ""));
+    JsonNode noTable =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(SOME_INVALID_FIELD, "")
+                .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_NAME + ".column")
+                .put(Constants.JOIN_RIGHT_KEY, "table.column"));
+    JsonNode noLeftKey =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(SOME_INVALID_FIELD, "")
+                .put(Constants.JOIN_RIGHT_KEY, "table.column"));
+    JsonNode noRightKey =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(SOME_INVALID_FIELD, "")
+                .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_NAME + ".column"));
+    JsonNode invalidLeftKeyType =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, 0)
+                .put(Constants.JOIN_RIGHT_KEY, "table.column"));
+    JsonNode invalidRightKeyType =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_NAME + ".column")
+                .put(Constants.JOIN_RIGHT_KEY, 0));
+    JsonNode invalidJoinKeyFormat =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, "")
+                .put(Constants.JOIN_RIGHT_KEY, ""));
+    JsonNode unknownTableForLeftKey =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, "unknown.column")
+                .put(Constants.JOIN_RIGHT_KEY, "table.column"));
+    JsonNode unknownTableForRightKey =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_NAME + ".column")
+                .put(Constants.JOIN_RIGHT_KEY, "unknown.column"));
+    JsonNode ambiguousTable =
+        createArrayNode(
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_NAME + ".column")
+                .put(Constants.JOIN_RIGHT_KEY, "table.column"),
+            mapper
+                .createObjectNode()
+                .put(Constants.JOIN_TABLE, "table")
+                .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_NAME + ".column")
+                .put(Constants.JOIN_RIGHT_KEY, "table.column"));
+    JsonNode argument1 = baseArgument.deepCopy().put(Constants.QUERY_JOINS, "non-array");
+    JsonNode argument2 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, noRequiredFields);
+    JsonNode argument3 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, noTable);
+    JsonNode argument4 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, noLeftKey);
+    JsonNode argument5 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, noRightKey);
+    JsonNode argument6 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, invalidLeftKeyType);
+    JsonNode argument7 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, invalidRightKeyType);
+    JsonNode argument8 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, invalidJoinKeyFormat);
+    JsonNode argument9 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, unknownTableForLeftKey);
+    JsonNode argument10 =
+        baseArgument.deepCopy().set(Constants.QUERY_JOINS, unknownTableForRightKey);
+    JsonNode argument11 = baseArgument.deepCopy().set(Constants.QUERY_JOINS, ambiguousTable);
+
+    // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    assertThatThrownBy(() -> select.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + noRequiredFields.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + noTable.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + noLeftKey.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + noRightKey.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument6, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + invalidLeftKeyType.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument7, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + invalidRightKeyType.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument8, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + invalidJoinKeyFormat.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument9, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + unknownTableForLeftKey.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument10, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_JOIN_FORMAT + unknownTableForRightKey.get(0));
+    assertThatThrownBy(() -> select.invoke(ledger, argument11, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.TABLE_AMBIGUOUS + "table");
+    verify(ledger, never()).get(anyString());
+  }
+
+  @Test
+  public void invoke_InvalidConditionsGiven_ShouldThrowException() {
     // Arrange
     ArrayNode conditions1 = mapper.createArrayNode().add(0);
     ArrayNode conditions2 = mapper.createArrayNode().add(mapper.createObjectNode());
@@ -256,6 +511,9 @@ public class SelectTest {
                     .set(Constants.CONDITION_VALUE, mapper.createArrayNode()));
 
     // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(IntNode.valueOf(0)), null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
     assertThatThrownBy(() -> select.invoke(ledger, createQueryArguments(conditions1), null))
         .isExactlyInstanceOf(ContractContextException.class)
         .hasMessage(Constants.INVALID_CONDITION_FORMAT + conditions1.get(0));
@@ -299,8 +557,124 @@ public class SelectTest {
   }
 
   @Test
+  public void invoke_InvalidConditionColumnsGiven_ShouldThrowException() {
+    // Arrange
+    ObjectNode baseScanArgument = mapper.createObjectNode().put(Constants.QUERY_TABLE, "table1");
+    ObjectNode baseJoinArgument =
+        baseScanArgument
+            .deepCopy()
+            .set(
+                Constants.QUERY_JOINS,
+                createArrayNode(
+                    mapper
+                        .createObjectNode()
+                        .put(Constants.JOIN_TABLE, "table2")
+                        .put(Constants.JOIN_LEFT_KEY, "table1.column")
+                        .put(Constants.JOIN_RIGHT_KEY, "table2.column")));
+    JsonNode noTableReference1 = createConditions("invalid-column-name", "val");
+    JsonNode noTableReference2 = createConditions("column", "val");
+    JsonNode withTableReference = createConditions("unknown_table.column", "val");
+    JsonNode argument1 =
+        baseScanArgument.deepCopy().set(Constants.QUERY_CONDITIONS, noTableReference1);
+    JsonNode argument2 =
+        baseJoinArgument.deepCopy().set(Constants.QUERY_CONDITIONS, noTableReference2);
+    JsonNode argument3 =
+        baseJoinArgument.deepCopy().set(Constants.QUERY_CONDITIONS, withTableReference);
+
+    // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_COLUMN_FORMAT + "invalid-column-name");
+    assertThatThrownBy(() -> select.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_COLUMN_FORMAT + "column");
+    assertThatThrownBy(() -> select.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.UNKNOWN_TABLE + "unknown_table");
+    verify(ledger, never()).get(anyString());
+  }
+
+  @Test
   public void invoke_InvalidProjectionsGiven_ShouldThrowException() {
-    ObjectNode argument = mapper.createObjectNode().put(Constants.QUERY_TABLE, SOME_TABLE_NAME);
+    // Arrange
+    ObjectNode baseScanArgument =
+        mapper
+            .createObjectNode()
+            .put(Constants.QUERY_TABLE, "table1")
+            .set(Constants.QUERY_CONDITIONS, createConditions("table1.column", "val"));
+    ObjectNode baseJoinArgument =
+        baseScanArgument
+            .deepCopy()
+            .set(
+                Constants.QUERY_JOINS,
+                createArrayNode(
+                    mapper
+                        .createObjectNode()
+                        .put(Constants.JOIN_TABLE, "table2")
+                        .put(Constants.JOIN_LEFT_KEY, "table1.column")
+                        .put(Constants.JOIN_RIGHT_KEY, "table2.column")));
+    JsonNode argument1 = baseScanArgument.deepCopy().put(Constants.QUERY_PROJECTIONS, 0);
+    JsonNode argument2 =
+        baseScanArgument
+            .deepCopy()
+            .set(Constants.QUERY_PROJECTIONS, createArrayNode(IntNode.valueOf(0)));
+    JsonNode argument3 =
+        baseScanArgument
+            .deepCopy()
+            .set(
+                Constants.QUERY_PROJECTIONS,
+                createArrayNode(TextNode.valueOf("invalid-column-name")));
+    JsonNode argument4 =
+        baseJoinArgument
+            .deepCopy()
+            .set(Constants.QUERY_PROJECTIONS, createArrayNode(TextNode.valueOf("column")));
+    JsonNode argument5 =
+        baseJoinArgument
+            .deepCopy()
+            .set(
+                Constants.QUERY_PROJECTIONS,
+                createArrayNode(TextNode.valueOf("unknown_table.column")));
+
+    // Act Assert
+    assertThatThrownBy(() -> select.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_QUERY_FORMAT);
+    assertThatThrownBy(() -> select.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_PROJECTION_FORMAT + "0");
+    assertThatThrownBy(() -> select.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_COLUMN_FORMAT + "invalid-column-name");
+    assertThatThrownBy(() -> select.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_COLUMN_FORMAT + "column");
+    assertThatThrownBy(() -> select.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.UNKNOWN_TABLE + "unknown_table");
+    verify(ledger, never()).get(anyString());
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithJoinsGiven_ShouldReturnRecords() {
+    // Arrange
+    ObjectNode argument = mapper.createObjectNode();
+    argument.put(Constants.QUERY_TABLE, SOME_TABLE_NAME_1);
+    argument.set(
+        Constants.QUERY_JOINS,
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.JOIN_TABLE, SOME_TABLE_NAME_2)
+                    .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_PREFIX_1 + SOME_COLUMN_STRING)
+                    .put(Constants.JOIN_RIGHT_KEY, SOME_TABLE_PREFIX_2 + SOME_PRIMARY_KEY_COLUMN))
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.JOIN_TABLE, SOME_TABLE_NAME_3)
+                    .put(Constants.JOIN_LEFT_KEY, SOME_TABLE_PREFIX_2 + SOME_COLUMN_STRING)
+                    .put(Constants.JOIN_RIGHT_KEY, SOME_TABLE_PREFIX_3 + SOME_INDEX_KEY_COLUMN)));
     argument.set(
         Constants.QUERY_CONDITIONS,
         mapper
@@ -308,14 +682,71 @@ public class SelectTest {
             .add(
                 mapper
                     .createObjectNode()
-                    .put(Constants.CONDITION_COLUMN, SOME_COLUMN_STRING)
-                    .put(Constants.CONDITION_VALUE, "aaa")
+                    .put(Constants.CONDITION_COLUMN, SOME_TABLE_PREFIX_1 + SOME_INDEX_KEY_COLUMN)
+                    .put(Constants.CONDITION_VALUE, "0")
                     .put(Constants.CONDITION_OPERATOR, Constants.OPERATOR_EQ)));
-    argument.set(Constants.QUERY_PROJECTIONS, mapper.createArrayNode().add(0));
+    argument.set(
+        Constants.QUERY_PROJECTIONS,
+        mapper
+            .createArrayNode()
+            .add(SOME_TABLE_PREFIX_1 + SOME_PRIMARY_KEY_COLUMN)
+            .add(SOME_TABLE_PREFIX_3 + SOME_COLUMN_STRING));
+    Asset<JsonNode> table1 = createAsset(createTable(SOME_TABLE_NAME_1));
+    Asset<JsonNode> table2 = createAsset(createTable(SOME_TABLE_NAME_2));
+    Asset<JsonNode> table3 = createAsset(createTable(SOME_TABLE_NAME_3));
+    JsonNode records1 =
+        mapper.createArrayNode().add(createRecord("1", "0", "3")).add(createRecord("2", "0", "4"));
+    JsonNode records2 = mapper.createArrayNode().add(createRecord("3", "1", "1"));
+    JsonNode records3 = mapper.createArrayNode().add(createRecord("4", "1", "2"));
+    JsonNode records4 = mapper.createArrayNode();
+    JsonNode records5 =
+        mapper.createArrayNode().add(createRecord("5", "2", "3")).add(createRecord("6", "2", "3"));
+    JsonNode expected =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(SOME_TABLE_PREFIX_1 + SOME_PRIMARY_KEY_COLUMN, "2")
+                    .put(SOME_TABLE_PREFIX_3 + SOME_COLUMN_STRING, "3"))
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(SOME_TABLE_PREFIX_1 + SOME_PRIMARY_KEY_COLUMN, "2")
+                    .put(SOME_TABLE_PREFIX_3 + SOME_COLUMN_STRING, "3"));
+    JsonNode expectedScan1 =
+        createQueryArguments(SOME_TABLE_NAME_1, createConditions(SOME_INDEX_KEY_COLUMN, "0"));
+    JsonNode expectedScan2 =
+        createQueryArguments(SOME_TABLE_NAME_2, createConditions(SOME_PRIMARY_KEY_COLUMN, "3"));
+    JsonNode expectedScan3 =
+        createQueryArguments(SOME_TABLE_NAME_2, createConditions(SOME_PRIMARY_KEY_COLUMN, "4"));
+    JsonNode expectedScan4 =
+        createQueryArguments(SOME_TABLE_NAME_3, createConditions(SOME_INDEX_KEY_COLUMN, "1"));
+    JsonNode expectedScan5 =
+        createQueryArguments(SOME_TABLE_NAME_3, createConditions(SOME_INDEX_KEY_COLUMN, "2"));
+    when(ledger.get(Constants.PREFIX_TABLE + SOME_TABLE_NAME_1)).thenReturn(Optional.of(table1));
+    when(ledger.get(Constants.PREFIX_TABLE + SOME_TABLE_NAME_2)).thenReturn(Optional.of(table2));
+    when(ledger.get(Constants.PREFIX_TABLE + SOME_TABLE_NAME_3)).thenReturn(Optional.of(table3));
+    doReturn(records1)
+        .doReturn(records2)
+        .doReturn(records3)
+        .doReturn(records4)
+        .doReturn(records5)
+        .when(select)
+        .invokeSubContract(eq(Constants.CONTRACT_SCAN), eq(ledger), any(JsonNode.class));
 
-    // Act Assert
-    assertThatThrownBy(() -> select.invoke(ledger, argument, null))
-        .isExactlyInstanceOf(ContractContextException.class)
-        .hasMessage(Constants.INVALID_PROJECTION_FORMAT + "0");
+    // Act
+    JsonNode actual = select.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual).isEqualTo(expected);
+    verify(select, times(5))
+        .invokeSubContract(eq(Constants.CONTRACT_SCAN), eq(ledger), any(JsonNode.class));
+    verify(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, expectedScan1);
+    verify(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, expectedScan2);
+    verify(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, expectedScan3);
+    verify(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, expectedScan4);
+    verify(select).invokeSubContract(Constants.CONTRACT_SCAN, ledger, expectedScan5);
   }
 }


### PR DESCRIPTION
## Description

This PR adds the join functionality in the select generic contract added in #119. For details about the specification, see the [design doc](https://docs.google.com/document/d/1lrpOKbVedrIVcee5kkiR2MItmNlEEDO_CLw7FfbS4uo/edit?tab=t.0#heading=h.pr0ibayfnmin); note that I've added the terms (e.g., "column reference") and definitions [here](https://docs.google.com/document/d/1lrpOKbVedrIVcee5kkiR2MItmNlEEDO_CLw7FfbS4uo/edit?pli=1&tab=t.0#heading=h.k01mkkrzb84s).

## Related issues and/or PRs

- #119

## Changes made

- Add the join functionality.
- Support table alias (like SQL's `as`) and column reference (i.e., a format like `tableA.columX`) in conditions and projections.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- E2E tests with creating tables and inserting records will be added in the next PR.

## Release notes

Added join functionality in select contract.