### PR TITLE
Upgrade ScalarDB to fix CVE-2025-49146

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
         jsonpVersion = '1.1.4'
         jacksonVersion = '2.19.1'
         toml4jVersion = '0.7.2'
-        scalarDbVersion = '3.15.3'
+        scalarDbVersion = '3.15.5'
         scalarAdminVersion = '2.2.1'
         resilience4jRetryVersion = '1.7.1'
         dropwizardMetricsVersion = '4.2.32'


### PR DESCRIPTION
## Description

This PR fixes CVE-2025-49146 by bumping up the ScalarDB version to v3.15.5.

## Related issues and/or PRs

- scalar-labs/scalardb#2772

## Changes made

- Upgrade ScalarDB to v3.15.5

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This PR also needs to be backported for ScalarDL 3.10.x with ScalarDB v3.14.4.

## Release notes

Upgraded ScalarDB to fix CVE-2025-49146.