### PR TITLE
Fix to put state even in read-only transactions

### DIFF
--- a/ledger/build.gradle
+++ b/ledger/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.4'
 
     testImplementation group: 'com.scalar-labs', name: 'scalardb-schema-loader', version: "${scalarDbVersion}"
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: "${junitVersion}"
 
     // for Error Prone
     errorprone "com.google.errorprone:error_prone_core:${errorproneVersion}"

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
@@ -133,15 +133,15 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
       if (snapshot.hasWriteSet()) {
         puts = assetComposer.compose(snapshot, request);
 
-        if (config.isTxStateManagementEnabled()) {
-          stateManager.putCommit(transaction, transaction.getId());
-        }
-
         transaction.put(puts);
 
         if (!config.isDirectAssetAccessEnabled()) {
           metadata.put(snapshot.getWriteSet().values());
         }
+      }
+
+      if (config.isTxStateManagementEnabled()) {
+        stateManager.putCommit(transaction, transaction.getId());
       }
 
       transaction.commit();


### PR DESCRIPTION
## Description

This PR fixes the state management behavior for read-only transactions. Without this fix, when recovering read-only transactions, Auditor always tries to put the "aborted" state, which is a kind of garbage, even if the read-only transaction is actually committed.

## Related issues and/or PRs

N/A

## Changes made

- Always put the transaction state if the own transaction state management is enabled.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed the state management behavior for read-only transactions.