### PR TITLE
Simplify join logic by adding table reference in the Scan contract

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Constants.java
@@ -54,6 +54,7 @@ public class Constants {
   public static final String OPERATOR_IS_NOT_NULL = "IS_NOT_NULL";
   public static final String SCAN_OPTIONS = "options";
   public static final String SCAN_OPTIONS_INCLUDE_METADATA = "include_metadata";
+  public static final String SCAN_OPTIONS_TABLE_REFERENCE = "table_reference";
   public static final String SCAN_METADATA_AGE = "age$";
 
   // Patterns

--- a/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.java
+++ b/generic-contracts/src/main/java/com/scalar/dl/genericcontracts/table/v1_0_0/Scan.java
@@ -257,7 +257,7 @@ public class Scan extends JacksonBasedContract {
     return tableReference + Constants.COLUMN_SEPARATOR + columnName;
   }
 
-  private JsonNode addTableReferenceForColumns(JsonNode record, String tableReference) {
+  private JsonNode addTableReferenceToColumns(JsonNode record, String tableReference) {
     ObjectNode renamed = getObjectMapper().createObjectNode();
     Iterator<Entry<String, JsonNode>> columns = record.fields();
 
@@ -293,7 +293,7 @@ public class Scan extends JacksonBasedContract {
       }
       if (allMatched) {
         results.add(
-            tableReference == null ? record : addTableReferenceForColumns(record, tableReference));
+            tableReference == null ? record : addTableReferenceToColumns(record, tableReference));
       }
     }
 


### PR DESCRIPTION
## Description

This PR simplifies the join logic by adding the table reference in the Scan contract, which is motivated by Aki's comment https://github.com/scalar-labs/scalardl/pull/124#discussion_r2070006068.

## Related issues and/or PRs

- #124

## Changes made

- Introduce the table reference option in the Scan contract to add the table reference if necessary

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Simplified join logic by adding table reference in the Scan contract.