### PR TITLE
Add GitHub action to assign reviewers on PR created by Dependabot

### DIFF
--- a/.github/workflows/assign-dependabot-pr-reviewers.yaml
+++ b/.github/workflows/assign-dependabot-pr-reviewers.yaml
@@ -1,0 +1,19 @@
+name: Assign reviewer to dependabot PRs
+# This action assigns the ScalarDL team as reviewers when Dependabot opens a pull request.
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Assign ScalarDL team as reviewers for Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.ASSIGN_PR_REVIEWERS_PAT }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: gh pr edit $PR_NUMBER --repo $REPOSITORY --add-reviewer scalar-labs/scalardl


### PR DESCRIPTION
## Description

This PR adds a GitHub action to assign reviewers to PRs created by Dependabot. `CODEOWNERS` file can automatically assign the ScalarDL team as reviewers to any pull request created, but it also assigns reviewers for the backport PRs, which is sometimes noisy. So, we use this action, the same as ScalarDB.

## Related issues and/or PRs

- #284
- scalar-labs/scalardb#2694
- scalar-labs/scalardb#2958

## Changes made

- Add GitHub action to assign reviewers on PR created by Dependabot

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A