### PR TITLE
Revise scan and index data structure

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -19,6 +19,8 @@ public class Constants {
   public static final String TABLE_INDEXES = "indexes";
   public static final String INDEX_KEY = "key";
   public static final String INDEX_KEY_TYPE = "type";
+  public static final String INDEX_ASSET_ADDED_AGE = "age";
+  public static final String INDEX_ASSET_DELETE_MARKER = "deleted";
   public static final String RECORD_TABLE = "table";
   public static final String RECORD_VALUES = "values";
   public static final String QUERY_TABLE = "table";
@@ -35,7 +37,9 @@ public class Constants {
   public static final String OPERATOR_GTE = "GTE";
   public static final String OPERATOR_IS_NULL = "IS_NULL";
   public static final String OPERATOR_IS_NOT_NULL = "IS_NOT_NULL";
-  public static final String ASSET_AGE = "age";
+  public static final String SCAN_OPTIONS = "options";
+  public static final String SCAN_OPTIONS_INCLUDE_METADATA = "include_metadata";
+  public static final String SCAN_METADATA_AGE = "age$";
 
   // Error messages
   public static final String INVALID_TABLE_FORMAT = "The specified format of the table is invalid.";

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Insert.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Insert.java
@@ -79,11 +79,11 @@ public class Insert extends JacksonBasedContract {
         assetId = getAssetIdForNullIndex(tableName, indexKey);
       }
 
-      ObjectNode node = getObjectMapper().createObjectNode();
-      node.set(key, values.get(key));
-      node.put(Constants.ASSET_AGE, 0);
+      ObjectNode indexEntry = getObjectMapper().createObjectNode();
+      indexEntry.set(key, values.get(key));
+      indexEntry.put(Constants.INDEX_ASSET_ADDED_AGE, 0);
 
-      ledger.put(assetId, node);
+      ledger.put(assetId, getObjectMapper().createArrayNode().add(indexEntry));
     }
   }
 

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/InsertTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/InsertTest.java
@@ -12,7 +12,10 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.scalar.dl.ledger.exception.ContractContextException;
 import com.scalar.dl.ledger.statemachine.Asset;
 import com.scalar.dl.ledger.statemachine.Ledger;
@@ -71,13 +74,10 @@ public class InsertTest {
           + SOME_INDEX_KEY_3
           + Constants.ASSET_ID_SEPARATOR
           + "false";
-  private static final ObjectNode SOME_INDEX_ASSET =
-      mapper.createObjectNode().put(SOME_TABLE_KEY, SOME_RECORD_KEY).put(Constants.ASSET_AGE, 0);
-  private static final ObjectNode SOME_INDEX_ASSET_WITH_NUMBER_KEY =
-      mapper
-          .createObjectNode()
-          .put(SOME_TABLE_KEY, SOME_RECORD_NUMBER_KEY)
-          .put(Constants.ASSET_AGE, 0);
+  private static final ArrayNode SOME_INDEX_ASSET =
+      createIndexAsset(SOME_TABLE_KEY, TextNode.valueOf(SOME_RECORD_KEY));
+  private static final ArrayNode SOME_INDEX_ASSET_WITH_NUMBER_KEY =
+      createIndexAsset(SOME_TABLE_KEY, DoubleNode.valueOf(SOME_RECORD_NUMBER_KEY));
   private static final ObjectNode SOME_TABLE =
       mapper
           .createObjectNode()
@@ -123,6 +123,16 @@ public class InsertTest {
         .createObjectNode()
         .put(Constants.INDEX_KEY, key)
         .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  private static ArrayNode createIndexAsset(String primaryKey, JsonNode value) {
+    return mapper
+        .createArrayNode()
+        .add(
+            mapper
+                .createObjectNode()
+                .put(Constants.INDEX_ASSET_ADDED_AGE, 0)
+                .set(primaryKey, value));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds an option in the Scan contract to return records with metadata like the asset age and changes the index data structure to handle multiple index entries in a single asset record (i.e., in a single age).

The added metadata will be used in the Update contract so that it can add the record age into the updated index record to track when the index value changes.

The new index structure enables the Update contract to update index values of multiple records in a single transaction. Before this change, we put an index asset record age for each actual record, and it makes it difficult to put multiple record ages since we can only put the same asset just one time in a single transaction.

## Related issues and/or PRs

- #119

## Changes made

- Add an option to return records with metadata in the Scan contract
- Change the index asset structure
- Implement skipping logic for removed index

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Revised scan and index data structure.