### PR TITLE
Fix numeric value handling and add integration tests for table-based generic contracts

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
   // Metadata
   public static final String PACKAGE = "table";
   public static final String VERSION = "v1_0_0";
+  public static final String CONTRACT_GET_ASSET_ID = PACKAGE + "." + VERSION + ".GetAssetId";
   public static final String CONTRACT_SCAN = PACKAGE + "." + VERSION + ".Scan";
 
   // Constants
@@ -14,6 +15,8 @@ public class Constants {
   public static final String PREFIX_INDEX = "idx_";
   public static final String PREFIX_RECORD = "rec_";
   public static final String ASSET_ID_METADATA_TABLES = "metadata_tables";
+  public static final String ASSET_ID_PREFIX = "prefix";
+  public static final String ASSET_ID_VALUES = "values";
   public static final String ASSET_ID_SEPARATOR = "_";
   public static final String TABLE_NAME = "name";
   public static final String TABLE_KEY = "key";

--- a/common/src/main/java/com/scalar/dl/ledger/server/BaseServer.java
+++ b/common/src/main/java/com/scalar/dl/ledger/server/BaseServer.java
@@ -1,5 +1,6 @@
 package com.scalar.dl.ledger.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Injector;
 import com.scalar.dl.ledger.config.ServerConfig;
@@ -124,7 +125,8 @@ public class BaseServer {
         config.getDecommissioningDurationSecs(), TimeUnit.SECONDS);
   }
 
-  private void stop() throws InterruptedException {
+  @VisibleForTesting
+  public void stop() throws InterruptedException {
     if (server != null) {
       server.shutdown();
     }

--- a/generic-contracts/conf/table-authenticity-management-contracts.toml
+++ b/generic-contracts/conf/table-authenticity-management-contracts.toml
@@ -14,6 +14,11 @@ contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Select"
 contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Select.class"
 
 [[contracts]]
+contract-id = "table.v1_0_0.GetAssetId"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.GetAssetId"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/GetAssetId.class"
+
+[[contracts]]
 contract-id = "table.v1_0_0.Scan"
 contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Scan"
 contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.class"

--- a/generic-contracts/src/integration-test/java/com/scalar/dl/genericcontracts/GenericContractEndToEndTestBase.java
+++ b/generic-contracts/src/integration-test/java/com/scalar/dl/genericcontracts/GenericContractEndToEndTestBase.java
@@ -1,0 +1,299 @@
+package com.scalar.dl.genericcontracts;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.schemaloader.SchemaLoader;
+import com.scalar.db.schemaloader.SchemaLoaderException;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.storage.dynamo.DynamoAdmin;
+import com.scalar.db.storage.dynamo.DynamoConfig;
+import com.scalar.dl.client.config.ClientConfig;
+import com.scalar.dl.client.service.ClientServiceFactory;
+import com.scalar.dl.client.service.GenericContractClientService;
+import com.scalar.dl.ledger.config.LedgerConfig;
+import com.scalar.dl.ledger.server.AdminService;
+import com.scalar.dl.ledger.server.BaseServer;
+import com.scalar.dl.ledger.server.LedgerPrivilegedService;
+import com.scalar.dl.ledger.server.LedgerServerModule;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class GenericContractEndToEndTestBase {
+  private static final int THREAD_NUM = 1;
+  private static final String SCALAR_NAMESPACE = "scalar";
+  private static final String ASSET_TABLE = "asset";
+  private static final String ASSET_METADATA_TABLE = "asset_metadata";
+  private static final String LEDGER_SCHEMA_PATH = "/scripts/ledger-schema.json";
+  private static final String FUNCTION_DB_SCHEMA_PATH = "/scripts/objects-table-schema.json";
+  private static final String PACKAGE_PREFIX = "com.scalar.dl.genericcontracts.";
+  private static final String CLASS_DIR = "build/classes/java/main/";
+  private static final String FUNCTION_NAMESPACE = "test";
+  private static final String FUNCTION_TABLE = "objects";
+
+  private static final String JDBC_TRANSACTION_MANAGER = "jdbc";
+  private static final String PROP_STORAGE = "scalardb.storage";
+  private static final String PROP_CONTACT_POINTS = "scalardb.contact_points";
+  private static final String PROP_USERNAME = "scalardb.username";
+  private static final String PROP_PASSWORD = "scalardb.password";
+  private static final String PROP_TRANSACTION_MANAGER = "scalardb.transaction_manager";
+  private static final String PROP_DYNAMO_ENDPOINT_OVERRIDE = "scalardb.dynamo.endpoint_override";
+  private static final String DEFAULT_STORAGE = "jdbc";
+  private static final String DEFAULT_CONTACT_POINTS = "jdbc:mysql://localhost/";
+  private static final String DEFAULT_USERNAME = "root";
+  private static final String DEFAULT_PASSWORD = "mysql";
+  private static final String DEFAULT_TRANSACTION_MANAGER = "consensus-commit";
+  private static final String DEFAULT_DYNAMO_ENDPOINT_OVERRIDE = "http://localhost:8000";
+
+  private static final String SOME_ENTITY_1 = "entity1";
+  private static final String SOME_ENTITY_2 = "entity2";
+  private static final String SOME_PRIVATE_KEY =
+      "-----BEGIN EC PRIVATE KEY-----\n"
+          + "MHcCAQEEIF4SjQxTArRcZaROSFjlBP2rR8fAKtL8y+kmGiSlM5hEoAoGCCqGSM49\n"
+          + "AwEHoUQDQgAEY0i/iAFxIBS3etbjoSC1/aUKQV66+wiawL4bZqklu86ObIc7wrif\n"
+          + "HExPmVhKFSklOyZqGoOiVZA0zf0LZeFaPA==\n"
+          + "-----END EC PRIVATE KEY-----";
+  public static final String SOME_CERTIFICATE =
+      "-----BEGIN CERTIFICATE-----\n"
+          + "MIICQTCCAeagAwIBAgIUEKARigcZQ3sLEXdlEtjYissVx0cwCgYIKoZIzj0EAwIw\n"
+          + "QTELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5bzES\n"
+          + "MBAGA1UEChMJU2FtcGxlIENBMB4XDTE4MDYyMTAyMTUwMFoXDTE5MDYyMTAyMTUw\n"
+          + "MFowRTELMAkGA1UEBhMCSlAxDjAMBgNVBAgTBVRva3lvMQ4wDAYDVQQHEwVUb2t5\n"
+          + "bzEWMBQGA1UEChMNU2FtcGxlIENsaWVudDBZMBMGByqGSM49AgEGCCqGSM49AwEH\n"
+          + "A0IABGNIv4gBcSAUt3rW46Egtf2lCkFeuvsImsC+G2apJbvOjmyHO8K4nxxMT5lY\n"
+          + "ShUpJTsmahqDolWQNM39C2XhWjyjgbcwgbQwDgYDVR0PAQH/BAQDAgWgMB0GA1Ud\n"
+          + "JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQW\n"
+          + "BBTpBQl/JxB7yr77uMVT9mMicPeVJTAfBgNVHSMEGDAWgBQrJo3N3/0j3oPS6F6m\n"
+          + "wunHe8xLpzA1BgNVHREELjAsghJjbGllbnQuZXhhbXBsZS5jb22CFnd3dy5jbGll\n"
+          + "bnQuZXhhbXBsZS5jb20wCgYIKoZIzj0EAwIDSQAwRgIhAJPtXSzuncDJXnM+7us8\n"
+          + "46MEVjGHJy70bRY1My23RkxbAiEA5oFgTKMvls8e4UpnmUgFNP+FH8a5bF4tUPaV\n"
+          + "BQiBbgk=\n"
+          + "-----END CERTIFICATE-----";
+  private static final int SOME_KEY_VERSION = 1;
+
+  private ExecutorService executorService;
+  private Properties props;
+  private Map<String, String> creationOptions = new HashMap<>();
+  private Path ledgerSchemaPath;
+  private Path databaseSchemaPath;
+  private String functionNamespace;
+  private String functionTable;
+
+  protected DistributedStorage storage;
+  protected DistributedStorageAdmin storageAdmin;
+  protected final ClientServiceFactory clientServiceFactory = new ClientServiceFactory();
+  protected GenericContractClientService clientService;
+  protected GenericContractClientService anotherClientService;
+
+  @BeforeAll
+  public void setUpBeforeClass() throws Exception {
+    executorService = Executors.newFixedThreadPool(getThreadNum());
+    props = createLedgerProperties();
+    StorageFactory factory = StorageFactory.create(props);
+    storage = factory.getStorage();
+    storageAdmin = factory.getStorageAdmin();
+    ledgerSchemaPath = Paths.get(System.getProperty("user.dir") + LEDGER_SCHEMA_PATH);
+    databaseSchemaPath = Paths.get(getFunctionDatabaseSchema());
+    functionNamespace = getFunctionNamespace();
+    functionTable = getFunctionTable();
+    createSchema();
+
+    createServer(new LedgerConfig(props));
+
+    clientService = createClientService(SOME_ENTITY_1);
+    clientService.registerCertificate();
+    registerContracts(clientService, getContractsMap(), getContractPropertiesMap());
+    registerFunction(clientService, getFunctionsMap());
+
+    anotherClientService = createClientService(SOME_ENTITY_2);
+    anotherClientService.registerCertificate();
+    registerContracts(anotherClientService, getContractsMap(), getAnotherContractPropertiesMap());
+  }
+
+  @AfterAll
+  public void tearDownAfterClass() throws SchemaLoaderException {
+    storage.close();
+    storageAdmin.close();
+    SchemaLoader.unload(props, ledgerSchemaPath, true);
+    SchemaLoader.unload(props, databaseSchemaPath, true);
+  }
+
+  @BeforeEach
+  public void setUp() {}
+
+  @AfterEach
+  public void tearDown() throws ExecutionException {
+    storageAdmin.truncateTable(SCALAR_NAMESPACE, ASSET_TABLE);
+    storageAdmin.truncateTable(SCALAR_NAMESPACE, ASSET_METADATA_TABLE);
+    storageAdmin.truncateTable(functionNamespace, functionTable);
+  }
+
+  abstract Map<String, String> getContractsMap();
+
+  abstract Map<String, String> getFunctionsMap();
+
+  protected Map<String, JsonNode> getContractPropertiesMap() {
+    return ImmutableMap.of();
+  }
+
+  protected Map<String, JsonNode> getAnotherContractPropertiesMap() {
+    return ImmutableMap.of();
+  }
+
+  protected String getScalarNamespace() {
+    return SCALAR_NAMESPACE;
+  }
+
+  protected String getAssetTable() {
+    return ASSET_TABLE;
+  }
+
+  protected String getAssetMetadataTable() {
+    return ASSET_METADATA_TABLE;
+  }
+
+  protected String getFunctionDatabaseSchema() {
+    return System.getProperty("user.dir") + FUNCTION_DB_SCHEMA_PATH;
+  }
+
+  protected String getFunctionNamespace() {
+    return FUNCTION_NAMESPACE;
+  }
+
+  protected String getFunctionTable() {
+    return FUNCTION_TABLE;
+  }
+
+  protected static String getContractId(String prefix, String contractName) {
+    return prefix + "." + contractName;
+  }
+
+  protected static String getContractBinaryName(String prefix, String contractName) {
+    return PACKAGE_PREFIX + getContractId(prefix, contractName);
+  }
+
+  protected static String getFunctionId(String prefix, String functionName) {
+    return prefix + "." + functionName;
+  }
+
+  protected static String getFunctionBinaryName(String prefix, String functionName) {
+    return PACKAGE_PREFIX + getFunctionId(prefix, functionName);
+  }
+
+  protected int getThreadNum() {
+    return THREAD_NUM;
+  }
+
+  protected void executeInParallel(List<Callable<Void>> testCallables)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    List<Future<Void>> futures = executorService.invokeAll(testCallables);
+    for (Future<Void> future : futures) {
+      future.get();
+    }
+  }
+
+  private Properties createLedgerProperties() {
+    String storage = System.getProperty(PROP_STORAGE, DEFAULT_STORAGE);
+    String contactPoints = System.getProperty(PROP_CONTACT_POINTS, DEFAULT_CONTACT_POINTS);
+    String username = System.getProperty(PROP_USERNAME, DEFAULT_USERNAME);
+    String password = System.getProperty(PROP_PASSWORD, DEFAULT_PASSWORD);
+    String transactionManager =
+        System.getProperty(PROP_TRANSACTION_MANAGER, DEFAULT_TRANSACTION_MANAGER);
+    String endpointOverride =
+        System.getProperty(PROP_DYNAMO_ENDPOINT_OVERRIDE, DEFAULT_DYNAMO_ENDPOINT_OVERRIDE);
+
+    Properties props = new Properties();
+    props.put(DatabaseConfig.STORAGE, storage);
+    props.put(DatabaseConfig.CONTACT_POINTS, contactPoints);
+    props.put(DatabaseConfig.USERNAME, username);
+    props.put(DatabaseConfig.PASSWORD, password);
+    props.put(DatabaseConfig.TRANSACTION_MANAGER, transactionManager);
+    if (transactionManager.equals(JDBC_TRANSACTION_MANAGER)) {
+      props.put(LedgerConfig.TX_STATE_MANAGEMENT_ENABLED, "true");
+    }
+    props.put(LedgerConfig.PROOF_ENABLED, "true");
+    props.put(LedgerConfig.PROOF_PRIVATE_KEY_PEM, SOME_PRIVATE_KEY);
+
+    if (storage.equals(DynamoConfig.STORAGE_NAME)) {
+      props.put(DynamoConfig.ENDPOINT_OVERRIDE, endpointOverride);
+      props.put(
+          DynamoConfig.TABLE_METADATA_NAMESPACE, DatabaseConfig.DEFAULT_SYSTEM_NAMESPACE_NAME);
+      creationOptions =
+          ImmutableMap.of(DynamoAdmin.NO_SCALING, "true", DynamoAdmin.NO_BACKUP, "true");
+    }
+
+    return props;
+  }
+
+  private void createSchema() throws SchemaLoaderException {
+    SchemaLoader.load(props, ledgerSchemaPath, creationOptions, true);
+    SchemaLoader.load(props, databaseSchemaPath, creationOptions, true);
+  }
+
+  private void createServer(LedgerConfig config) throws IOException, InterruptedException {
+    Injector injector = Guice.createInjector(new LedgerServerModule(config));
+    BaseServer ledgerServer = new BaseServer(injector, config);
+
+    ledgerServer.start(com.scalar.dl.ledger.server.LedgerService.class);
+    ledgerServer.startPrivileged(LedgerPrivilegedService.class);
+    ledgerServer.startAdmin(AdminService.class);
+  }
+
+  private GenericContractClientService createClientService(String entity) throws IOException {
+    Properties props = new Properties();
+    props.put(ClientConfig.ENTITY_ID, entity);
+    props.put(ClientConfig.DS_CERT_VERSION, String.valueOf(SOME_KEY_VERSION));
+    props.put(ClientConfig.DS_CERT_PEM, SOME_CERTIFICATE);
+    props.put(ClientConfig.DS_PRIVATE_KEY_PEM, SOME_PRIVATE_KEY);
+    return clientServiceFactory.createForGenericContract(new ClientConfig(props));
+  }
+
+  private void registerContracts(
+      GenericContractClientService clientService,
+      Map<String, String> contractsMap,
+      Map<String, JsonNode> propertiesMap)
+      throws IOException {
+    for (Map.Entry<String, String> entry : contractsMap.entrySet()) {
+      String contractId = entry.getKey();
+      String contractBinaryName = entry.getValue();
+      String contractFilePath = CLASS_DIR + contractBinaryName.replace('.', '/') + ".class";
+      byte[] bytes = Files.readAllBytes(new File(contractFilePath).toPath());
+      JsonNode properties = propertiesMap.getOrDefault(contractId, null);
+      clientService.registerContract(contractId, contractBinaryName, bytes, properties);
+    }
+  }
+
+  private void registerFunction(
+      GenericContractClientService clientService, Map<String, String> functionsMap)
+      throws IOException {
+    for (Map.Entry<String, String> entry : functionsMap.entrySet()) {
+      String functionId = entry.getKey();
+      String functionBinaryName = entry.getValue();
+      String functionFilePath = CLASS_DIR + functionBinaryName.replace('.', '/') + ".class";
+      byte[] bytes = Files.readAllBytes(new File(functionFilePath).toPath());
+      clientService.registerFunction(functionId, functionBinaryName, bytes);
+    }
+  }
+}

--- a/generic-contracts/src/integration-test/java/com/scalar/dl/genericcontracts/GenericContractEndToEndTestBase.java
+++ b/generic-contracts/src/integration-test/java/com/scalar/dl/genericcontracts/GenericContractEndToEndTestBase.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class GenericContractEndToEndTestBase {
-  private static final int THREAD_NUM = 1;
+  private static final int THREAD_NUM = 10;
   private static final String SCALAR_NAMESPACE = "scalar";
   private static final String ASSET_TABLE = "asset";
   private static final String ASSET_METADATA_TABLE = "asset_metadata";
@@ -93,6 +93,7 @@ public abstract class GenericContractEndToEndTestBase {
           + "-----END CERTIFICATE-----";
   private static final int SOME_KEY_VERSION = 1;
 
+  private BaseServer ledgerServer;
   private ExecutorService executorService;
   private Properties props;
   private Map<String, String> creationOptions = new HashMap<>();
@@ -133,7 +134,8 @@ public abstract class GenericContractEndToEndTestBase {
   }
 
   @AfterAll
-  public void tearDownAfterClass() throws SchemaLoaderException {
+  public void tearDownAfterClass() throws SchemaLoaderException, InterruptedException {
+    ledgerServer.stop();
     storage.close();
     storageAdmin.close();
     SchemaLoader.unload(props, ledgerSchemaPath, true);
@@ -254,7 +256,7 @@ public abstract class GenericContractEndToEndTestBase {
 
   private void createServer(LedgerConfig config) throws IOException, InterruptedException {
     Injector injector = Guice.createInjector(new LedgerServerModule(config));
-    BaseServer ledgerServer = new BaseServer(injector, config);
+    ledgerServer = new BaseServer(injector, config);
 
     ledgerServer.start(com.scalar.dl.ledger.server.LedgerService.class);
     ledgerServer.startPrivileged(LedgerPrivilegedService.class);

--- a/generic-contracts/src/integration-test/java/com/scalar/dl/genericcontracts/GenericContractTableEndToEndTest.java
+++ b/generic-contracts/src/integration-test/java/com/scalar/dl/genericcontracts/GenericContractTableEndToEndTest.java
@@ -1,0 +1,1569 @@
+package com.scalar.dl.genericcontracts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableTable;
+import com.scalar.dl.client.exception.ClientException;
+import com.scalar.dl.genericcontracts.table.v1_0_0.Constants;
+import com.scalar.dl.ledger.model.ContractExecutionResult;
+import com.scalar.dl.ledger.util.JacksonSerDe;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GenericContractTableEndToEndTest extends GenericContractEndToEndTestBase {
+  private static final String CONTRACT_NAME_CREATE = "Create";
+  private static final String CONTRACT_NAME_INSERT = "Insert";
+  private static final String CONTRACT_NAME_SELECT = "Select";
+  private static final String CONTRACT_NAME_GET_ASSET_ID = "GetAssetId";
+  private static final String CONTRACT_NAME_SCAN = "Scan";
+  private static final String CONTRACT_ID_PREFIX = Constants.PACKAGE + "." + Constants.VERSION;
+  private static final String CONTRACT_ID_CREATE = getContractId(CONTRACT_NAME_CREATE);
+  private static final String CONTRACT_ID_INSERT = getContractId(CONTRACT_NAME_INSERT);
+  private static final String CONTRACT_ID_SELECT = getContractId(CONTRACT_NAME_SELECT);
+  private static final String CONTRACT_ID_SCAN = getContractId(CONTRACT_NAME_SCAN);
+  private static final String CONTRACT_ID_GET_ASSET_ID = getContractId(CONTRACT_NAME_GET_ASSET_ID);
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final JacksonSerDe jacksonSerDe = new JacksonSerDe(mapper);
+  private static final String KEY_COLUMN = "column";
+  private static final String KEY_TYPE = "type";
+  private static final String KEY_VALUE = "value";
+  private static final String KEY_OPERATOR = "operator";
+  private static final String KEY_EXPECTED = "expected";
+  private static final String COMMON_TEST_TABLE = "test_table";
+  private static final String TABLE_NAME_1 = "table1";
+  private static final String TABLE_NAME_2 = "table2";
+  private static final String TABLE_NAME_3 = "table3";
+  private static final String TABLE_ALIAS = "tbl";
+  private static final String COLUMN_NAME_1 = "col1";
+  private static final String COLUMN_NAME_2 = "col2";
+  private static final String COLUMN_NAME_3 = "col3";
+  private static final String COLUMN_NAME_4 = "col4";
+  private static final String COLUMN_NAME_5 = "col5";
+  private static final String COLUMN_NAME_6 = "col6";
+  private static final String COLUMN_NAME_7 = "col7";
+  private static final String KEY_TYPE_STRING = "string";
+  private static final String KEY_TYPE_NUMBER = "number";
+  private static final String KEY_TYPE_BOOLEAN = "boolean";
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    createTable(
+        COMMON_TEST_TABLE,
+        COLUMN_NAME_1,
+        KEY_TYPE_STRING,
+        ImmutableMap.of(COLUMN_NAME_2, KEY_TYPE_NUMBER));
+  }
+
+  private static String getContractId(String contractName) {
+    return getContractId(CONTRACT_ID_PREFIX, contractName);
+  }
+
+  private static String getContractBinaryName(String contractName) {
+    return getContractBinaryName(CONTRACT_ID_PREFIX, contractName);
+  }
+
+  @Override
+  Map<String, String> getContractsMap() {
+    return ImmutableMap.<String, String>builder()
+        .put(CONTRACT_ID_CREATE, getContractBinaryName(CONTRACT_NAME_CREATE))
+        .put(CONTRACT_ID_INSERT, getContractBinaryName(CONTRACT_NAME_INSERT))
+        .put(CONTRACT_ID_SELECT, getContractBinaryName(CONTRACT_NAME_SELECT))
+        .put(CONTRACT_ID_GET_ASSET_ID, getContractBinaryName(CONTRACT_NAME_GET_ASSET_ID))
+        .put(CONTRACT_ID_SCAN, getContractBinaryName(CONTRACT_NAME_SCAN))
+        .build();
+  }
+
+  @Override
+  Map<String, String> getFunctionsMap() {
+    return ImmutableMap.of();
+  }
+
+  private ArrayNode createArrayNode(JsonNode... jsonNodes) {
+    ArrayNode result = mapper.createArrayNode();
+    Arrays.stream(jsonNodes).forEach(result::add);
+    return result;
+  }
+
+  private void createTable(
+      String tableName, String keyColumnName, String keyColumnType, Map<String, String> indexes) {
+    ArrayNode indexNodes = mapper.createArrayNode();
+    indexes.forEach((column, type) -> indexNodes.add(createIndexNode(column, type)));
+    JsonNode table =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, tableName)
+            .put(Constants.TABLE_KEY, keyColumnName)
+            .put(Constants.TABLE_KEY_TYPE, keyColumnType)
+            .set(Constants.TABLE_INDEXES, indexNodes);
+    clientService.executeContract(CONTRACT_ID_CREATE, table);
+  }
+
+  private static ObjectNode createIndexNode(String key, String type) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.INDEX_KEY, key)
+        .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  private List<JsonNode> insertAndGetRecords() {
+    JsonNode record0 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("1"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                TextNode.valueOf("aaa"),
+                COLUMN_NAME_4,
+                IntNode.valueOf(1),
+                COLUMN_NAME_5,
+                DoubleNode.valueOf(1.23),
+                COLUMN_NAME_6,
+                BooleanNode.valueOf(true),
+                COLUMN_NAME_7,
+                NullNode.getInstance()));
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("2"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                TextNode.valueOf("bbb"),
+                COLUMN_NAME_4,
+                IntNode.valueOf(2),
+                COLUMN_NAME_5,
+                DoubleNode.valueOf(2.34),
+                COLUMN_NAME_6,
+                BooleanNode.valueOf(false),
+                COLUMN_NAME_7,
+                createArrayNode()));
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("3"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                TextNode.valueOf("ccc"),
+                COLUMN_NAME_4,
+                IntNode.valueOf(3),
+                COLUMN_NAME_5,
+                DoubleNode.valueOf(3.45),
+                COLUMN_NAME_6,
+                BooleanNode.valueOf(true)));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record0));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    return ImmutableList.of(record0, record1, record2);
+  }
+
+  private void insertRecord(String tableName, int primaryKey, int indexKey) {
+    JsonNode record =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                IntNode.valueOf(primaryKey),
+                COLUMN_NAME_2,
+                IntNode.valueOf(indexKey)));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(tableName, record));
+  }
+
+  private void insertRecord(
+      String tableName, int primaryKey, int indexKey, int value1, int value2) {
+    JsonNode record =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                IntNode.valueOf(primaryKey),
+                COLUMN_NAME_2,
+                IntNode.valueOf(indexKey),
+                COLUMN_NAME_3,
+                IntNode.valueOf(value1),
+                COLUMN_NAME_4,
+                IntNode.valueOf(value2)));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(tableName, record));
+  }
+
+  private void prepareJoinTables() {
+    createTable(
+        TABLE_NAME_1,
+        COLUMN_NAME_1,
+        KEY_TYPE_NUMBER,
+        ImmutableMap.of(COLUMN_NAME_2, KEY_TYPE_NUMBER));
+    insertRecord(TABLE_NAME_1, 1, 20250101, 101, 300);
+    insertRecord(TABLE_NAME_1, 2, 20250101, 201, 400);
+    insertRecord(TABLE_NAME_1, 3, 20250101);
+    insertRecord(TABLE_NAME_1, 4, 20251231, 301, 500);
+    createTable(
+        TABLE_NAME_2,
+        COLUMN_NAME_1,
+        KEY_TYPE_NUMBER,
+        ImmutableMap.of(COLUMN_NAME_2, KEY_TYPE_NUMBER));
+    insertRecord(TABLE_NAME_2, 101, 0, 0, 0);
+    insertRecord(TABLE_NAME_2, 201, 1, 1, 1);
+    createTable(
+        TABLE_NAME_3,
+        COLUMN_NAME_1,
+        KEY_TYPE_NUMBER,
+        ImmutableMap.of(COLUMN_NAME_2, KEY_TYPE_NUMBER));
+    insertRecord(TABLE_NAME_3, 111, 400, 0, 0);
+    insertRecord(TABLE_NAME_3, 222, 400, 1, 1);
+    insertRecord(TABLE_NAME_3, 333, 300, 0, 0);
+    insertRecord(TABLE_NAME_3, 444, 300, 0, 0);
+  }
+
+  private ObjectNode prepareRecord(Map<String, JsonNode> map) {
+    ObjectNode record = mapper.createObjectNode();
+    map.forEach(record::set);
+    return record;
+  }
+
+  private JsonNode prepareInsert(String tableName, JsonNode values) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.RECORD_TABLE, tableName)
+        .set(Constants.RECORD_VALUES, values);
+  }
+
+  private ObjectNode prepareSelect(
+      String tableName, String keyColumnName, JsonNode value, JsonNode... conditions) {
+    List<JsonNode> conditionList = new ArrayList<>();
+    conditionList.add(prepareCondition(keyColumnName, value, Constants.OPERATOR_EQ));
+    conditionList.addAll(Arrays.asList(conditions));
+    return mapper
+        .createObjectNode()
+        .put(Constants.QUERY_TABLE, tableName)
+        .set(Constants.QUERY_CONDITIONS, prepareArrayNode(conditionList));
+  }
+
+  private ObjectNode prepareSelect(String tableName, String keyColumnName) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.QUERY_TABLE, tableName)
+        .set(
+            Constants.QUERY_CONDITIONS,
+            prepareArrayNode(
+                ImmutableList.of(prepareCondition(keyColumnName, Constants.OPERATOR_IS_NULL))));
+  }
+
+  private ArrayNode prepareArrayNode(List<JsonNode> jsonNodes) {
+    ArrayNode result = mapper.createArrayNode();
+    jsonNodes.forEach(result::add);
+    return result;
+  }
+
+  private JsonNode prepareTableAlias(String name, String alias) {
+    return mapper.createObjectNode().put(Constants.ALIAS_NAME, name).put(Constants.ALIAS_AS, alias);
+  }
+
+  private JsonNode prepareJoin(JsonNode table, String leftColumn, String rightColumn) {
+    ObjectNode join = mapper.createObjectNode();
+    join.set(Constants.JOIN_TABLE, table);
+    join.put(Constants.JOIN_LEFT_KEY, leftColumn);
+    join.put(Constants.JOIN_RIGHT_KEY, rightColumn);
+    return join;
+  }
+
+  private JsonNode prepareCondition(String column, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_OPERATOR, operator);
+  }
+
+  private JsonNode prepareCondition(String column, JsonNode value, String operator) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.CONDITION_COLUMN, column)
+        .put(Constants.CONDITION_OPERATOR, operator)
+        .set(Constants.CONDITION_VALUE, value);
+  }
+
+  private void runConditionTestCasesInParallel(ImmutableTable<Integer, String, JsonNode> caseTable)
+      throws ExecutionException, InterruptedException {
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    caseTable
+        .rowMap()
+        .forEach(
+            (id, row) -> {
+              testCallables.add(
+                  () -> {
+                    select_AdditionalConditionsGiven_ShouldSelectSingleRecordProperly(
+                        id,
+                        row.get(KEY_COLUMN).asText(),
+                        row.get(KEY_VALUE),
+                        row.get(KEY_OPERATOR).asText(),
+                        row.get(KEY_EXPECTED));
+                    return null;
+                  });
+            });
+
+    executeInParallel(testCallables);
+  }
+
+  private void addTestCase(
+      ImmutableTable.Builder<Integer, String, JsonNode> caseBuilder,
+      int caseId,
+      Map<String, JsonNode> row) {
+    row.forEach((column, value) -> caseBuilder.put(caseId, column, value));
+  }
+
+  private String description(String table, String column, String value) {
+    return String.format("failed with table: %s, column: %s, value: %s", table, column, value);
+  }
+
+  private String description(int caseId, String column, JsonNode value, String operator) {
+    return String.format(
+        "failed with case: %d, column: %s, value: %s, operator: %s",
+        caseId, column, value.asText(), operator);
+  }
+
+  private void assertSelectResult(JsonNode actual, List<JsonNode> expected) {
+    List<JsonNode> records = new ArrayList<>();
+    assertThat(actual.isArray()).isTrue();
+    actual.forEach(records::add);
+    assertThat(records).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private void assertSelectResult(JsonNode actual, List<JsonNode> expected, String description) {
+    List<JsonNode> records = new ArrayList<>();
+    assertThat(actual.isArray()).describedAs(description).isTrue();
+    actual.forEach(records::add);
+    assertThat(records).describedAs(description).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private void assertSelectResult(JsonNode actual, JsonNode expected, String description) {
+    List<JsonNode> expectedRecords = new ArrayList<>();
+    expected.forEach(expectedRecords::add);
+    assertSelectResult(actual, expectedRecords, description);
+  }
+
+  @Test
+  public void insert_NonExistingRecordGiven_ShouldInsertRecordProperly() {
+    // Arrange
+    JsonNode key = TextNode.valueOf("key");
+    JsonNode value = IntNode.valueOf(1);
+    JsonNode record = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key, COLUMN_NAME_2, value));
+    JsonNode insert = prepareInsert(COMMON_TEST_TABLE, record);
+    JsonNode select = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_1, key);
+    JsonNode expected = createArrayNode(record);
+
+    // Act
+    clientService.executeContract(CONTRACT_ID_INSERT, insert);
+
+    // Assert
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+    assertThat(actual.getContractResult()).isPresent();
+    assertThat(actual.getContractResult().get()).isEqualTo(jacksonSerDe.serialize(expected));
+  }
+
+  @Test
+  public void insert_ExistingRecordGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode key = TextNode.valueOf("key");
+    JsonNode value1 = IntNode.valueOf(1);
+    JsonNode value2 = IntNode.valueOf(2);
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key, COLUMN_NAME_2, value1));
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key, COLUMN_NAME_2, value2));
+    JsonNode insert1 = prepareInsert(COMMON_TEST_TABLE, record1);
+    JsonNode insert2 = prepareInsert(COMMON_TEST_TABLE, record2);
+    clientService.executeContract(CONTRACT_ID_INSERT, insert1);
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_INSERT, insert2))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.RECORD_ALREADY_EXISTS);
+  }
+
+  @Test
+  public void insert_RecordForNonExistingTableGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode key = TextNode.valueOf("key");
+    JsonNode value = IntNode.valueOf(1);
+    JsonNode record = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key, COLUMN_NAME_2, value));
+    JsonNode insert = prepareInsert(TABLE_NAME_1, record);
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_INSERT, insert))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.TABLE_NOT_EXIST);
+  }
+
+  @Test
+  public void insert_EqualButDifferentNumericTypePrimaryKeysGiven_ShouldNotInsertRecords() {
+    // Arrange
+    createTable(TABLE_NAME_1, COLUMN_NAME_1, KEY_TYPE_NUMBER, ImmutableMap.of());
+    JsonNode key1 = IntNode.valueOf(1);
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key1));
+    JsonNode key2 = DoubleNode.valueOf(1.0);
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key2));
+    JsonNode key3 = LongNode.valueOf(1L);
+    JsonNode record3 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key3));
+    JsonNode key4 = DecimalNode.valueOf(new BigDecimal("1.000"));
+    JsonNode record4 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key4));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record1));
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                clientService.executeContract(
+                    CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record2)))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.RECORD_ALREADY_EXISTS);
+    assertThatThrownBy(
+            () ->
+                clientService.executeContract(
+                    CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record3)))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.RECORD_ALREADY_EXISTS);
+    assertThatThrownBy(
+            () ->
+                clientService.executeContract(
+                    CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record4)))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.RECORD_ALREADY_EXISTS);
+  }
+
+  @Test
+  public void select_PrimaryKeyConditionGiven_ShouldSelectSingleRecordProperly()
+      throws ExecutionException, InterruptedException {
+    ImmutableTable<String, String, JsonNode> cases =
+        new ImmutableTable.Builder<String, String, JsonNode>()
+            .put("tbl1", KEY_TYPE, TextNode.valueOf(KEY_TYPE_STRING))
+            .put("tbl1", KEY_VALUE, TextNode.valueOf("1"))
+            .put("tbl2", KEY_TYPE, TextNode.valueOf(KEY_TYPE_NUMBER))
+            .put("tbl2", KEY_VALUE, IntNode.valueOf(1))
+            .put("tbl3", KEY_TYPE, TextNode.valueOf(KEY_TYPE_NUMBER))
+            .put("tbl3", KEY_VALUE, DoubleNode.valueOf(1.2345))
+            .put("tbl4", KEY_TYPE, TextNode.valueOf(KEY_TYPE_BOOLEAN))
+            .put("tbl4", KEY_VALUE, BooleanNode.valueOf(false))
+            .build();
+    cases
+        .rowMap()
+        .forEach(
+            (tableName, row) ->
+                createTable(
+                    tableName, COLUMN_NAME_1, row.get(KEY_TYPE).asText(), ImmutableMap.of()));
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    cases
+        .rowMap()
+        .forEach(
+            (tableName, row) -> {
+              testCallables.add(
+                  () -> {
+                    select_PrimaryKeyConditionGiven_ShouldSelectSingleRecordProperly(
+                        tableName, row.get(KEY_VALUE));
+                    return null;
+                  });
+            });
+
+    executeInParallel(testCallables);
+  }
+
+  private void select_PrimaryKeyConditionGiven_ShouldSelectSingleRecordProperly(
+      String tableName, JsonNode value) {
+    // Arrange
+    JsonNode record = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, value));
+    JsonNode select = prepareSelect(tableName, COLUMN_NAME_1, value);
+    JsonNode expected = createArrayNode(record);
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(tableName, record));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertThat(actual.getContractResult().get()).isEqualTo(jacksonSerDe.serialize(expected));
+  }
+
+  @Test
+  public void select_ProjectionsGiven_ShouldSelectSingleRecordProperly() {
+    // Arrange
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("1"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                TextNode.valueOf("0"),
+                COLUMN_NAME_4,
+                TextNode.valueOf("aaa")));
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("2"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                IntNode.valueOf(0),
+                COLUMN_NAME_5,
+                TextNode.valueOf("aaa")));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    JsonNode select =
+        prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, IntNode.valueOf(1))
+            .set(
+                Constants.QUERY_PROJECTIONS,
+                createArrayNode(
+                    TextNode.valueOf(
+                        COMMON_TEST_TABLE + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1),
+                    TextNode.valueOf(COLUMN_NAME_3),
+                    TextNode.valueOf(COLUMN_NAME_4),
+                    TextNode.valueOf(COLUMN_NAME_5)));
+    ObjectNode expectedRecord1 = record1.deepCopy();
+    ObjectNode expectedRecord2 = record2.deepCopy();
+    expectedRecord1.remove(COLUMN_NAME_2);
+    expectedRecord2.remove(COLUMN_NAME_2);
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()),
+        ImmutableList.of(expectedRecord1, expectedRecord2));
+  }
+
+  @Test
+  public void select_IndexKeyConditionGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    ImmutableTable<String, String, JsonNode> cases =
+        new ImmutableTable.Builder<String, String, JsonNode>()
+            .put("tbl1", KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_2))
+            .put("tbl1", KEY_TYPE, TextNode.valueOf(KEY_TYPE_STRING))
+            .put("tbl1", KEY_VALUE, TextNode.valueOf("abc"))
+            .put("tbl2", KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3))
+            .put("tbl2", KEY_TYPE, TextNode.valueOf(KEY_TYPE_NUMBER))
+            .put("tbl2", KEY_VALUE, IntNode.valueOf(-10))
+            .put("tbl3", KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4))
+            .put("tbl3", KEY_TYPE, TextNode.valueOf(KEY_TYPE_NUMBER))
+            .put("tbl3", KEY_VALUE, DoubleNode.valueOf(1.23))
+            .put("tbl4", KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5))
+            .put("tbl4", KEY_TYPE, TextNode.valueOf(KEY_TYPE_BOOLEAN))
+            .put("tbl4", KEY_VALUE, BooleanNode.valueOf(true))
+            .build();
+    cases
+        .rowMap()
+        .forEach(
+            (tableName, row) -> {
+              // prepare test table
+              createTable(
+                  tableName,
+                  COLUMN_NAME_1,
+                  KEY_TYPE_STRING,
+                  ImmutableMap.of(row.get(KEY_COLUMN).asText(), row.get(KEY_TYPE).asText()));
+              // prepare a record that does not match the condition is the test case
+              JsonNode record =
+                  mapper
+                      .createObjectNode()
+                      .put(COLUMN_NAME_1, "key")
+                      .put(COLUMN_NAME_2, "val")
+                      .put(COLUMN_NAME_3, 10)
+                      .put(COLUMN_NAME_4, 1.2345)
+                      .put(COLUMN_NAME_5, false);
+              clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(tableName, record));
+            });
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    cases
+        .rowMap()
+        .forEach(
+            (tableName, row) -> {
+              testCallables.add(
+                  () -> {
+                    select_IndexKeyConditionGiven_ShouldSelectRecordsProperly(
+                        tableName, row.get(KEY_COLUMN).asText(), row.get(KEY_VALUE));
+                    return null;
+                  });
+            });
+
+    executeInParallel(testCallables);
+  }
+
+  private void select_IndexKeyConditionGiven_ShouldSelectRecordsProperly(
+      String tableName, String indexColumnName, JsonNode value) {
+    // Arrange
+    JsonNode key1 = TextNode.valueOf("key1");
+    JsonNode key2 = TextNode.valueOf("key2");
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key1, indexColumnName, value));
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key2, indexColumnName, value));
+    JsonNode select = prepareSelect(tableName, indexColumnName, value);
+    ImmutableList<JsonNode> expected = ImmutableList.of(record1, record2);
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(tableName, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(tableName, record2));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()),
+        expected,
+        description(tableName, indexColumnName, value.asText()));
+  }
+
+  @Test
+  public void select_NullIndexKeyConditionGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    createTable(
+        TABLE_NAME_1,
+        COLUMN_NAME_1,
+        KEY_TYPE_STRING,
+        ImmutableMap.of(
+            COLUMN_NAME_2,
+            KEY_TYPE_STRING,
+            COLUMN_NAME_3,
+            KEY_TYPE_NUMBER,
+            COLUMN_NAME_4,
+            KEY_TYPE_BOOLEAN));
+    JsonNode record0 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("1"),
+                COLUMN_NAME_2,
+                TextNode.valueOf("aaa"),
+                COLUMN_NAME_3,
+                IntNode.valueOf(1),
+                COLUMN_NAME_4,
+                BooleanNode.valueOf(true)));
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("2"),
+                COLUMN_NAME_2,
+                NullNode.getInstance(),
+                COLUMN_NAME_3,
+                NullNode.getInstance(),
+                COLUMN_NAME_4,
+                NullNode.getInstance()));
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("3"),
+                COLUMN_NAME_2,
+                NullNode.getInstance(),
+                COLUMN_NAME_3,
+                NullNode.getInstance(),
+                COLUMN_NAME_4,
+                NullNode.getInstance()));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record0));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, record2));
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    ImmutableList.of(COLUMN_NAME_2, COLUMN_NAME_3, COLUMN_NAME_4)
+        .forEach(
+            column ->
+                testCallables.add(
+                    () -> {
+                      select_NullIndexKeyConditionGiven_ShouldSelectRecordsProperly(
+                          column, createArrayNode(record1, record2));
+                      return null;
+                    }));
+
+    executeInParallel(testCallables);
+  }
+
+  private void select_NullIndexKeyConditionGiven_ShouldSelectRecordsProperly(
+      String columnName, JsonNode expected) {
+    // Arrange
+    JsonNode select = prepareSelect(TABLE_NAME_1, columnName);
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()),
+        expected,
+        description(TABLE_NAME_1, columnName, NullNode.getInstance().asText()));
+  }
+
+  @Test
+  public void select_AdditionalStringConditionsGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    List<JsonNode> records = insertAndGetRecords();
+    ImmutableTable.Builder<Integer, String, JsonNode> caseBuilder = new ImmutableTable.Builder<>();
+    addTestCase(
+        caseBuilder,
+        1,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_VALUE, TextNode.valueOf("bbb"),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_EQ),
+            KEY_EXPECTED, createArrayNode(records.get(1))));
+    addTestCase(
+        caseBuilder,
+        2,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_VALUE, TextNode.valueOf("bbb"),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_NE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        3,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_VALUE, TextNode.valueOf("bbb"),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_LT),
+            KEY_EXPECTED, createArrayNode(records.get(0))));
+    addTestCase(
+        caseBuilder,
+        4,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_VALUE, TextNode.valueOf("bbb"),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_LTE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(1))));
+    addTestCase(
+        caseBuilder,
+        5,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_VALUE, TextNode.valueOf("bbb"),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GT),
+            KEY_EXPECTED, createArrayNode(records.get(2))));
+    addTestCase(
+        caseBuilder,
+        6,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_VALUE, TextNode.valueOf("bbb"),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GTE),
+            KEY_EXPECTED, createArrayNode(records.get(1), records.get(2))));
+
+    runConditionTestCasesInParallel(caseBuilder.build());
+  }
+
+  @Test
+  public void select_AdditionalIntConditionsGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    List<JsonNode> records = insertAndGetRecords();
+    ImmutableTable.Builder<Integer, String, JsonNode> caseBuilder = new ImmutableTable.Builder<>();
+    addTestCase(
+        caseBuilder,
+        1,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_EQ),
+            KEY_EXPECTED, createArrayNode(records.get(1))));
+    addTestCase(
+        caseBuilder,
+        2,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_NE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        3,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_LT),
+            KEY_EXPECTED, createArrayNode(records.get(0))));
+    addTestCase(
+        caseBuilder,
+        4,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_LTE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(1))));
+    addTestCase(
+        caseBuilder,
+        5,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GT),
+            KEY_EXPECTED, createArrayNode(records.get(2))));
+    addTestCase(
+        caseBuilder,
+        6,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_4),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GTE),
+            KEY_EXPECTED, createArrayNode(records.get(1), records.get(2))));
+
+    runConditionTestCasesInParallel(caseBuilder.build());
+  }
+
+  @Test
+  public void select_AdditionalDoubleConditionsGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    List<JsonNode> records = insertAndGetRecords();
+    ImmutableTable.Builder<Integer, String, JsonNode> caseBuilder = new ImmutableTable.Builder<>();
+    addTestCase(
+        caseBuilder,
+        1,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, DoubleNode.valueOf(2.34),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_EQ),
+            KEY_EXPECTED, createArrayNode(records.get(1))));
+    addTestCase(
+        caseBuilder,
+        2,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, DoubleNode.valueOf(2.34),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_NE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        3,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, DoubleNode.valueOf(2.34),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_LT),
+            KEY_EXPECTED, createArrayNode(records.get(0))));
+    addTestCase(
+        caseBuilder,
+        4,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, DoubleNode.valueOf(2.34),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_LTE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(1))));
+    addTestCase(
+        caseBuilder,
+        5,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, DoubleNode.valueOf(2.34),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GT),
+            KEY_EXPECTED, createArrayNode(records.get(2))));
+    addTestCase(
+        caseBuilder,
+        6,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, DoubleNode.valueOf(2.34),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GTE),
+            KEY_EXPECTED, createArrayNode(records.get(1), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        7,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_EQ),
+            KEY_EXPECTED, createArrayNode()));
+    addTestCase(
+        caseBuilder,
+        8,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_NE),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(1), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        9,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_5),
+            KEY_VALUE, IntNode.valueOf(2),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_GT),
+            KEY_EXPECTED, createArrayNode(records.get(1), records.get(2))));
+
+    runConditionTestCasesInParallel(caseBuilder.build());
+  }
+
+  @Test
+  public void select_AdditionalBooleanConditionsGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    List<JsonNode> records = insertAndGetRecords();
+    ImmutableTable.Builder<Integer, String, JsonNode> caseBuilder = new ImmutableTable.Builder<>();
+    addTestCase(
+        caseBuilder,
+        1,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_6),
+            KEY_VALUE, BooleanNode.valueOf(true),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_EQ),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        2,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_6),
+            KEY_VALUE, BooleanNode.valueOf(true),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_NE),
+            KEY_EXPECTED, createArrayNode(records.get(1))));
+
+    runConditionTestCasesInParallel(caseBuilder.build());
+  }
+
+  private void select_AdditionalConditionsGiven_ShouldSelectSingleRecordProperly(
+      int caseId, String columnName, JsonNode value, String operator, JsonNode expected) {
+    // Arrange
+    ObjectNode select =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            IntNode.valueOf(1),
+            prepareCondition(columnName, value, operator));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()),
+        expected,
+        description(caseId, columnName, value, operator));
+  }
+
+  @Test
+  public void select_AdditionalNullConditionsGiven_ShouldSelectRecordsProperly()
+      throws ExecutionException, InterruptedException {
+    List<JsonNode> records = insertAndGetRecords();
+    ImmutableTable.Builder<Integer, String, JsonNode> caseBuilder = new ImmutableTable.Builder<>();
+    addTestCase(
+        caseBuilder,
+        1,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_7),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_IS_NULL),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(2))));
+    addTestCase(
+        caseBuilder,
+        2,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_7),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_IS_NOT_NULL),
+            KEY_EXPECTED, createArrayNode(records.get(1))));
+    addTestCase(
+        caseBuilder,
+        3,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_IS_NULL),
+            KEY_EXPECTED, createArrayNode()));
+    addTestCase(
+        caseBuilder,
+        4,
+        ImmutableMap.of(
+            KEY_COLUMN, TextNode.valueOf(COLUMN_NAME_3),
+            KEY_OPERATOR, TextNode.valueOf(Constants.OPERATOR_IS_NOT_NULL),
+            KEY_EXPECTED, createArrayNode(records.get(0), records.get(1), records.get(2))));
+
+    List<Callable<Void>> testCallables = new ArrayList<>();
+    caseBuilder
+        .build()
+        .rowMap()
+        .forEach(
+            (id, row) -> {
+              testCallables.add(
+                  () -> {
+                    select_AdditionalNullConditionsGiven_ShouldSelectSingleRecordProperly(
+                        id,
+                        row.get(KEY_COLUMN).asText(),
+                        row.get(KEY_OPERATOR).asText(),
+                        row.get(KEY_EXPECTED));
+                    return null;
+                  });
+            });
+
+    executeInParallel(testCallables);
+  }
+
+  private void select_AdditionalNullConditionsGiven_ShouldSelectSingleRecordProperly(
+      int caseId, String columnName, String operator, JsonNode expected) {
+    // Arrange
+    ObjectNode select =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            IntNode.valueOf(1),
+            prepareCondition(columnName, operator));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()),
+        expected,
+        description(caseId, columnName, NullNode.getInstance(), operator));
+  }
+
+  @Test
+  public void select_JoinsAndProjectionsGiven_ShouldSelectSingleRecordProperly() {
+    // Arrange
+    prepareJoinTables();
+    String columnReference1 = TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1;
+    String columnReference2 = TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2;
+    String columnReference3 = TABLE_NAME_2 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1;
+    String columnReference4 = TABLE_NAME_2 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2;
+    String columnReference5 = TABLE_ALIAS + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1;
+    String columnReference6 = TABLE_ALIAS + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2;
+    String columnReference7 = TABLE_ALIAS + Constants.COLUMN_SEPARATOR + COLUMN_NAME_3;
+    ObjectNode select =
+        prepareSelect(
+            TABLE_NAME_1,
+            columnReference2,
+            IntNode.valueOf(20250101),
+            prepareCondition(columnReference7, IntNode.valueOf(0), Constants.OPERATOR_EQ));
+    JsonNode joinTable2 =
+        prepareJoin(
+            TextNode.valueOf(TABLE_NAME_2),
+            TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_3,
+            TABLE_NAME_2 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1);
+    JsonNode table3 = prepareTableAlias(TABLE_NAME_3, TABLE_ALIAS);
+    JsonNode joinTable3 =
+        prepareJoin(
+            table3,
+            TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_4,
+            TABLE_ALIAS + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2);
+    select.set(Constants.QUERY_JOINS, createArrayNode(joinTable2, joinTable3));
+    select.set(
+        Constants.QUERY_PROJECTIONS,
+        createArrayNode(
+            TextNode.valueOf(columnReference1),
+            TextNode.valueOf(columnReference3),
+            TextNode.valueOf(columnReference4),
+            TextNode.valueOf(columnReference5),
+            TextNode.valueOf(columnReference6),
+            TextNode.valueOf(columnReference7)));
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(
+                columnReference1, IntNode.valueOf(1),
+                columnReference3, IntNode.valueOf(101),
+                columnReference4, IntNode.valueOf(0),
+                columnReference5, IntNode.valueOf(333),
+                columnReference6, IntNode.valueOf(300),
+                columnReference7, IntNode.valueOf(0)));
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(
+                columnReference1, IntNode.valueOf(1),
+                columnReference3, IntNode.valueOf(101),
+                columnReference4, IntNode.valueOf(0),
+                columnReference5, IntNode.valueOf(444),
+                columnReference6, IntNode.valueOf(300),
+                columnReference7, IntNode.valueOf(0)));
+    JsonNode record3 =
+        prepareRecord(
+            ImmutableMap.of(
+                columnReference1, IntNode.valueOf(2),
+                columnReference3, IntNode.valueOf(201),
+                columnReference4, IntNode.valueOf(1),
+                columnReference5, IntNode.valueOf(111),
+                columnReference6, IntNode.valueOf(400),
+                columnReference7, IntNode.valueOf(0)));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()),
+        ImmutableList.of(record1, record2, record3));
+  }
+
+  @Test
+  public void select_JoinOnDifferentKeyTypeGiven_ShouldNotReturnRecords() {
+    // Arrange
+    createTable(TABLE_NAME_1, COLUMN_NAME_1, KEY_TYPE_NUMBER, ImmutableMap.of());
+    clientService.executeContract(
+        CONTRACT_ID_INSERT,
+        prepareInsert(
+            TABLE_NAME_1,
+            prepareRecord(
+                ImmutableMap.of(
+                    COLUMN_NAME_1, IntNode.valueOf(1), COLUMN_NAME_2, IntNode.valueOf(1)))));
+    createTable(TABLE_NAME_2, COLUMN_NAME_1, KEY_TYPE_STRING, ImmutableMap.of());
+    clientService.executeContract(
+        CONTRACT_ID_INSERT,
+        prepareInsert(
+            TABLE_NAME_2,
+            prepareRecord(
+                ImmutableMap.of(
+                    COLUMN_NAME_1, TextNode.valueOf("1"), COLUMN_NAME_2, IntNode.valueOf(1)))));
+
+    String columnReference1 = TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1;
+    String columnReference2 = TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2;
+    String columnReference3 = TABLE_NAME_2 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1;
+    ObjectNode select = prepareSelect(TABLE_NAME_1, columnReference1, IntNode.valueOf(1));
+    JsonNode join = prepareJoin(TextNode.valueOf(TABLE_NAME_2), columnReference2, columnReference3);
+    select.set(Constants.QUERY_JOINS, createArrayNode(join));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()), ImmutableList.of());
+  }
+
+  @Test
+  public void
+      select_RecordsWithJsonObjectColumnAndNumericTypeConditionGiven_ShouldNotReturnRecords() {
+    // Arrange
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("aaa"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                mapper.createObjectNode()));
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(
+                COLUMN_NAME_1,
+                TextNode.valueOf("bbb"),
+                COLUMN_NAME_2,
+                IntNode.valueOf(1),
+                COLUMN_NAME_3,
+                mapper.createArrayNode()));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    JsonNode select =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            IntNode.valueOf(1),
+            prepareCondition(COLUMN_NAME_3, IntNode.valueOf(10), Constants.OPERATOR_NE));
+
+    // Act
+    ContractExecutionResult actual = clientService.executeContract(CONTRACT_ID_SELECT, select);
+
+    // Assert
+    assertThat(actual.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual.getContractResult().get()), ImmutableList.of());
+  }
+
+  @Test
+  public void select_JsonObjectTypeConditionsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode condition1 =
+        prepareCondition(COLUMN_NAME_3, mapper.createObjectNode(), Constants.OPERATOR_EQ);
+    JsonNode condition2 =
+        prepareCondition(COLUMN_NAME_3, mapper.createArrayNode(), Constants.OPERATOR_EQ);
+    JsonNode select1 =
+        prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, IntNode.valueOf(1), condition1);
+    JsonNode select2 =
+        prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, IntNode.valueOf(1), condition2);
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select1))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + condition1);
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select2))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.INVALID_CONDITION_FORMAT + condition2);
+  }
+
+  @Test
+  public void select_EqualButDifferentNumericTypePrimaryKeysGiven_ShouldReturnRecordProperly() {
+    // Arrange
+    createTable(TABLE_NAME_1, COLUMN_NAME_1, KEY_TYPE_NUMBER, ImmutableMap.of());
+    JsonNode oneInt = IntNode.valueOf(1);
+    JsonNode oneDouble = DoubleNode.valueOf(1.0);
+    JsonNode oneLong = LongNode.valueOf(1L);
+    JsonNode oneDecimal = DecimalNode.valueOf(new BigDecimal("1.000"));
+    JsonNode twoInt = IntNode.valueOf(2);
+    JsonNode twoDouble = DoubleNode.valueOf(2.0);
+    JsonNode twoLong = LongNode.valueOf(2L);
+    JsonNode twoDecimal = DecimalNode.valueOf(new BigDecimal("2.000"));
+    JsonNode recordOne = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, oneInt));
+    JsonNode recordTwo = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, twoDouble));
+    JsonNode selectOneByDouble = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, oneDouble);
+    JsonNode selectOneByLong = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, oneLong);
+    JsonNode selectOneByDecimal = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, oneDecimal);
+    JsonNode selectTwoByInt = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, twoInt);
+    JsonNode selectTwoByLong = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, twoLong);
+    JsonNode selectTwoByDecimal = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, twoDecimal);
+    ImmutableList<JsonNode> expectedOne = ImmutableList.of(recordOne);
+    ImmutableList<JsonNode> expectedTwo = ImmutableList.of(recordTwo);
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, recordOne));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(TABLE_NAME_1, recordTwo));
+
+    // Act
+    ContractExecutionResult actual1 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectOneByDouble);
+    ContractExecutionResult actual2 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectOneByLong);
+    ContractExecutionResult actual3 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectOneByDecimal);
+    ContractExecutionResult actual4 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectTwoByInt);
+    ContractExecutionResult actual5 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectTwoByLong);
+    ContractExecutionResult actual6 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectTwoByDecimal);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertThat(actual3.getContractResult()).isPresent();
+    assertThat(actual4.getContractResult()).isPresent();
+    assertThat(actual5.getContractResult()).isPresent();
+    assertThat(actual6.getContractResult()).isPresent();
+    assertSelectResult(jacksonSerDe.deserialize(actual1.getContractResult().get()), expectedOne);
+    assertSelectResult(jacksonSerDe.deserialize(actual2.getContractResult().get()), expectedOne);
+    assertSelectResult(jacksonSerDe.deserialize(actual3.getContractResult().get()), expectedOne);
+    assertSelectResult(jacksonSerDe.deserialize(actual4.getContractResult().get()), expectedTwo);
+    assertSelectResult(jacksonSerDe.deserialize(actual5.getContractResult().get()), expectedTwo);
+    assertSelectResult(jacksonSerDe.deserialize(actual6.getContractResult().get()), expectedTwo);
+  }
+
+  @Test
+  public void select_EqualButDifferentNumericTypeIndexValuesGiven_ShouldReturnRecordsProperly() {
+    // Arrange
+    JsonNode key1 = TextNode.valueOf("aaa");
+    JsonNode value1 = IntNode.valueOf(1);
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key1, COLUMN_NAME_2, value1));
+    JsonNode key2 = TextNode.valueOf("bbb");
+    JsonNode value2 = DoubleNode.valueOf(1.0);
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key2, COLUMN_NAME_2, value2));
+    JsonNode key3 = TextNode.valueOf("ccc");
+    JsonNode value3 = LongNode.valueOf(1L);
+    JsonNode record3 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key3, COLUMN_NAME_2, value3));
+    JsonNode key4 = TextNode.valueOf("ddd");
+    JsonNode value4 = DecimalNode.valueOf(new BigDecimal("1.000"));
+    JsonNode record4 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key4, COLUMN_NAME_2, value4));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record3));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record4));
+    JsonNode selectByInt = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value1);
+    JsonNode selectByDouble = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value2);
+    JsonNode selectByLong = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value3);
+    JsonNode selectByDecimal = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value4);
+    ImmutableList<JsonNode> expected =
+        ImmutableList.of(
+            record1,
+            record2,
+            prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key3, COLUMN_NAME_2, value1)),
+            prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key4, COLUMN_NAME_2, value2)));
+
+    // Act
+    ContractExecutionResult actual1 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByInt);
+    ContractExecutionResult actual2 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByDouble);
+    ContractExecutionResult actual3 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByLong);
+    ContractExecutionResult actual4 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByDecimal);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertThat(actual3.getContractResult()).isPresent();
+    assertThat(actual4.getContractResult()).isPresent();
+    assertSelectResult(jacksonSerDe.deserialize(actual1.getContractResult().get()), expected);
+    assertSelectResult(jacksonSerDe.deserialize(actual2.getContractResult().get()), expected);
+    assertSelectResult(jacksonSerDe.deserialize(actual3.getContractResult().get()), expected);
+    assertSelectResult(jacksonSerDe.deserialize(actual4.getContractResult().get()), expected);
+  }
+
+  @Test
+  public void select_HighPrecisionIndexValuesGiven_ShouldReturnRecordsWithLosingPrecision() {
+    // Arrange
+    JsonNode key1 = TextNode.valueOf("aaa");
+    JsonNode value1 = DoubleNode.valueOf(1.2345678901234567);
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key1, COLUMN_NAME_2, value1));
+    JsonNode key2 = TextNode.valueOf("bbb");
+    JsonNode value2 = DoubleNode.valueOf(1.2345678901234568);
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key2, COLUMN_NAME_2, value2));
+    JsonNode key3 = TextNode.valueOf("ccc");
+    JsonNode value3 = DecimalNode.valueOf(new BigDecimal("1.2345678901234567890123456789"));
+    JsonNode record3 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key3, COLUMN_NAME_2, value3));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record3));
+    JsonNode selectByDouble = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value1);
+    JsonNode selectByDecimal = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value3);
+    ImmutableList<JsonNode> expected =
+        ImmutableList.of(
+            record1,
+            record2,
+            prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key3, COLUMN_NAME_2, value1)));
+
+    // Act
+    ContractExecutionResult actual1 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByDouble);
+    ContractExecutionResult actual2 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByDecimal);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertSelectResult(jacksonSerDe.deserialize(actual1.getContractResult().get()), expected);
+    assertSelectResult(jacksonSerDe.deserialize(actual2.getContractResult().get()), expected);
+  }
+
+  @Test
+  public void select_MinAndMaxLongIndexValuesGiven_ShouldReturnRecordsProperly() {
+    // Arrange
+    JsonNode key1 = TextNode.valueOf("aaa");
+    JsonNode value1 = LongNode.valueOf(Long.MIN_VALUE);
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key1, COLUMN_NAME_2, value1));
+    JsonNode key2 = TextNode.valueOf("bbb");
+    JsonNode value2 = LongNode.valueOf(Long.MAX_VALUE);
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key2, COLUMN_NAME_2, value2));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    JsonNode selectByMin = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value1);
+    JsonNode selectByMax = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value2);
+
+    // Act
+    ContractExecutionResult actual1 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByMin);
+    ContractExecutionResult actual2 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByMax);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual1.getContractResult().get()), ImmutableList.of(record1));
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual2.getContractResult().get()), ImmutableList.of(record2));
+  }
+
+  @Test
+  public void select_BigIntegerIndexValuesGiven_ShouldReturnRecordsProperly() {
+    // Arrange
+    JsonNode key1 = TextNode.valueOf("aaa");
+    JsonNode value1 =
+        BigIntegerNode.valueOf(BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN));
+    JsonNode record1 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key1, COLUMN_NAME_2, value1));
+    JsonNode key2 = TextNode.valueOf("bbb");
+    JsonNode value2 =
+        BigIntegerNode.valueOf(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN));
+    JsonNode record2 = prepareRecord(ImmutableMap.of(COLUMN_NAME_1, key2, COLUMN_NAME_2, value2));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    JsonNode selectByNegative = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value1);
+    JsonNode selectByPositive = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, value2);
+
+    // Act
+    ContractExecutionResult actual1 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByNegative);
+    ContractExecutionResult actual2 =
+        clientService.executeContract(CONTRACT_ID_SELECT, selectByPositive);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual1.getContractResult().get()), ImmutableList.of(record1));
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual2.getContractResult().get()), ImmutableList.of(record2));
+  }
+
+  @Test
+  public void select_ConditionWithMaxLongValuesGiven_ShouldReturnRecordsWithoutLosingPrecision() {
+    // Arrange
+    JsonNode indexValue = IntNode.valueOf(1);
+    JsonNode key1 = TextNode.valueOf("aaa");
+    JsonNode value1 = LongNode.valueOf(Long.MAX_VALUE);
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(COLUMN_NAME_1, key1, COLUMN_NAME_2, indexValue, COLUMN_NAME_3, value1));
+    JsonNode key2 = TextNode.valueOf("bbb");
+    JsonNode value2 = LongNode.valueOf(Long.MAX_VALUE - 1);
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(COLUMN_NAME_1, key2, COLUMN_NAME_2, indexValue, COLUMN_NAME_3, value2));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    JsonNode selectEq =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            indexValue,
+            prepareCondition(COLUMN_NAME_3, value1, Constants.OPERATOR_EQ));
+    JsonNode selectNe =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            indexValue,
+            prepareCondition(COLUMN_NAME_3, value1, Constants.OPERATOR_NE));
+
+    // Act
+    ContractExecutionResult actual1 = clientService.executeContract(CONTRACT_ID_SELECT, selectEq);
+    ContractExecutionResult actual2 = clientService.executeContract(CONTRACT_ID_SELECT, selectNe);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual1.getContractResult().get()), ImmutableList.of(record1));
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual2.getContractResult().get()), ImmutableList.of(record2));
+  }
+
+  @Test
+  public void
+      select_ConditionWithBigIntegerValuesGiven_ShouldReturnRecordsWithoutLosingPrecision() {
+    // Arrange
+    JsonNode indexValue = IntNode.valueOf(1);
+    JsonNode key1 = TextNode.valueOf("aaa");
+    JsonNode value1 =
+        BigIntegerNode.valueOf(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN));
+    JsonNode record1 =
+        prepareRecord(
+            ImmutableMap.of(COLUMN_NAME_1, key1, COLUMN_NAME_2, indexValue, COLUMN_NAME_3, value1));
+    JsonNode key2 = TextNode.valueOf("bbb");
+    JsonNode value2 =
+        BigIntegerNode.valueOf(
+            BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN).add(BigInteger.ONE));
+    JsonNode record2 =
+        prepareRecord(
+            ImmutableMap.of(COLUMN_NAME_1, key2, COLUMN_NAME_2, indexValue, COLUMN_NAME_3, value2));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record1));
+    clientService.executeContract(CONTRACT_ID_INSERT, prepareInsert(COMMON_TEST_TABLE, record2));
+    JsonNode selectEq =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            indexValue,
+            prepareCondition(COLUMN_NAME_3, value1, Constants.OPERATOR_EQ));
+    JsonNode selectNe =
+        prepareSelect(
+            COMMON_TEST_TABLE,
+            COLUMN_NAME_2,
+            indexValue,
+            prepareCondition(COLUMN_NAME_3, value1, Constants.OPERATOR_NE));
+
+    // Act
+    ContractExecutionResult actual1 = clientService.executeContract(CONTRACT_ID_SELECT, selectEq);
+    ContractExecutionResult actual2 = clientService.executeContract(CONTRACT_ID_SELECT, selectNe);
+
+    // Assert
+    assertThat(actual1.getContractResult()).isPresent();
+    assertThat(actual2.getContractResult()).isPresent();
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual1.getContractResult().get()), ImmutableList.of(record1));
+    assertSelectResult(
+        jacksonSerDe.deserialize(actual2.getContractResult().get()), ImmutableList.of(record2));
+  }
+
+  @Test
+  public void select_NonExistingTableGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode select = prepareSelect(TABLE_NAME_1, COLUMN_NAME_1, IntNode.valueOf(1));
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.TABLE_NOT_EXIST);
+  }
+
+  @Test
+  public void select_DifferentTypeKeyConditionGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode select = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_1, IntNode.valueOf(1));
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.INVALID_KEY_TYPE);
+  }
+
+  @Test
+  public void select_DifferentTypeIndexConditionGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode select = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_2, TextNode.valueOf("a"));
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.INVALID_INDEX_KEY_TYPE);
+  }
+
+  @Test
+  public void select_WithoutKeyConditionsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode select = prepareSelect(COMMON_TEST_TABLE, COLUMN_NAME_3, IntNode.valueOf(1));
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.INVALID_KEY_SPECIFICATION);
+  }
+
+  @Test
+  public void select_JoinOnNonKeyRightColumnGiven_ShouldThrowContractContextException() {
+    // Arrange
+    createTable(TABLE_NAME_1, COLUMN_NAME_1, KEY_TYPE_NUMBER, ImmutableMap.of());
+    clientService.executeContract(
+        CONTRACT_ID_INSERT,
+        prepareInsert(
+            TABLE_NAME_1,
+            prepareRecord(
+                ImmutableMap.of(
+                    COLUMN_NAME_1, IntNode.valueOf(1), COLUMN_NAME_2, IntNode.valueOf(1)))));
+    createTable(TABLE_NAME_2, COLUMN_NAME_1, KEY_TYPE_STRING, ImmutableMap.of());
+
+    String columnReference1 = TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_1;
+    String columnReference2 = TABLE_NAME_1 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2;
+    String columnReference3 = TABLE_NAME_2 + Constants.COLUMN_SEPARATOR + COLUMN_NAME_2;
+    ObjectNode select = prepareSelect(TABLE_NAME_1, columnReference1, IntNode.valueOf(1));
+    JsonNode join = prepareJoin(TextNode.valueOf(TABLE_NAME_2), columnReference2, columnReference3);
+    select.set(Constants.QUERY_JOINS, createArrayNode(join));
+
+    // Act Assert
+    assertThatThrownBy(() -> clientService.executeContract(CONTRACT_ID_SELECT, select))
+        .isExactlyInstanceOf(ClientException.class)
+        .hasMessage(Constants.INVALID_JOIN_COLUMN + COLUMN_NAME_2);
+  }
+}

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Create.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Create.java
@@ -3,6 +3,7 @@ package com.scalar.dl.genericcontracts.table.v1_0_0;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.scalar.dl.ledger.contract.JacksonBasedContract;
 import com.scalar.dl.ledger.exception.ContractContextException;
 import com.scalar.dl.ledger.statemachine.Asset;
@@ -38,7 +39,7 @@ public class Create extends JacksonBasedContract {
     }
 
     // Get the table existence
-    String assetId = getAssetIdForTable(arguments.get(Constants.TABLE_NAME).asText());
+    String assetId = getAssetIdForTable(ledger, arguments.get(Constants.TABLE_NAME).asText());
     Optional<Asset<JsonNode>> asset = ledger.get(assetId);
     if (asset.isPresent()) {
       throw new ContractContextException(Constants.TABLE_ALREADY_EXISTS);
@@ -88,7 +89,13 @@ public class Create extends JacksonBasedContract {
     }
   }
 
-  private String getAssetIdForTable(String tableName) {
-    return Constants.PREFIX_TABLE + tableName;
+  @VisibleForTesting
+  String getAssetIdForTable(Ledger<JsonNode> ledger, String tableName) {
+    JsonNode arguments =
+        getObjectMapper()
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_TABLE)
+            .set(Constants.ASSET_ID_VALUES, getObjectMapper().createArrayNode().add(tableName));
+    return invoke(Constants.CONTRACT_GET_ASSET_ID, ledger, arguments).asText();
   }
 }

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetAssetId.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetAssetId.java
@@ -1,0 +1,90 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import javax.annotation.Nullable;
+
+public class GetAssetId extends JacksonBasedContract {
+
+  /**
+   * Returns the asset ID based on the specified asset type (prefix) and values. Specify the values
+   * as an array of {@code JsonNode}. For the table asset, only include a {@code TextNode} of the
+   * table name in the array. For the record and index asset, include a {@code TextNode} of the
+   * table name, a {@code TextNode} of the primary or index key column name, and a {@code JsonNode}
+   * of the key column value.
+   *
+   * @param ledger ledger
+   * @param arguments contract argument that includes the asset ID prefix and values
+   * @param properties pre-registered contract properties
+   * @return {@code TextNode}
+   */
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+    String prefix = arguments.get(Constants.ASSET_ID_PREFIX).asText();
+    ArrayNode values = (ArrayNode) arguments.get(Constants.ASSET_ID_VALUES);
+    return TextNode.valueOf(getAssetId(prefix, values));
+  }
+
+  private String getAssetId(String prefix, ArrayNode values) {
+    switch (prefix) {
+      case Constants.PREFIX_TABLE:
+        return getAssetIdForTable(values.get(0).asText());
+      case Constants.PREFIX_RECORD:
+        return getAssetIdForRecord(values.get(0).asText(), values.get(1).asText(), values.get(2));
+      case Constants.PREFIX_INDEX:
+        if (values.get(2).isNull()) {
+          return getAssetIdForNullIndex(values.get(0).asText(), values.get(1).asText());
+        } else {
+          return getAssetIdForIndex(values.get(0).asText(), values.get(1).asText(), values.get(2));
+        }
+      default:
+        throw new ContractContextException(Constants.ILLEGAL_ARGUMENT);
+    }
+  }
+
+  @VisibleForTesting
+  static String getAssetIdForTable(String tableName) {
+    return Constants.PREFIX_TABLE + tableName;
+  }
+
+  @VisibleForTesting
+  static String getAssetIdForRecord(String tableName, String primaryKey, JsonNode value) {
+    return Constants.PREFIX_RECORD
+        + tableName
+        + Constants.ASSET_ID_SEPARATOR
+        + primaryKey
+        + Constants.ASSET_ID_SEPARATOR
+        + toStringFrom(value);
+  }
+
+  @VisibleForTesting
+  static String getAssetIdForIndex(String tableName, String indexKey, JsonNode value) {
+    return Constants.PREFIX_INDEX
+        + tableName
+        + Constants.ASSET_ID_SEPARATOR
+        + indexKey
+        + Constants.ASSET_ID_SEPARATOR
+        + toStringFrom(value);
+  }
+
+  @VisibleForTesting
+  static String getAssetIdForNullIndex(String tableName, String indexKey) {
+    return Constants.PREFIX_INDEX + tableName + Constants.ASSET_ID_SEPARATOR + indexKey;
+  }
+
+  private static String toStringFrom(JsonNode value) {
+    if (value.canConvertToExactIntegral()) {
+      return value.bigIntegerValue().toString();
+    } else if (value.isNumber()) {
+      return value.decimalValue().toString();
+    } else {
+      return value.asText();
+    }
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/CreateTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/CreateTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 public class CreateTest {
 
@@ -42,8 +44,7 @@ public class CreateTest {
           .add(createIndexNode(SOME_INDEX_KEY_1, SOME_KEY_TYPE_BOOLEAN))
           .add(createIndexNode(SOME_INDEX_KEY_2, SOME_KEY_TYPE_NUMBER));
 
-  private final Create create = new Create();
-
+  @Spy private final Create create = new Create();
   @Mock private Ledger<JsonNode> ledger;
 
   @BeforeEach
@@ -68,6 +69,9 @@ public class CreateTest {
             .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
             .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
             .set(Constants.TABLE_INDEXES, SOME_INDEXES);
+    doReturn(GetAssetId.getAssetIdForTable(SOME_TABLE_NAME))
+        .when(create)
+        .getAssetIdForTable(ledger, SOME_TABLE_NAME);
     when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.empty());
 
     // Act
@@ -91,6 +95,9 @@ public class CreateTest {
             .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
     ObjectNode expected = argument.deepCopy();
     expected.set(Constants.TABLE_INDEXES, mapper.createArrayNode());
+    doReturn(GetAssetId.getAssetIdForTable(SOME_TABLE_NAME))
+        .when(create)
+        .getAssetIdForTable(ledger, SOME_TABLE_NAME);
     when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.empty());
 
     // Act
@@ -351,6 +358,9 @@ public class CreateTest {
             .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
             .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
     Asset<JsonNode> asset = (Asset<JsonNode>) mock(Asset.class);
+    doReturn(GetAssetId.getAssetIdForTable(SOME_TABLE_NAME))
+        .when(create)
+        .getAssetIdForTable(ledger, SOME_TABLE_NAME);
     when(ledger.get(SOME_TABLE_ASSET_ID)).thenReturn(Optional.of(asset));
 
     // Act Assert

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetAssetIdTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetAssetIdTest.java
@@ -1,0 +1,220 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.math.BigInteger;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class GetAssetIdTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final TextNode SOME_TABLE = TextNode.valueOf("table");
+  private static final TextNode SOME_KEY = TextNode.valueOf("key");
+  private static final TextNode SOME_VALUE_TEXT = TextNode.valueOf("value");
+  private static final DoubleNode SOME_VALUE_DOUBLE = DoubleNode.valueOf(1.23);
+  private static final DoubleNode SOME_VALUE_DOUBLE_INT = DoubleNode.valueOf(1.0);
+  private static final BigIntegerNode SOME_VALUE_BIG_INTEGER =
+      BigIntegerNode.valueOf(BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.TEN));
+
+  private final GetAssetId getAssetId = new GetAssetId();
+
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private ArrayNode createArrayNode(JsonNode... jsonNodes) {
+    ArrayNode result = mapper.createArrayNode();
+    Arrays.stream(jsonNodes).forEach(result::add);
+    return result;
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForTableGiven_ShouldReturnTableAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_TABLE)
+            .set(Constants.ASSET_ID_VALUES, createArrayNode(SOME_TABLE));
+    String expected = Constants.PREFIX_TABLE + SOME_TABLE.asText();
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForRecordGiven_ShouldReturnRecordAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_RECORD)
+            .set(Constants.ASSET_ID_VALUES, createArrayNode(SOME_TABLE, SOME_KEY, SOME_VALUE_TEXT));
+    String expected =
+        Constants.PREFIX_RECORD
+            + SOME_TABLE.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_KEY.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_VALUE_TEXT.asText();
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForRecordWithBigIntegerKeyGiven_ShouldReturnRecordAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_RECORD)
+            .set(
+                Constants.ASSET_ID_VALUES,
+                createArrayNode(SOME_TABLE, SOME_KEY, SOME_VALUE_BIG_INTEGER));
+    String expected =
+        Constants.PREFIX_RECORD
+            + SOME_TABLE.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_KEY.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + Long.MIN_VALUE
+            + "0";
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForTextIndexValueGiven_ShouldReturnIndexAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_INDEX)
+            .set(Constants.ASSET_ID_VALUES, createArrayNode(SOME_TABLE, SOME_KEY, SOME_VALUE_TEXT));
+    String expected =
+        Constants.PREFIX_INDEX
+            + SOME_TABLE.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_KEY.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_VALUE_TEXT.asText();
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForDoubleIndexValueGiven_ShouldReturnIndexAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_INDEX)
+            .set(
+                Constants.ASSET_ID_VALUES,
+                createArrayNode(SOME_TABLE, SOME_KEY, SOME_VALUE_DOUBLE));
+    String expected =
+        Constants.PREFIX_INDEX
+            + SOME_TABLE.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_KEY.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_VALUE_DOUBLE.asText();
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForDoubleIntIndexValueGiven_ShouldReturnIndexAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_INDEX)
+            .set(
+                Constants.ASSET_ID_VALUES,
+                createArrayNode(SOME_TABLE, SOME_KEY, SOME_VALUE_DOUBLE_INT));
+    String expected =
+        Constants.PREFIX_INDEX
+            + SOME_TABLE.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_KEY.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_VALUE_DOUBLE.asInt();
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsForNullIndexValueGiven_ShouldReturnNullIndexAssetId() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, Constants.PREFIX_INDEX)
+            .set(
+                Constants.ASSET_ID_VALUES,
+                createArrayNode(SOME_TABLE, SOME_KEY, NullNode.getInstance()));
+    String expected =
+        Constants.PREFIX_INDEX
+            + SOME_TABLE.asText()
+            + Constants.ASSET_ID_SEPARATOR
+            + SOME_KEY.asText();
+
+    // Act
+    JsonNode actual = getAssetId.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isNotNull();
+    assertThat(actual.isTextual()).isTrue();
+    assertThat(actual.textValue()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes numeric value handling when converting the value into the asset ID and adds e2e integration tests for table-based generic contracts with some refactoring. Previously, we converted primary or index key values into the asset IDs by simply calling `asText()`. However, it causes problems for floating point numbers that can be converted to integers (e.g., `1.0`, `2.0`, ...) since we would like to handle them the same as integers `1` and `3`. So, this PR changes to convert them in a unified manner in the newly introduced contract `GetAssetId`.

## Related issues and/or PRs

N/A

## Changes made

- Fix numeric value handling when converting the value into the asset ID
- Introduce the GetAssetId contract to standardize the conversion
- Added integration tests for table-based generic contracts

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed numeric value handling in table-based generic contracts.