### PR TITLE
Fix certificate and secret key version check and messages

### DIFF
--- a/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
@@ -405,10 +405,8 @@ public class ClientConfig {
               ENTITY_ID, CERT_HOLDER_ID));
 
       // identity based on digital signature
-      certVersion = ConfigUtils.getInt(props, DS_CERT_VERSION, 0);
-      if (certVersion <= 0) {
-        certVersion = ConfigUtils.getInt(props, CERT_VERSION, DEFAULT_CERT_VERSION);
-      }
+      certVersion = ConfigUtils.getInt(props, CERT_VERSION, DEFAULT_CERT_VERSION);
+      certVersion = ConfigUtils.getInt(props, DS_CERT_VERSION, certVersion);
       cert = ConfigUtils.getString(props, DS_CERT_PEM, null);
       if (cert == null) {
         cert = ConfigUtils.getStringFromFilePath(props, DS_CERT_PATH, null);

--- a/client/src/main/java/com/scalar/dl/client/config/DigitalSignatureIdentityConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/DigitalSignatureIdentityConfig.java
@@ -81,8 +81,7 @@ public class DigitalSignatureIdentityConfig {
 
     public DigitalSignatureIdentityConfig.Builder certVersion(int certVersion) {
       checkArgument(
-          certVersion >= 0,
-          CommonError.CERT_VERSION_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO.buildMessage());
+          certVersion > 0, CommonError.CERT_VERSION_MUST_BE_GREATER_THAN_ZERO.buildMessage());
       this.certVersion = certVersion;
       return this;
     }

--- a/client/src/main/java/com/scalar/dl/client/config/HmacIdentityConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/HmacIdentityConfig.java
@@ -72,8 +72,8 @@ public class HmacIdentityConfig {
 
     public HmacIdentityConfig.Builder secretKeyVersion(int secretKeyVersion) {
       checkArgument(
-          secretKeyVersion >= 0,
-          CommonError.SECRET_VERSION_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO.buildMessage());
+          secretKeyVersion > 0,
+          CommonError.SECRET_VERSION_MUST_BE_GREATER_THAN_ZERO.buildMessage());
       this.secretKeyVersion = secretKeyVersion;
       return this;
     }

--- a/client/src/test/java/com/scalar/dl/client/config/ClientConfigTest.java
+++ b/client/src/test/java/com/scalar/dl/client/config/ClientConfigTest.java
@@ -589,10 +589,12 @@ public class ClientConfigTest {
           throws IOException {
     // Arrange
     Properties props = new Properties();
-    props.put(ClientConfig.ENTITY_ID, SOME_ENTITY_ID);
+    props.put(ClientConfig.CERT_VERSION, "0");
     props.put(ClientConfig.CERT_HOLDER_ID, SOME_CERT_HOLDER_ID);
     props.put(ClientConfig.CERT_PEM, SOME_CERT_PEM);
     props.put(ClientConfig.PRIVATE_KEY_PEM, SOME_PRIVATE_KEY_PEM);
+    props.put(ClientConfig.ENTITY_ID, SOME_ENTITY_ID);
+    props.put(ClientConfig.DS_CERT_VERSION, SOME_CERT_VERSION);
     props.put(ClientConfig.DS_CERT_PEM, SOME_CERT_PEM + "New");
     props.put(ClientConfig.DS_PRIVATE_KEY_PEM, SOME_PRIVATE_KEY_PEM + "New");
 
@@ -601,6 +603,8 @@ public class ClientConfigTest {
 
     // Assert
     assertThat(config.getDigitalSignatureIdentityConfig().getEntityId()).isEqualTo(SOME_ENTITY_ID);
+    assertThat(config.getDigitalSignatureIdentityConfig().getCertVersion())
+        .isEqualTo(Integer.parseInt(SOME_CERT_VERSION));
     assertThat(config.getDigitalSignatureIdentityConfig().getCert())
         .isEqualTo(SOME_CERT_PEM + "New");
     assertThat(config.getDigitalSignatureIdentityConfig().getPrivateKey())
@@ -739,5 +743,60 @@ public class ClientConfigTest {
         .isNotEqualTo(config2.getDigitalSignatureIdentityConfig());
     assertThat(config1.getLedgerTargetConfig()).isNotEqualTo(config2.getLedgerTargetConfig());
     assertThat(config1.getAuditorTargetConfig()).isNotEqualTo(config2.getAuditorTargetConfig());
+  }
+
+  @Test
+  public void constructor_CertVersionZeroGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.put(ClientConfig.ENTITY_ID, SOME_CERT_HOLDER_ID);
+    props.put(ClientConfig.DS_CERT_VERSION, "0");
+    props.put(ClientConfig.DS_CERT_PEM, SOME_CERT_PEM);
+    props.put(ClientConfig.DS_PRIVATE_KEY_PEM, SOME_PRIVATE_KEY_PEM);
+
+    // Act Assert
+    assertThatThrownBy(() -> new ClientConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_DeprecatedCertVersionZeroGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.put(ClientConfig.CERT_HOLDER_ID, SOME_CERT_HOLDER_ID);
+    props.put(ClientConfig.CERT_VERSION, "0");
+    props.put(ClientConfig.CERT_PEM, SOME_CERT_PEM);
+    props.put(ClientConfig.PRIVATE_KEY_PEM, SOME_PRIVATE_KEY_PEM);
+
+    // Act Assert
+    assertThatThrownBy(() -> new ClientConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_NewWrongCertVersionAndDeprecatedCorrectCertVersionGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.put(ClientConfig.ENTITY_ID, SOME_CERT_HOLDER_ID);
+    props.put(ClientConfig.DS_CERT_VERSION, "0");
+    props.put(ClientConfig.DS_CERT_PEM, SOME_CERT_PEM);
+    props.put(ClientConfig.DS_PRIVATE_KEY_PEM, SOME_PRIVATE_KEY_PEM);
+    props.put(ClientConfig.CERT_HOLDER_ID, SOME_CERT_HOLDER_ID);
+    props.put(ClientConfig.CERT_VERSION, SOME_CERT_VERSION);
+
+    // Act Assert
+    assertThatThrownBy(() -> new ClientConfig(props)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_SecretVersionZeroGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    Properties props = new Properties();
+    props.put(ClientConfig.ENTITY_ID, SOME_ENTITY_ID);
+    props.put(ClientConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
+    props.put(ClientConfig.HMAC_SECRET_KEY, SOME_SECRET_KEY);
+    props.put(ClientConfig.HMAC_SECRET_KEY_VERSION, "0");
+
+    // Act Assert
+    assertThatThrownBy(() -> new ClientConfig(props)).isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
+++ b/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
@@ -163,10 +163,10 @@ public enum CommonError implements ScalarDlError {
       ""),
   PRIVATE_KEY_AND_CERT_REQUIRED(
       StatusCode.INVALID_ARGUMENT, "009", "The private key and certificate are required.", "", ""),
-  CERT_VERSION_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO(
+  CERT_VERSION_MUST_BE_GREATER_THAN_ZERO(
       StatusCode.INVALID_ARGUMENT,
       "010",
-      "The certificate version must be greater than or equal to zero.",
+      "The certificate version must be greater than zero.",
       "",
       ""),
   SECRET_KEY_REQUIRED(
@@ -175,10 +175,10 @@ public enum CommonError implements ScalarDlError {
       "A secret key is required for HMAC authentication.",
       "",
       ""),
-  SECRET_VERSION_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO(
+  SECRET_VERSION_MUST_BE_GREATER_THAN_ZERO(
       StatusCode.INVALID_ARGUMENT,
       "012",
-      "The secret version for HMAC authentication must be greater than or equal to zero.",
+      "The secret version for HMAC authentication must be greater than zero.",
       "",
       ""),
   GRPC_DEADLINE_DURATION_MUST_BE_GREATER_THAN_OR_EQUAL_TO_ZERO(


### PR DESCRIPTION
## Description

This PR fixes the certificate and secret key version check and messages. Since we only accept the versions greater than zero (cf. [certificate version](https://github.com/scalar-labs/scalardl/blob/5d9bdcfc7363f8049401b364724d931e9950d400/ledger/src/main/java/com/scalar/dl/ledger/model/AbstractRequest.java#L14) and [secret key version](https://github.com/scalar-labs/scalardl/blob/5d9bdcfc7363f8049401b364724d931e9950d400/ledger/src/main/java/com/scalar/dl/ledger/crypto/SecretEntry.java#L41)) on the Ledger side, we should have the same rules on the client side. Without fixing this issue, users will see an unexpected error instead of `IllegalArgumentException` in the client.

## Related issues and/or PRs

N/A

## Changes made

- Fix the version requirement and error messages for the cert and secret key.
- Always use the new (non-deprecated) cert version with higher priority to avoid confusion.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

[The error code docs](https://scalardl.scalar-labs.com/docs/latest/scalardl-common-status-codes) should be fixed after this PR is merged.

## Release notes

Fixed certificate and secret key version check and messages.