### PR TITLE
Use new vuln-check composite actions

### DIFF
--- a/.github/workflows/manual-vuln-check.yaml
+++ b/.github/workflows/manual-vuln-check.yaml
@@ -8,5 +8,3 @@ jobs:
     uses: ./.github/workflows/vuln-check.yaml
     with:
       target-ref: ${{ github.ref_name }}
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}

--- a/.github/workflows/scheduled-vuln-check.yaml
+++ b/.github/workflows/scheduled-vuln-check.yaml
@@ -10,24 +10,18 @@ jobs:
     uses: ./.github/workflows/vuln-check.yaml
     with:
       target-ref: master
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+    secrets: inherit
 
   call-vuln-check-for-v3_9:
     uses: ./.github/workflows/vuln-check.yaml
     with:
       target-ref: v3.9
       find-latest-release: true
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+    secrets: inherit
 
   call-vuln-check-for-v3_10:
     uses: ./.github/workflows/vuln-check.yaml
     with:
       target-ref: v3.10
       find-latest-release: true
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+    secrets: inherit

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -14,18 +14,39 @@ on:
         type: boolean
         default: false
     secrets:
-      CR_PAT:
-        required: true
       SLACK_SECURITY_WEBHOOK_URL:
         required: false
 
 jobs:
-  call-vuln-check:
-    uses: scalar-labs/actions/.github/workflows/vuln-check-reusable.yaml@main
-    with:
-      target-ref: ${{ inputs.target-ref }}
-      find-latest-release: ${{ inputs.find-latest-release }}
-      images: '[["ScalarDL Ledger", "scalardl-ledger"], ["ScalarDL Client", "scalardl-client"]]'
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
-      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+  vuln-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build docker images
+        id: build-docker-images
+        uses: scalar-labs/actions/.github/actions/build-docker-images@vuln-check-composite-actions
+        with:
+          target-ref: ${{ inputs.target-ref }}
+          find-latest-release: ${{ inputs.find-latest-release }}
+
+      - name: Find Docker image refs
+        id: find-docker-image-refs
+        shell: bash
+        run: |
+          list='${{ steps.build-docker-images.outputs.docker-images }}'
+          echo ref-scalardl-ledger=$(grep scalardl-ledger <<< "$list") >> $GITHUB_OUTPUT
+          echo ref-scalardl-client=$(grep scalardl-client <<< "$list") >> $GITHUB_OUTPUT
+
+      - name: Run ScalarDL Ledger vulnerability check
+        continue-on-error: true
+        uses: scalar-labs/actions/.github/actions/vuln-check@vuln-check-composite-actions
+        with:
+          image-ref: ${{ steps.find-docker-image-refs.outputs.ref-scalardl-ledger }}
+          slack-webhook-url: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+
+      - name: Run ScalarDL Client vulnerability check
+        continue-on-error: true
+        uses: scalar-labs/actions/.github/actions/vuln-check@vuln-check-composite-actions
+        with:
+          image-ref: ${{ steps.find-docker-image-refs.outputs.ref-scalardl-client }}
+          slack-webhook-url: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

This PR fixes the vulnerability check workflow to use scalar-labs/actions#17 so that it runs on freshly built Docker images.

## Related issues and/or PRs

- scalar-labs/actions#17

## Changes made

- Replaced the reusable workflow with new composite actions for vulnerability checks.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes

Once scalar-labs/actions#17 is merged, the reference to the composite actions should be updated to `@main`. For example, change `uses: scalar-labs/actions/.github/actions/build-docker-images@vuln-check-composite-actions` to `uses: scalar-labs/actions/.github/actions/build-docker-images@main`.

## Release notes

Replaced reusable workflow with composite actions for vulnerability checks.
