### PR TITLE
Backport to branch(3.9) : Fix CVE-2025-22869

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/busybox:1.36 AS tools
 
 ENV DOCKERIZE_VERSION v0.6.1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.37
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.38
 
 # Install dockerize
 RUN set -x && \


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/142
- **Commit to backport:** e59166f6fdebc03ab72c798a36c4c2a0babd7fa9

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.9-pull-142 &&
git cherry-pick --no-rerere-autoupdate -m1 e59166f6fdebc03ab72c798a36c4c2a0babd7fa9
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!