### PR TITLE
Support time-related data types in generic function

### DIFF
--- a/common/src/main/java/com/scalar/dl/genericcontracts/object/Constants.java
+++ b/common/src/main/java/com/scalar/dl/genericcontracts/object/Constants.java
@@ -1,5 +1,20 @@
 package com.scalar.dl.genericcontracts.object;
 
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.ZoneOffset;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+
 public class Constants {
 
   // Object authenticity management
@@ -49,5 +64,62 @@ public class Constants {
   public static final String COLLECTION_ID_IS_MISSING_OR_INVALID =
       "The collection ID is not specified in the arguments or is invalid.";
   public static final String INVALID_PUT_MUTABLE_FUNCTION_ARGUMENT_FORMAT =
-      "The specified format of the PutMutable function argument is invalid.";
+      "The specified format of the PutToMutableDatabase function argument is invalid.";
+
+  /** A formatter for a DATE literal. The format is "YYYY-MM-DD". For example, "2020-03-04". */
+  public static final DateTimeFormatter DATE_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendValue(YEAR, 4, 4, SignStyle.NEVER)
+          .appendLiteral('-')
+          .appendValue(MONTH_OF_YEAR, 2)
+          .appendLiteral('-')
+          .appendValue(DAY_OF_MONTH, 2)
+          .toFormatter()
+          .withResolverStyle(ResolverStyle.STRICT)
+          .withChronology(IsoChronology.INSTANCE);
+  /**
+   * A formatter for a TIME literal. The format is "HH:MM:SS[.FFFFFF]". For example,
+   * "12:34:56.123456". The fractional second is optional.
+   */
+  public static final DateTimeFormatter TIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendValue(HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2)
+          .optionalStart()
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2)
+          .optionalStart()
+          .appendFraction(NANO_OF_SECOND, 0, 6, true)
+          .toFormatter()
+          .withResolverStyle(ResolverStyle.STRICT)
+          .withChronology(IsoChronology.INSTANCE);
+  /**
+   * A formatter for a TIMESTAMP literal. The format is "YYYY-MM-DD HH:MM:SS[.FFF]". For example,
+   * "2020-03-04 12:34:56.123". The fractional second is optional.
+   */
+  public static final DateTimeFormatter TIMESTAMP_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .append(DATE_FORMATTER)
+          .appendLiteral(' ')
+          .appendValue(HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2)
+          .optionalStart()
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2)
+          .optionalStart()
+          .appendFraction(NANO_OF_SECOND, 0, 3, true)
+          .toFormatter();
+  /**
+   * A formatter for a TIMESTAMPTZ literal. The format is "YYYY-MM-DD HH:MM:SS[.FFF] Z". For
+   * example, "2020-03-04 12:34:56.123 Z". The fractional second is optional.
+   */
+  public static final DateTimeFormatter TIMESTAMPTZ_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .append(TIMESTAMP_FORMATTER)
+          .appendLiteral(' ')
+          .appendLiteral('Z')
+          .toFormatter()
+          .withZone(ZoneOffset.UTC);
 }

--- a/generic-contracts/scripts/objects-table-schema.json
+++ b/generic-contracts/scripts/objects-table-schema.json
@@ -11,7 +11,7 @@
       "object_id": "TEXT",
       "version": "TEXT",
       "status": "INT",
-      "registered_at": "BIGINT"
+      "registered_at": "TIMESTAMP"
     },
     "compaction-strategy": "LCS"
   }

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/object/PutToMutableDatabaseTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/object/PutToMutableDatabaseTest.java
@@ -20,6 +20,11 @@ import com.scalar.db.api.Scan;
 import com.scalar.db.io.Key;
 import com.scalar.dl.ledger.database.Database;
 import com.scalar.dl.ledger.exception.ContractContextException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -47,6 +52,21 @@ public class PutToMutableDatabaseTest {
   private static final double SOME_DOUBLE_COLUMN_VALUE = 1.23;
   private static final String SOME_BLOB_COLUMN_NAME = "blob_column";
   private static final byte[] SOME_BLOB_COLUMN_VALUE = {10, 20, 30};
+  private static final String SOME_DATE_COLUMN_NAME = "date_column";
+  private static final String SOME_DATE_COLUMN_TEXT = "2021-02-03";
+  private static final LocalDate SOME_DATE_COLUMN_VALUE = LocalDate.of(2021, 2, 3);
+  private static final String SOME_TIME_COLUMN_NAME = "time_column";
+  private static final String SOME_TIME_COLUMN_TEXT = "05:45:00";
+  private static final LocalTime SOME_TIME_COLUMN_VALUE = LocalTime.of(5, 45);
+  private static final String SOME_TIMESTAMP_COLUMN_NAME = "timestamp_column";
+  private static final String SOME_TIMESTAMP_COLUMN_TEXT = "2021-02-03 05:45:00";
+  private static final LocalDateTime SOME_TIMESTAMP_COLUMN_VALUE =
+      LocalDateTime.of(2021, 2, 3, 5, 45);
+  private static final String SOME_TIMESTAMPTZ_COLUMN_NAME = "timestamptz_column";
+  private static final String SOME_TIMESTAMPTZ_COLUMN_TEXT = "2021-02-04 05:45:00 Z";
+  private static final Instant SOME_TIMESTAMPTZ_COLUMN_VALUE =
+      LocalDateTime.of(2021, 2, 4, 5, 45).toInstant(ZoneOffset.UTC);
+
   private static final JsonNode SOME_TEXT_COLUMN1 =
       mapper
           .createObjectNode()
@@ -101,6 +121,30 @@ public class PutToMutableDatabaseTest {
           .put(Constants.COLUMN_NAME, SOME_COLUMN_NAME)
           .put(Constants.VALUE, (byte[]) null)
           .put(Constants.DATA_TYPE, "BLOB");
+  private static final JsonNode SOME_DATE_COLUMN =
+      mapper
+          .createObjectNode()
+          .put(Constants.COLUMN_NAME, SOME_DATE_COLUMN_NAME)
+          .put(Constants.VALUE, SOME_DATE_COLUMN_TEXT)
+          .put(Constants.DATA_TYPE, "DATE");
+  private static final JsonNode SOME_TIME_COLUMN =
+      mapper
+          .createObjectNode()
+          .put(Constants.COLUMN_NAME, SOME_TIME_COLUMN_NAME)
+          .put(Constants.VALUE, SOME_TIME_COLUMN_TEXT)
+          .put(Constants.DATA_TYPE, "TIME");
+  private static final JsonNode SOME_TIMESTAMP_COLUMN =
+      mapper
+          .createObjectNode()
+          .put(Constants.COLUMN_NAME, SOME_TIMESTAMP_COLUMN_NAME)
+          .put(Constants.VALUE, SOME_TIMESTAMP_COLUMN_TEXT)
+          .put(Constants.DATA_TYPE, "TIMESTAMP");
+  private static final JsonNode SOME_TIMESTAMPTZ_COLUMN =
+      mapper
+          .createObjectNode()
+          .put(Constants.COLUMN_NAME, SOME_TIMESTAMPTZ_COLUMN_NAME)
+          .put(Constants.VALUE, SOME_TIMESTAMPTZ_COLUMN_TEXT)
+          .put(Constants.DATA_TYPE, "TIMESTAMPTZ");
   private static final JsonNode SOME_COLUMN_WITHOUT_VALUE =
       mapper.createObjectNode().put(Constants.COLUMN_NAME, SOME_COLUMN_NAME);
   private static final JsonNode SOME_COLUMN_WITH_INVALID_TYPE =
@@ -155,7 +199,11 @@ public class PutToMutableDatabaseTest {
             .add(SOME_BIGINT_COLUMN)
             .add(SOME_FLOAT_COLUMN)
             .add(SOME_DOUBLE_COLUMN)
-            .add(SOME_BLOB_COLUMN);
+            .add(SOME_BLOB_COLUMN)
+            .add(SOME_DATE_COLUMN)
+            .add(SOME_TIME_COLUMN)
+            .add(SOME_TIMESTAMP_COLUMN)
+            .add(SOME_TIMESTAMPTZ_COLUMN);
     ObjectNode arguments = mapper.createObjectNode();
     arguments.put(Constants.NAMESPACE, SOME_NAMESPACE);
     arguments.put(Constants.TABLE, SOME_TABLE);
@@ -174,6 +222,10 @@ public class PutToMutableDatabaseTest {
             .floatValue(SOME_FLOAT_COLUMN_NAME, SOME_FLOAT_COLUMN_VALUE)
             .doubleValue(SOME_DOUBLE_COLUMN_NAME, SOME_DOUBLE_COLUMN_VALUE)
             .blobValue(SOME_BLOB_COLUMN_NAME, SOME_BLOB_COLUMN_VALUE)
+            .dateValue(SOME_DATE_COLUMN_NAME, SOME_DATE_COLUMN_VALUE)
+            .timeValue(SOME_TIME_COLUMN_NAME, SOME_TIME_COLUMN_VALUE)
+            .timestampValue(SOME_TIMESTAMP_COLUMN_NAME, SOME_TIMESTAMP_COLUMN_VALUE)
+            .timestampTZValue(SOME_TIMESTAMPTZ_COLUMN_NAME, SOME_TIMESTAMPTZ_COLUMN_VALUE)
             .build();
 
     // Act
@@ -518,6 +570,71 @@ public class PutToMutableDatabaseTest {
   }
 
   private void invoke_ColumnsWithUnmatchedTypeGiven_ShouldThrowContractContextException(
+      JsonNode column, String description) {
+    // Arrange
+    ArrayNode partitionKey = mapper.createArrayNode().add(SOME_TEXT_COLUMN1);
+    ArrayNode columns = mapper.createArrayNode().add(column);
+    ObjectNode arguments = mapper.createObjectNode();
+    arguments.put(Constants.NAMESPACE, SOME_NAMESPACE);
+    arguments.put(Constants.TABLE, SOME_TABLE);
+    arguments.set(Constants.PARTITION_KEY, partitionKey);
+    arguments.set(Constants.COLUMNS, columns);
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> putToMutableDatabase.invoke(database, arguments, null, null), description)
+        .isExactlyInstanceOf(ContractContextException.class)
+        .hasMessage(Constants.INVALID_PUT_MUTABLE_FUNCTION_ARGUMENT_FORMAT);
+    verify(database, never()).put(any());
+  }
+
+  @Test
+  public void
+      invoke_ColumnsWithInvalidTimeRelatedFormatGiven_ShouldThrowContractContextException() {
+    // Arrange
+    Builder<JsonNode, String> builder = ImmutableMap.builder();
+    builder
+        .put(
+            mapper
+                .createObjectNode()
+                .put(Constants.COLUMN_NAME, SOME_DATE_COLUMN_NAME)
+                .put(Constants.VALUE, "2025-07")
+                .put(Constants.DATA_TYPE, "DATE"),
+            "DATE without day")
+        .put(
+            mapper
+                .createObjectNode()
+                .put(Constants.COLUMN_NAME, SOME_TIME_COLUMN_NAME)
+                .put(Constants.VALUE, "10:20 PM")
+                .put(Constants.DATA_TYPE, "TIME"),
+            "TIME with unexpected am/pm")
+        .put(
+            mapper
+                .createObjectNode()
+                .put(Constants.COLUMN_NAME, SOME_TIMESTAMP_COLUMN_NAME)
+                .put(Constants.VALUE, "2025-07 10:20:00")
+                .put(Constants.DATA_TYPE, "TIMESTAMP"),
+            "TIMESTAMP without day")
+        .put(
+            mapper
+                .createObjectNode()
+                .put(Constants.COLUMN_NAME, SOME_TIMESTAMPTZ_COLUMN_NAME)
+                .put(Constants.VALUE, "2027-07-01 12:34")
+                .put(Constants.DATA_TYPE, "TIMESTAMPTZ"),
+            "TIMESTAMPTZ without Z");
+
+    // Act Assert
+    builder
+        .build()
+        .entrySet()
+        .parallelStream()
+        .forEach(
+            entry ->
+                invoke_ColumnsWithUnmatchedTypeGiven_ShouldThrowContractContextException(
+                    entry.getKey(), entry.getValue()));
+  }
+
+  private void invoke_ColumnsWithInvalidTimeRelatedFormatGiven_ShouldThrowContractContextException(
       JsonNode column, String description) {
     // Arrange
     ArrayNode partitionKey = mapper.createArrayNode().add(SOME_TEXT_COLUMN1);

--- a/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/object/PutToMutableDatabaseTest.java
+++ b/generic-contracts/src/test/java/com/scalar/dl/genericcontracts/object/PutToMutableDatabaseTest.java
@@ -565,27 +565,8 @@ public class PutToMutableDatabaseTest {
         .parallelStream()
         .forEach(
             entry ->
-                invoke_ColumnsWithUnmatchedTypeGiven_ShouldThrowContractContextException(
+                invoke_ColumnsWithInvalidArguments_ShouldThrowContractContextException(
                     entry.getKey(), entry.getValue()));
-  }
-
-  private void invoke_ColumnsWithUnmatchedTypeGiven_ShouldThrowContractContextException(
-      JsonNode column, String description) {
-    // Arrange
-    ArrayNode partitionKey = mapper.createArrayNode().add(SOME_TEXT_COLUMN1);
-    ArrayNode columns = mapper.createArrayNode().add(column);
-    ObjectNode arguments = mapper.createObjectNode();
-    arguments.put(Constants.NAMESPACE, SOME_NAMESPACE);
-    arguments.put(Constants.TABLE, SOME_TABLE);
-    arguments.set(Constants.PARTITION_KEY, partitionKey);
-    arguments.set(Constants.COLUMNS, columns);
-
-    // Act Assert
-    assertThatThrownBy(
-            () -> putToMutableDatabase.invoke(database, arguments, null, null), description)
-        .isExactlyInstanceOf(ContractContextException.class)
-        .hasMessage(Constants.INVALID_PUT_MUTABLE_FUNCTION_ARGUMENT_FORMAT);
-    verify(database, never()).put(any());
   }
 
   @Test
@@ -630,11 +611,11 @@ public class PutToMutableDatabaseTest {
         .parallelStream()
         .forEach(
             entry ->
-                invoke_ColumnsWithUnmatchedTypeGiven_ShouldThrowContractContextException(
+                invoke_ColumnsWithInvalidArguments_ShouldThrowContractContextException(
                     entry.getKey(), entry.getValue()));
   }
 
-  private void invoke_ColumnsWithInvalidTimeRelatedFormatGiven_ShouldThrowContractContextException(
+  private void invoke_ColumnsWithInvalidArguments_ShouldThrowContractContextException(
       JsonNode column, String description) {
     // Arrange
     ArrayNode partitionKey = mapper.createArrayNode().add(SOME_TEXT_COLUMN1);


### PR DESCRIPTION
## Description

This PR adds time-related data type support in the generic function of object authenticity management. Similar to the ScalarDL SQL grammar, you can specify it with text literals that follow a specific format to put DATE, TIME, TIMESTAMP, and TIMESTAMPTZ values.

https://scalardb.scalar-labs.com/docs/latest/scalardb-sql/grammar/#date-and-time

## Related issues and/or PRs

N/A

## Changes made

- Add time-related data type support in the generic function of object authenticity management

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Supported time-related data types in the generic function.