### PR TITLE
Backport to branch(3) : Bump org.partiql:partiql-parser from 1.2.3 to 1.3.0 in the dependencies group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
         googleJavaFormatVersion = '1.7'
         dockerPluginVersion = '0.34.0'
         bouncyCastleCryptoVersion = '1.70'
-        partiqlVersion = '1.2.2'
+        partiqlVersion = '1.3.0'
 
         dockerVersion = project.properties['dockerVersion'] ?: project.version
     }


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/300
- **Commit to backport:** fe5e360e2ce1a98e44ea4b1326df168649e195cd

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-300 &&
git cherry-pick --no-rerere-autoupdate -m1 fe5e360e2ce1a98e44ea4b1326df168649e195cd
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!