### PR TITLE
Downgrade grpc-java version for stability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     project.version = projectVersion
 
     ext {
-        grpcVersion = '1.75.0'
+        grpcVersion = '1.74.0'
         protocVersion = '3.25.8'
         picoCliVersion = '4.7.7'
         guiceVersion = '5.1.0'


### PR DESCRIPTION
## Description

This PR downgrades the grpc-java version because the latest 1.75.0 seems unstable in our environments.

## Related issues and/or PRs

N/A

## Changes made

- Downgrades the grpc-java version to 1.74.0

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Downgraded the grpc-java version.