### PR TITLE
Remove CR_PAT secret from vuln-check workflows

### DIFF
--- a/.github/workflows/manual-vuln-check.yaml
+++ b/.github/workflows/manual-vuln-check.yaml
@@ -8,5 +8,3 @@ jobs:
     uses: ./.github/workflows/vuln-check.yaml
     with:
       target-ref: ${{ github.ref_name }}
-    secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}

--- a/.github/workflows/scheduled-vuln-check.yaml
+++ b/.github/workflows/scheduled-vuln-check.yaml
@@ -11,7 +11,6 @@ jobs:
     with:
       target-ref: master
     secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
 
   call-vuln-check-for-v3_9:
@@ -20,7 +19,6 @@ jobs:
       target-ref: v3.9
       find-latest-release: true
     secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
 
   call-vuln-check-for-v3_10:
@@ -29,7 +27,6 @@ jobs:
       target-ref: v3.10
       find-latest-release: true
     secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
 
   call-vuln-check-for-v3_11:
@@ -38,5 +35,4 @@ jobs:
       target-ref: v3.11
       find-latest-release: true
     secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -14,8 +14,6 @@ on:
         type: boolean
         default: false
     secrets:
-      CR_PAT:
-        required: true
       SLACK_SECURITY_WEBHOOK_URL:
         required: false
 
@@ -27,5 +25,4 @@ jobs:
       find-latest-release: ${{ inputs.find-latest-release }}
       images: '[["ScalarDL Ledger", "scalardl-ledger"], ["ScalarDL Client", "scalardl-client"]]'
     secrets:
-      CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

This PR removes the `CR_PAT` secret from all vulnerability check workflows as it is no longer required.

## Related issues and/or PRs

- scalar-labs/actions#23

## Changes made

- Removed `CR_PAT` secret requirement from `vuln-check.yaml` workflow
- Removed `CR_PAT` secret passing from `manual-vuln-check.yaml` workflow
- Removed `CR_PAT` secret passing from all jobs in `scheduled-vuln-check.yaml` workflow

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [xI have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes

This PR depends on scalar-labs/actions#23, which must be merged first.

## Release notes

Removed the `CR_PAT` secret from all vulnerability check workflows.
