### PR TITLE
Add --no-install-recommends option in args of apt-get

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jre-jammy
 
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /scalar

--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x && \
 
 FROM eclipse-temurin:8-jre-jammy
 
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tools grpc_health_probe /usr/local/bin/


### PR DESCRIPTION
## Description

This PR adds the `--no-install-recommends` option in arguments of the `apt-get` command in the Dockerfile.

It seems that, now, using the `--no-install-recommends` option is recommended in the [Building best practices](https://docs.docker.com/build/building/best-practices/#apt-get) of Docker. It can avoid installing unnecessary packages when we run the `apt-get` command.

- FYI:
  - Manual page of the `apt-get` command. You can see the details of the `--no-install-recommends` option.
    - https://manpages.ubuntu.com/manpages/noble/en/man8/apt-get.8.html
  - The PR that the `--no-install-recommends` option is added in Docker documentation.
    - https://github.com/docker/docs/pull/21045

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Add the `--no-install-recommends` option in each Dockerfile.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
