### PR TITLE
Backport to branch(3.9) : Fix to correctly validate authentication settings

### DIFF
--- a/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
@@ -154,8 +154,9 @@ public class ClientConfig {
   public static final String DS_PRIVATE_KEY_PEM = DS_IDENTITY_PREFIX + "private_key_pem";
   /**
    * <code>scalar.dl.client.authentication_method</code> (Optional)<br>
-   * The authentication method for a client and servers. Use {@code "digital-signature"} (default)
-   * or {@code "hmac"}.
+   * The authentication method for clients and Ledger/Auditor servers. {@code "digital-signature"}
+   * (default) or {@code "hmac"} can be specified. This must be consistent with the Ledger/Auditor
+   * configuration.
    *
    * @deprecated This variable will be deleted in release 5.0.0. Use {@code
    *     scalar.dl.client.authentication.method} instead.
@@ -163,8 +164,9 @@ public class ClientConfig {
   public static final String DEPRECATED_AUTHENTICATION_METHOD = PREFIX + "authentication_method";
   /**
    * <code>scalar.dl.client.authentication.method</code> (Optional)<br>
-   * The authentication method for a client and servers. Use {@code "digital-signature"} (default)
-   * or {@code "hmac"}.
+   * The authentication method for clients and Ledger/Auditor servers. {@code "digital-signature"}
+   * (default) or {@code "hmac"} can be specified. This must be consistent with the Ledger/Auditor
+   * configuration.
    */
   public static final String AUTHENTICATION_METHOD = PREFIX + "authentication.method";
   /**

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
@@ -2425,7 +2425,9 @@ public class LedgerServiceEndToEndTest {
     Properties props2 = createProperties();
     props2.put(LedgerConfig.AUDITOR_ENABLED, "true");
     props2.put(LedgerConfig.PROOF_ENABLED, "true");
-    props2.put(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SECRET_KEY_A);
+    props2.put(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
+    props2.put(LedgerConfig.AUTHENTICATION_HMAC_CIPHER_KEY, SOME_CIPHER_KEY);
+    props2.put(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SECRET_KEY_B);
     createServices(new LedgerConfig(props2));
     String nonce = UUID.randomUUID().toString();
     JsonNode contractArgument =
@@ -2436,18 +2438,18 @@ public class LedgerServiceEndToEndTest {
     String argument = Argument.format(contractArgument, nonce, Collections.emptyList());
 
     byte[] serialized =
-        ContractExecutionRequest.serialize(CREATE_CONTRACT_ID3, argument, ENTITY_ID_A, KEY_VERSION);
+        ContractExecutionRequest.serialize(CREATE_CONTRACT_ID3, argument, ENTITY_ID_C, KEY_VERSION);
     ContractExecutionRequest request =
         new ContractExecutionRequest(
             nonce,
-            ENTITY_ID_A,
+            ENTITY_ID_C,
             KEY_VERSION,
             CREATE_CONTRACT_ID3,
             argument,
             Collections.emptyList(),
             null,
-            dsSigner1.sign(serialized),
-            hmacSigner1.sign(nonce.getBytes(StandardCharsets.UTF_8)));
+            hmacSigner1.sign(serialized),
+            hmacSigner2.sign(nonce.getBytes(StandardCharsets.UTF_8)));
 
     // Act
     Throwable thrown = catchThrowable(() -> ledgerService.execute(request));
@@ -2463,6 +2465,8 @@ public class LedgerServiceEndToEndTest {
     Properties props2 = createProperties();
     props2.put(LedgerConfig.AUDITOR_ENABLED, "true");
     props2.put(LedgerConfig.PROOF_ENABLED, "true");
+    props2.put(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
+    props2.put(LedgerConfig.AUTHENTICATION_HMAC_CIPHER_KEY, SOME_CIPHER_KEY);
     props2.put(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SECRET_KEY_A);
     createServices(new LedgerConfig(props2));
     String nonce = UUID.randomUUID().toString();
@@ -2474,17 +2478,17 @@ public class LedgerServiceEndToEndTest {
     String argument = Argument.format(contractArgument, nonce, Collections.emptyList());
 
     byte[] serialized =
-        ContractExecutionRequest.serialize(CREATE_CONTRACT_ID3, argument, ENTITY_ID_A, KEY_VERSION);
+        ContractExecutionRequest.serialize(CREATE_CONTRACT_ID3, argument, ENTITY_ID_C, KEY_VERSION);
     ContractExecutionRequest request =
         new ContractExecutionRequest(
             nonce,
-            ENTITY_ID_A,
+            ENTITY_ID_C,
             KEY_VERSION,
             CREATE_CONTRACT_ID3,
             argument,
             Collections.emptyList(),
             null,
-            dsSigner1.sign(serialized),
+            hmacSigner1.sign(serialized),
             hmacSigner2.sign(nonce.getBytes(StandardCharsets.UTF_8))); // invalid HMAC signature
 
     // Act

--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -64,8 +64,8 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
   public static final String NAMESPACE = PREFIX + "namespace";
   /**
    * <code>scalar.dl.ledger.authentication.method</code> (Optional)<br>
-   * The authentication method for a client and servers. ("digital-signature" by default) This has
-   * to be consistent with the client configuration.
+   * The authentication method for clients and Ledger servers. {@code "digital-signature"} (default)
+   * or {@code "hmac"} can be specified.
    */
   public static final String AUTHENTICATION_METHOD = PREFIX + "authentication.method";
   /**
@@ -446,20 +446,19 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
       }
       serversAuthHmacSecretKey =
           ConfigUtils.getString(props, SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, null);
-      if (serversAuthHmacSecretKey == null && proofPrivateKey == null) {
+      if (authenticationMethod == AuthenticationMethod.DIGITAL_SIGNATURE
+          && proofPrivateKey == null) {
         throw new IllegalArgumentException(
             String.format(
                 "Authentication between Ledger and Auditor is not correctly configured."
-                    + "Set %s or set a private key with %s or %s.",
-                SERVERS_AUTHENTICATION_HMAC_SECRET_KEY,
-                PROOF_PRIVATE_KEY_PATH,
-                PROOF_PRIVATE_KEY_PEM));
-      }
-      if (authenticationMethod == AuthenticationMethod.HMAC && serversAuthHmacSecretKey == null) {
+                    + " Set a private key with %s or %s if you use digital signature authentication with Auditor enabled.",
+                PROOF_PRIVATE_KEY_PATH, PROOF_PRIVATE_KEY_PEM));
+      } else if (authenticationMethod == AuthenticationMethod.HMAC
+          && serversAuthHmacSecretKey == null) {
         throw new IllegalArgumentException(
             String.format(
                 "Authentication between Ledger and Auditor is not correctly configured."
-                    + "Set %s if you use HMAC authentication with Auditor enabled.",
+                    + " Set %s if you use HMAC authentication with Auditor enabled.",
                 SERVERS_AUTHENTICATION_HMAC_SECRET_KEY));
       }
     } else { // Auditor disabled

--- a/ledger/src/test/java/com/scalar/dl/ledger/config/LedgerConfigTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/config/LedgerConfigTest.java
@@ -450,20 +450,6 @@ public class LedgerConfigTest {
   }
 
   @Test
-  public void constructor_AuditorAndProofEnabledAndSecretKeyGiven_ShouldConstructProperly() {
-    // Arrange
-    props.setProperty(LedgerConfig.AUDITOR_ENABLED, "true");
-    props.setProperty(LedgerConfig.PROOF_ENABLED, "true");
-    props.setProperty(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SOME_KEY);
-
-    // Act
-    Throwable thrown = catchThrowable(() -> new LedgerConfig(props));
-
-    // Assert
-    assertThat(thrown).doesNotThrowAnyException();
-  }
-
-  @Test
   public void
       constructor_AuditorAndProofEnabledButNeitherPrivateKeyNorSecretKeyGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
@@ -524,12 +510,13 @@ public class LedgerConfigTest {
 
   @Test
   public void
-      constructor_AuditorAndProofEnabledAndHmacConfiguredButSecretKeyNotGiven_ShouldThrowIllegalArgumentException() {
+      constructor_AuditorEnabledButProofDisabledWithHmacConfiguration_ShouldThrowIllegalArgumentException() {
     // Arrange
     props.setProperty(LedgerConfig.AUDITOR_ENABLED, "true");
     props.setProperty(LedgerConfig.PROOF_ENABLED, "false");
     props.setProperty(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
     props.setProperty(LedgerConfig.AUTHENTICATION_HMAC_CIPHER_KEY, SOME_CIPHER_KEY);
+    props.setProperty(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SOME_SECRET_KEY);
 
     // Act
     Throwable thrown = catchThrowable(() -> new LedgerConfig(props));
@@ -545,6 +532,40 @@ public class LedgerConfigTest {
     props.setProperty(LedgerConfig.PROOF_ENABLED, "false");
     props.setProperty(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
     props.setProperty(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SOME_SECRET_KEY);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> new LedgerConfig(props));
+
+    // Assert
+    assertThat(thrown).isExactlyInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_AuditorAndProofEnabledInDigitalSignatureConfigurationButPrivateKeyNotGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    props.setProperty(LedgerConfig.AUDITOR_ENABLED, "true");
+    props.setProperty(LedgerConfig.PROOF_ENABLED, "true");
+    props.setProperty(
+        LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.DIGITAL_SIGNATURE.getMethod());
+    props.setProperty(LedgerConfig.SERVERS_AUTHENTICATION_HMAC_SECRET_KEY, SOME_SECRET_KEY);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> new LedgerConfig(props));
+
+    // Assert
+    assertThat(thrown).isExactlyInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void
+      constructor_AuditorAndProofEnabledInHmacConfigurationButSecretKeyNotGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    props.setProperty(LedgerConfig.AUDITOR_ENABLED, "true");
+    props.setProperty(LedgerConfig.PROOF_ENABLED, "true");
+    props.setProperty(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
+    props.setProperty(LedgerConfig.AUTHENTICATION_HMAC_CIPHER_KEY, SOME_CIPHER_KEY);
+    props.setProperty(LedgerConfig.PROOF_PRIVATE_KEY_PEM, SOME_PEM);
 
     // Act
     Throwable thrown = catchThrowable(() -> new LedgerConfig(props));


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/222
- **Commit to backport:** 5e29f90401bed71d956cf86cfd5965966ffae147

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.9-pull-222 &&
git cherry-pick --no-rerere-autoupdate -m1 5e29f90401bed71d956cf86cfd5965966ffae147
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!