### PR TITLE
Backport to branch(3.10) : Upgrade ScalarDB to fix CVE-2025-49146

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
         jsonpVersion = '1.1.4'
         jacksonVersion = '2.18.1'
         toml4jVersion = '0.7.2'
-        scalarDbVersion = '3.14.3'
+        scalarDbVersion = '3.14.4'
         scalarAdminVersion = '2.2.1'
         resilience4jRetryVersion = '1.7.1'
         dropwizardMetricsVersion = '4.2.28'


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/286
- **Commit to backport:** e3cb372b8a80ee7d4fcef98afafcfe035fe84a50

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.10-pull-286 &&
git cherry-pick --no-rerere-autoupdate -m1 e3cb372b8a80ee7d4fcef98afafcfe035fe84a50
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!