### PR TITLE
Add utility contracts for table-oriented generic contracts

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
   public static final String INDEX_ASSET_ADDED_AGE = "age";
   public static final String INDEX_ASSET_DELETE_MARKER = "deleted";
   public static final String RECORD_TABLE = "table";
+  public static final String RECORD_KEY = "key";
   public static final String RECORD_VALUES = "values";
   public static final String QUERY_TABLE = "table";
   public static final String QUERY_JOINS = "joins";
@@ -38,6 +39,8 @@ public class Constants {
   public static final String UPDATE_TABLE = "table";
   public static final String UPDATE_VALUES = "values";
   public static final String UPDATE_CONDITIONS = "conditions";
+  public static final String HISTORY_LIMIT = "limit";
+  public static final String HISTORY_ASSET_AGE = "age";
   public static final String ALIAS_NAME = "name";
   public static final String ALIAS_AS = "alias";
   public static final String CONDITION_COLUMN = "column";
@@ -63,6 +66,8 @@ public class Constants {
       Pattern.compile(OBJECT_NAME_PATTERN + "\\." + OBJECT_NAME_PATTERN);
 
   // Error messages
+  public static final String INVALID_CONTRACT_ARGUMENTS =
+      "The specified format of the contract arguments is invalid.";
   public static final String INVALID_TABLE_FORMAT = "The specified format of the table is invalid.";
   public static final String INVALID_INDEX_FORMAT =
       "The specified format of the indexes is invalid.";

--- a/generic-contracts/conf/table-authenticity-management-contracts.toml
+++ b/generic-contracts/conf/table-authenticity-management-contracts.toml
@@ -19,6 +19,16 @@ contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.Update"
 contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/Update.class"
 
 [[contracts]]
+contract-id = "table.v1_0_0.ShowTables"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.ShowTables"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/ShowTables.class"
+
+[[contracts]]
+contract-id = "table.v1_0_0.GetHistory"
+contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.GetHistory"
+contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/GetHistory.class"
+
+[[contracts]]
 contract-id = "table.v1_0_0.GetAssetId"
 contract-binary-name = "com.scalar.dl.genericcontracts.table.v1_0_0.GetAssetId"
 contract-class-file = "generic-contracts/build/classes/java/main/com/scalar/dl/genericcontracts/table/v1_0_0/GetAssetId.class"

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetHistory.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetHistory.java
@@ -1,0 +1,87 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.database.AssetFilter;
+import com.scalar.dl.ledger.database.AssetFilter.AgeOrder;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Arrays;
+import javax.annotation.Nullable;
+
+public class GetHistory extends JacksonBasedContract {
+
+  @Nullable
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+
+    // Check the arguments
+    if (arguments.size() < 2
+        || arguments.size() > 3
+        || !arguments.has(Constants.RECORD_TABLE)
+        || !arguments.get(Constants.RECORD_TABLE).isTextual()
+        || !arguments.has(Constants.RECORD_KEY)) {
+      throw new ContractContextException(Constants.INVALID_CONTRACT_ARGUMENTS);
+    }
+
+    // Get the table metadata
+    JsonNode tableName = arguments.get(Constants.RECORD_TABLE);
+    JsonNode table =
+        ledger
+            .get(getAssetId(ledger, Constants.PREFIX_TABLE, tableName))
+            .orElseThrow(() -> new ContractContextException(Constants.TABLE_NOT_EXIST))
+            .data();
+
+    // Check the key type
+    JsonNode keyColumn = table.get(Constants.TABLE_KEY);
+    JsonNode keyValue = arguments.get(Constants.RECORD_KEY);
+    String keyType = table.get(Constants.TABLE_KEY_TYPE).asText();
+    if (!keyType.toUpperCase().equals(keyValue.getNodeType().name())) {
+      throw new ContractContextException(Constants.INVALID_KEY_TYPE);
+    }
+
+    // Prepare scan for the asset of the record
+    String recordAssetId =
+        getAssetId(ledger, Constants.PREFIX_RECORD, tableName, keyColumn, keyValue);
+    AssetFilter filter = new AssetFilter(recordAssetId).withAgeOrder(AgeOrder.DESC);
+    if (arguments.has(Constants.HISTORY_LIMIT)) {
+      filter.withLimit(validateAndGetLimit(arguments.get(Constants.HISTORY_LIMIT)));
+    }
+
+    // Get history of the record
+    ArrayNode history = getObjectMapper().createArrayNode();
+    ledger
+        .scan(filter)
+        .forEach(
+            asset ->
+                history.add(
+                    getObjectMapper()
+                        .createObjectNode()
+                        .put(Constants.HISTORY_ASSET_AGE, asset.age())
+                        .set(Constants.RECORD_VALUES, asset.data())));
+
+    return history;
+  }
+
+  private Integer validateAndGetLimit(JsonNode limit) {
+    if (!limit.isInt() || limit.asInt() < 0) {
+      throw new ContractContextException(Constants.INVALID_CONTRACT_ARGUMENTS);
+    }
+    return limit.asInt();
+  }
+
+  @VisibleForTesting
+  String getAssetId(Ledger<JsonNode> ledger, String prefix, JsonNode... jsonNodes) {
+    ArrayNode values = getObjectMapper().createArrayNode();
+    Arrays.stream(jsonNodes).forEach(values::add);
+    JsonNode arguments =
+        getObjectMapper()
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, prefix)
+            .set(Constants.ASSET_ID_VALUES, values);
+    return invoke(Constants.CONTRACT_GET_ASSET_ID, ledger, arguments).asText();
+  }
+}

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/ShowTables.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/ShowTables.java
@@ -1,0 +1,64 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.scalar.dl.ledger.contract.JacksonBasedContract;
+import com.scalar.dl.ledger.database.AssetFilter;
+import com.scalar.dl.ledger.database.AssetFilter.AgeOrder;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class ShowTables extends JacksonBasedContract {
+
+  @Override
+  public JsonNode invoke(
+      Ledger<JsonNode> ledger, JsonNode arguments, @Nullable JsonNode properties) {
+
+    if (!arguments.isEmpty() && arguments.size() != 1) {
+      throw new ContractContextException(Constants.INVALID_CONTRACT_ARGUMENTS);
+    }
+
+    if (arguments.size() == 1 && !arguments.has(Constants.TABLE_NAME)) {
+      throw new ContractContextException(Constants.INVALID_CONTRACT_ARGUMENTS);
+    }
+
+    ArrayNode tables = getObjectMapper().createArrayNode();
+    if (arguments.has(Constants.TABLE_NAME)) {
+      if (!arguments.get(Constants.TABLE_NAME).isTextual()) {
+        throw new ContractContextException(Constants.INVALID_CONTRACT_ARGUMENTS);
+      }
+
+      String assetId =
+          getAssetId(ledger, Constants.PREFIX_TABLE, arguments.get(Constants.TABLE_NAME));
+      Asset<JsonNode> table =
+          ledger
+              .get(assetId)
+              .orElseThrow(() -> new ContractContextException(Constants.TABLE_NOT_EXIST));
+      tables.add(table.data());
+    } else {
+      AssetFilter filter = new AssetFilter(Constants.ASSET_ID_METADATA_TABLES);
+      filter.withAgeOrder(AgeOrder.ASC);
+      List<Asset<JsonNode>> results = ledger.scan(filter);
+      results.forEach(asset -> tables.add(asset.data()));
+    }
+
+    return tables;
+  }
+
+  @VisibleForTesting
+  String getAssetId(Ledger<JsonNode> ledger, String prefix, JsonNode... jsonNodes) {
+    ArrayNode values = getObjectMapper().createArrayNode();
+    Arrays.stream(jsonNodes).forEach(values::add);
+    JsonNode arguments =
+        getObjectMapper()
+            .createObjectNode()
+            .put(Constants.ASSET_ID_PREFIX, prefix)
+            .set(Constants.ASSET_ID_VALUES, values);
+    return invoke(Constants.CONTRACT_GET_ASSET_ID, ledger, arguments).asText();
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetHistoryTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/GetHistoryTest.java
@@ -1,0 +1,257 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import com.scalar.dl.ledger.database.AssetFilter;
+import com.scalar.dl.ledger.database.AssetFilter.AgeOrder;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class GetHistoryTest {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String SOME_TABLE_NAME = "tbl1";
+  private static final String SOME_TABLE_KEY = "key";
+  private static final String SOME_RECORD_KEY_VALUE = "key1";
+  private static final String SOME_COLUMN = "column";
+  private static final String SOME_COLUMN_VALUE_1 = "value1";
+  private static final String SOME_COLUMN_VALUE_2 = "value2";
+  private static final String SOME_INVALID_FIELD = "filed";
+  private static final String SOME_INVALID_VALUE = "value";
+  private static final String SOME_KEY_TYPE_STRING = "string";
+  private static final int SOME_LIMIT = 2;
+  private static final JsonNode SOME_TABLE = createTable(SOME_TABLE_NAME);
+
+  @Spy private final GetHistory getHistory = new GetHistory();
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private static JsonNode createTable(String tableName) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.TABLE_NAME, tableName)
+        .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+        .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING);
+  }
+
+  private String prepareTableAssetId(String tableName) {
+    String assetId = GetAssetId.getAssetIdForTable(tableName);
+    doReturn(assetId)
+        .when(getHistory)
+        .getAssetId(ledger, Constants.PREFIX_TABLE, TextNode.valueOf(tableName));
+    return assetId;
+  }
+
+  private String prepareRecordAssetId(String tableName, String key, JsonNode value) {
+    String assetId = GetAssetId.getAssetIdForRecord(tableName, key, value);
+    doReturn(assetId)
+        .when(getHistory)
+        .getAssetId(
+            ledger,
+            Constants.PREFIX_RECORD,
+            TextNode.valueOf(tableName),
+            TextNode.valueOf(key),
+            value);
+    return assetId;
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsGiven_ShouldShowSingleTable() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE)
+            .put(Constants.HISTORY_LIMIT, SOME_LIMIT);
+    String recordAssetId =
+        prepareRecordAssetId(
+            SOME_TABLE_NAME, SOME_TABLE_KEY, TextNode.valueOf(SOME_RECORD_KEY_VALUE));
+    AssetFilter filter = new AssetFilter(recordAssetId);
+    filter.withAgeOrder(AgeOrder.DESC);
+    filter.withLimit(SOME_LIMIT);
+    JsonNode record1 =
+        mapper
+            .createObjectNode()
+            .put(SOME_TABLE_KEY, SOME_RECORD_KEY_VALUE)
+            .put(SOME_COLUMN, SOME_COLUMN_VALUE_1);
+    JsonNode record2 =
+        mapper
+            .createObjectNode()
+            .put(SOME_TABLE_KEY, SOME_RECORD_KEY_VALUE)
+            .put(SOME_COLUMN, SOME_COLUMN_VALUE_2);
+    Asset<JsonNode> assetRecord1 = (Asset<JsonNode>) mock(Asset.class);
+    Asset<JsonNode> assetRecord2 = (Asset<JsonNode>) mock(Asset.class);
+    when(assetRecord1.data()).thenReturn(record1);
+    when(assetRecord2.data()).thenReturn(record2);
+    when(assetRecord1.age()).thenReturn(0);
+    when(assetRecord2.age()).thenReturn(1);
+    when(ledger.scan(filter)).thenReturn(ImmutableList.of(assetRecord2, assetRecord1));
+    String tableAssetId = prepareTableAssetId(SOME_TABLE_NAME);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(tableAssetId)).thenReturn(Optional.of(tableAsset));
+    JsonNode expected =
+        mapper
+            .createArrayNode()
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.HISTORY_ASSET_AGE, 1)
+                    .set(Constants.RECORD_VALUES, record2))
+            .add(
+                mapper
+                    .createObjectNode()
+                    .put(Constants.HISTORY_ASSET_AGE, 0)
+                    .set(Constants.RECORD_VALUES, record1));
+
+    // Act
+    JsonNode actual = getHistory.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+    verify(ledger).get(tableAssetId);
+    verify(ledger).scan(filter);
+  }
+
+  @Test
+  public void invoke_InvalidArgumentsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument1 = mapper.createObjectNode().put(Constants.RECORD_TABLE, SOME_TABLE_NAME);
+    JsonNode argument2 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE)
+            .put(Constants.RECORD_VALUES, SOME_INVALID_VALUE)
+            .put(SOME_INVALID_FIELD, SOME_INVALID_VALUE);
+    JsonNode argument3 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE)
+            .put(Constants.HISTORY_LIMIT, 0);
+    JsonNode argument4 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, 0)
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE);
+    JsonNode argument5 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.HISTORY_LIMIT, 10);
+
+    // Act Assert
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument4, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument5, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    verify(ledger, never()).get(any());
+    verify(ledger, never()).scan(any());
+  }
+
+  @Test
+  public void invoke_InvalidKeyTypeGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_KEY, 1);
+    String tableAssetId = prepareTableAssetId(SOME_TABLE_NAME);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(tableAssetId)).thenReturn(Optional.of(tableAsset));
+
+    // Act Assert
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_KEY_TYPE);
+    verify(ledger).get(tableAssetId);
+    verify(ledger, never()).scan(any());
+  }
+
+  @Test
+  public void invoke_InvalidLimitGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument1 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE)
+            .put(Constants.HISTORY_LIMIT, 1.23);
+    JsonNode argument2 =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE)
+            .put(Constants.HISTORY_LIMIT, -1);
+    String tableAssetId = prepareTableAssetId(SOME_TABLE_NAME);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE);
+    when(ledger.get(tableAssetId)).thenReturn(Optional.of(tableAsset));
+    prepareRecordAssetId(SOME_TABLE_NAME, SOME_TABLE_KEY, TextNode.valueOf(SOME_RECORD_KEY_VALUE));
+
+    // Act Assert
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    verify(ledger, times(2)).get(tableAssetId);
+    verify(ledger, never()).scan(any());
+  }
+
+  @Test
+  public void invoke_NonExistingTableGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument =
+        mapper
+            .createObjectNode()
+            .put(Constants.RECORD_TABLE, SOME_TABLE_NAME)
+            .put(Constants.RECORD_KEY, SOME_RECORD_KEY_VALUE);
+    String tableAssetId = prepareTableAssetId(SOME_TABLE_NAME);
+    when(ledger.get(tableAssetId)).thenReturn(Optional.empty());
+
+    // Act Assert
+    assertThatThrownBy(() -> getHistory.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.TABLE_NOT_EXIST);
+    verify(ledger).get(tableAssetId);
+  }
+}

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/ShowTablesTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/table/v1_0_0/ShowTablesTest.java
@@ -1,0 +1,156 @@
+package com.scalar.dl.genericcontracts.table.v1_0_0;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import com.scalar.dl.ledger.database.AssetFilter;
+import com.scalar.dl.ledger.database.AssetFilter.AgeOrder;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.statemachine.Asset;
+import com.scalar.dl.ledger.statemachine.Ledger;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+public class ShowTablesTest {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String SOME_TABLE_NAME_1 = "tbl1";
+  private static final String SOME_TABLE_NAME_2 = "tbl1";
+  private static final String SOME_TABLE_KEY = "key";
+  private static final String SOME_KEY_TYPE_STRING = "string";
+  private static final String SOME_INDEX_KEY_1 = "key1";
+  private static final String SOME_INDEX_KEY_2 = "key2";
+  private static final JsonNode SOME_TABLE_1 = createTable(SOME_TABLE_NAME_1);
+  private static final JsonNode SOME_TABLE_2 = createTable(SOME_TABLE_NAME_2);
+
+  @Spy private final ShowTables showTables = new ShowTables();
+  @Mock private Ledger<JsonNode> ledger;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+  }
+
+  private static JsonNode createIndexNode(String key, String type) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.INDEX_KEY, key)
+        .put(Constants.INDEX_KEY_TYPE, type);
+  }
+
+  private static JsonNode createTable(String tableName) {
+    return mapper
+        .createObjectNode()
+        .put(Constants.TABLE_NAME, tableName)
+        .put(Constants.TABLE_KEY, SOME_TABLE_KEY)
+        .put(Constants.TABLE_KEY_TYPE, SOME_KEY_TYPE_STRING)
+        .set(
+            Constants.TABLE_INDEXES,
+            mapper
+                .createArrayNode()
+                .add(createIndexNode(SOME_INDEX_KEY_1, SOME_KEY_TYPE_STRING))
+                .add(createIndexNode(SOME_INDEX_KEY_2, SOME_KEY_TYPE_STRING)));
+  }
+
+  private String prepareTableAssetId(String tableName) {
+    String assetId = GetAssetId.getAssetIdForTable(tableName);
+    doReturn(assetId)
+        .when(showTables)
+        .getAssetId(ledger, Constants.PREFIX_TABLE, TextNode.valueOf(tableName));
+    return assetId;
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithTableNameGiven_ShouldShowSingleTable() {
+    // Arrange
+    JsonNode argument = mapper.createObjectNode().put(Constants.TABLE_NAME, SOME_TABLE_NAME_1);
+    JsonNode expected = mapper.createArrayNode().add(SOME_TABLE_1);
+    String tableAssetId = prepareTableAssetId(SOME_TABLE_NAME_1);
+    Asset<JsonNode> tableAsset = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset.data()).thenReturn(SOME_TABLE_1);
+    when(ledger.get(tableAssetId)).thenReturn(Optional.of(tableAsset));
+
+    // Act
+    JsonNode actual = showTables.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+    verify(ledger).get(tableAssetId);
+    verify(ledger, never()).scan(any());
+  }
+
+  @Test
+  public void invoke_CorrectArgumentsWithoutTableNameGiven_ShouldShowAllTables() {
+    // Arrange
+    JsonNode argument = mapper.createObjectNode();
+    JsonNode expected = mapper.createArrayNode().add(SOME_TABLE_1).add(SOME_TABLE_2);
+    AssetFilter filter = new AssetFilter(Constants.ASSET_ID_METADATA_TABLES);
+    filter.withAgeOrder(AgeOrder.ASC);
+    Asset<JsonNode> tableAsset1 = (Asset<JsonNode>) mock(Asset.class);
+    Asset<JsonNode> tableAsset2 = (Asset<JsonNode>) mock(Asset.class);
+    when(tableAsset1.data()).thenReturn(SOME_TABLE_1);
+    when(tableAsset2.data()).thenReturn(SOME_TABLE_2);
+    when(ledger.scan(filter)).thenReturn(ImmutableList.of(tableAsset1, tableAsset2));
+
+    // Act
+    JsonNode actual = showTables.invoke(ledger, argument, null);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+    verify(ledger).scan(filter);
+    verify(ledger, never()).get(any());
+  }
+
+  @Test
+  public void invoke_InvalidArgumentsGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument1 =
+        mapper
+            .createObjectNode()
+            .put(Constants.TABLE_NAME, SOME_TABLE_NAME_1)
+            .put(Constants.TABLE_KEY, SOME_TABLE_KEY);
+    JsonNode argument2 = mapper.createObjectNode().put(Constants.TABLE_KEY, SOME_TABLE_KEY);
+    JsonNode argument3 = mapper.createObjectNode().put(Constants.TABLE_NAME, 0);
+
+    // Act Assert
+    assertThatThrownBy(() -> showTables.invoke(ledger, argument1, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> showTables.invoke(ledger, argument2, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    assertThatThrownBy(() -> showTables.invoke(ledger, argument3, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_CONTRACT_ARGUMENTS);
+    verify(ledger, never()).get(any());
+    verify(ledger, never()).scan(any());
+  }
+
+  @Test
+  public void invoke_NonExistingTableGiven_ShouldThrowContractContextException() {
+    // Arrange
+    JsonNode argument = mapper.createObjectNode().put(Constants.TABLE_NAME, SOME_TABLE_NAME_1);
+    String tableAssetId = prepareTableAssetId(SOME_TABLE_NAME_1);
+    when(ledger.get(tableAssetId)).thenReturn(Optional.empty());
+
+    // Act Assert
+    assertThatThrownBy(() -> showTables.invoke(ledger, argument, null))
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.TABLE_NOT_EXIST);
+    verify(ledger).get(tableAssetId);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds two utility contracts for table-oriented generic contracts: showing tables and getting a record history. See the design doc for detailed specifications: [`ShowTables`](https://docs.google.com/document/d/1lrpOKbVedrIVcee5kkiR2MItmNlEEDO_CLw7FfbS4uo/edit?pli=1&tab=t.0#heading=h.lpambew1v5mz) and [`GetHistory`](https://docs.google.com/document/d/1lrpOKbVedrIVcee5kkiR2MItmNlEEDO_CLw7FfbS4uo/edit?pli=1&tab=t.0#heading=h.41rtv7dz4csh).

## Related issues and/or PRs

N/A

## Changes made

- Add `ShowTables` and `GetHistory` contracts.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added utility contracts for table-oriented generic contracts.