### PR TITLE
Backport to branch(3.9) : Use JReleaser to release artifacts in Maven Central

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -30,16 +30,28 @@ jobs:
           VERSION=$(./gradlew :ledger:properties -q | grep "version:" | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Prepare artifacts in staging-deploy directories
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: ./gradlew publish
+
       - name: Upload the SNAPSHOT versions of scalardl-ledger, scalardl-java-client-sdk, scalardl-common, and scalardl-rpc to Maven Central Repository
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
-        run: |
-          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > /tmp/secring.gpg
-          ./gradlew publish \
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="$(echo /tmp/secring.gpg)" \
-          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+        env:
+          JRELEASER_NEXUS2_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
+        run: ./gradlew jreleaserDeploy
+
+      - name: Upload JReleaser outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release
+          path: |
+            build/jreleaser/trace.log
+            build/jreleaser/output.properties
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,16 +32,26 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Prepare artifacts in staging-deploy directories
+        run: ./gradlew publish
+
       - name: Upload scalardl-ledger, scalardl-java-client-sdk, scalardl-common, and scalardl-rpc to Maven Central Repository
-        run: |
-          echo "${{secrets.SIGNING_SECRET_KEY_RING}}" | base64 -d > /tmp/secring.gpg
-          ./gradlew publish \
-          -Pversion=${{ steps.version.outputs.version }} \
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-          -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
-          -Psigning.secretKeyRingFile="$(echo /tmp/secring.gpg)" \
-          -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-          -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+        env:
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
+        run: ./gradlew jreleaserDeploy
+
+      - name: Upload JReleaser outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release
+          path: |
+            build/jreleaser/trace.log
+            build/jreleaser/output.properties
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,15 @@
 plugins {
     id("com.diffplug.spotless") version "6.13.0"
+    id("org.jreleaser") version "1.19.0"
 }
+
+ext {
+    projectGroup = 'com.scalar-labs'
+    projectVersion = '3.9.7-SNAPSHOT'
+}
+
+group = projectGroup
+version = projectVersion
 
 subprojects {
     apply plugin: 'java'
@@ -10,7 +19,8 @@ subprojects {
     apply plugin: 'java-library-distribution'
     apply plugin: 'com.diffplug.spotless'
 
-    project.version = '3.9.7-SNAPSHOT'
+    group = projectGroup
+    project.version = projectVersion
 
     ext {
         grpcVersion = '1.68.1'
@@ -77,8 +87,6 @@ subprojects {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
-    group = "com.scalar-labs"
-
     distZip {
         archiveFileName = "${project.name}.zip"
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -103,5 +111,41 @@ subprojects {
     task dockerfileLint(type: Exec) {
         description 'Lint the Dockerfile'
         executable "${rootDir}/scripts/docker/lint.sh"
+    }
+}
+
+jreleaser {
+    gitRootSearch = true
+
+    signing {
+        active = 'ALWAYS'
+        armored = true
+    }
+
+    deploy {
+        maven {
+            def stagingRepositories = ['client/build/staging-deploy',
+                                       'common/build/staging-deploy',
+                                       'ledger/build/staging-deploy',
+                                       'rpc/build/staging-deploy']
+            mavenCentral {
+                'release-deploy' {
+                    active = 'RELEASE'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    stagingRepositories.each { stagingRepository(it) }
+                }
+            }
+            nexus2 {
+                'snapshot-deploy' {
+                    active = 'SNAPSHOT'
+                    snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
+                    applyMavenCentralRules = true
+                    snapshotSupported = true
+                    closeRepository = true
+                    releaseRepository = true
+                    stagingRepositories.each { stagingRepository(it) }
+                }
+            }
+        }
     }
 }

--- a/client/archive.gradle
+++ b/client/archive.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -42,17 +41,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = "${ossrhUsername}"
-                password = "${ossrhPassword}"
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    sign publishing.publications.mavenJava
 }

--- a/common/archive.gradle
+++ b/common/archive.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -40,17 +39,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = "${ossrhUsername}"
-                password = "${ossrhPassword}"
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    sign publishing.publications.mavenJava
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ledger/archive.gradle
+++ b/ledger/archive.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -40,17 +39,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = "${ossrhUsername}"
-                password = "${ossrhPassword}"
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    sign publishing.publications.mavenJava
 }

--- a/rpc/archive.gradle
+++ b/rpc/archive.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -40,17 +39,7 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = "${ossrhUsername}"
-                password = "${ossrhPassword}"
-            }
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
-}
-
-signing {
-    sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/194
- **Commit to backport:** 5d9bdcfc7363f8049401b364724d931e9950d400

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.9-pull-194 &&
git cherry-pick --no-rerere-autoupdate -m1 5d9bdcfc7363f8049401b364724d931e9950d400
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!