### PR TITLE
Fix JVM buffer sizes for Cosmos DB integeration tests

### DIFF
--- a/.github/workflows/storage-compatibility-check.yaml
+++ b/.github/workflows/storage-compatibility-check.yaml
@@ -101,7 +101,8 @@ jobs:
       - name: Run integration tests
         working-directory: ledger
         run: |
-          java -cp "build/test-libs/*;build/libs/*;build/classes/java/integrationTest" `
+          java -Xmx6g -XX:MaxDirectMemorySize=4g `
+          -cp "build/test-libs/*;build/libs/*;build/classes/java/integrationTest" `
           "-Dscalardb.storage=cosmos" `
           "-Dscalardb.contact_points=https://localhost:8081/" `
           "-Dscalardb.password=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" `

--- a/.github/workflows/storage-compatibility-check.yaml
+++ b/.github/workflows/storage-compatibility-check.yaml
@@ -100,6 +100,9 @@ jobs:
       # due to a gradle bug we must run the integration test separately
       - name: Run integration tests
         working-directory: ledger
+        # The heap size (-Xmx6g) and direct memory size (-XX:MaxDirectMemorySize=4g) were chosen
+        # to handle high memory demands of the Cosmos DB emulator during integration tests,
+        # ensuring stability and avoiding out-of-memory errors.
         run: |
           java -Xmx6g -XX:MaxDirectMemorySize=4g `
           -cp "build/test-libs/*;build/libs/*;build/classes/java/integrationTest" `


### PR DESCRIPTION
## Description

This PR fixes JVM buffer size configurations for Cosmos DB integration tests since [they were flaky recently](https://github.com/scalar-labs/scalardl/actions/workflows/scheduled-storage-compatibility-check.yaml) due to OoM errors. I followed the parameters in ScalarDB.

## Related issues and/or PRs

- scalar-labs/scalardb#1851

## Changes made

- Change heap size and direct buffer size

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes. [Done using a manual trigger](https://github.com/scalar-labs/scalardl/actions/workflows/manual-storage-compatibility-check.yaml)
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
