### PR TITLE
Fix NullPointerException when a client is misconfigured with digital signature

### DIFF
--- a/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
+++ b/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
@@ -215,6 +215,12 @@ public enum CommonError implements ScalarDlError {
       ""),
 
   //
+  // Errors for SECRET_NOT_FOUND(415)
+  //
+  SECRET_NOT_FOUND(
+      StatusCode.SECRET_NOT_FOUND, "001", "The specified secret is not found.", "", ""),
+
+  //
   // Errors for DATABASE_ERROR(500)
   //
   BINDING_CERTIFICATE_FAILED(

--- a/common/src/main/java/com/scalar/dl/ledger/service/Constants.java
+++ b/common/src/main/java/com/scalar/dl/ledger/service/Constants.java
@@ -1,5 +1,0 @@
-package com.scalar.dl.ledger.service;
-
-public class Constants {
-  public static final String KEYS_JSON_NAME = "_keys";
-}

--- a/common/src/main/java/com/scalar/dl/ledger/service/StatusCode.java
+++ b/common/src/main/java/com/scalar/dl/ledger/service/StatusCode.java
@@ -126,6 +126,9 @@ public enum StatusCode {
   /** StatusCode: 414. This indicates that the argument is invalid. */
   INVALID_ARGUMENT(414),
 
+  /** StatusCode: 415. This indicates that the given secret is not found. */
+  SECRET_NOT_FOUND(415),
+
   /**
    * StatusCode: 500. This indicates that the system encountered a database error such as IO error.
    */

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
@@ -92,6 +92,7 @@ import com.scalar.dl.ledger.exception.ConflictException;
 import com.scalar.dl.ledger.exception.ContractContextException;
 import com.scalar.dl.ledger.exception.LedgerException;
 import com.scalar.dl.ledger.exception.MissingContractException;
+import com.scalar.dl.ledger.exception.MissingSecretException;
 import com.scalar.dl.ledger.exception.SignatureException;
 import com.scalar.dl.ledger.model.CertificateRegistrationRequest;
 import com.scalar.dl.ledger.model.ContractExecutionRequest;
@@ -2495,7 +2496,7 @@ public class LedgerServiceEndToEndTest {
   }
 
   @Test
-  public void execute_HmacConfiguredAndInvalidHmacSignatureGiven_ShouldExecuteProperly() {
+  public void execute_HmacConfiguredAndInvalidHmacSignatureGiven_ShouldThrowSignatureException() {
     // Arrange
     Properties props2 = createProperties();
     props2.put(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
@@ -2528,6 +2529,43 @@ public class LedgerServiceEndToEndTest {
 
     // Assert
     assertThat(thrown).isExactlyInstanceOf(SignatureException.class);
+  }
+
+  @Test
+  public void
+      execute_HmacConfiguredAndValidDigitalSignatureGiven_ShouldThrowMissingSecretException() {
+    // Arrange
+    Properties props2 = createProperties();
+    props2.put(LedgerConfig.AUTHENTICATION_METHOD, AuthenticationMethod.HMAC.getMethod());
+    props2.put(LedgerConfig.AUTHENTICATION_HMAC_CIPHER_KEY, SOME_CIPHER_KEY);
+    createServices(new LedgerConfig(props2));
+    String nonce = UUID.randomUUID().toString();
+    JsonNode contractArgument =
+        mapper
+            .createObjectNode()
+            .put(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_1)
+            .put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1);
+    String argument = Argument.format(contractArgument, nonce, Collections.emptyList());
+
+    byte[] serialized =
+        ContractExecutionRequest.serialize(CREATE_CONTRACT_ID1, argument, ENTITY_ID_A, KEY_VERSION);
+    ContractExecutionRequest request =
+        new ContractExecutionRequest(
+            nonce,
+            ENTITY_ID_A,
+            KEY_VERSION,
+            CREATE_CONTRACT_ID1,
+            argument,
+            Collections.emptyList(),
+            null,
+            dsSigner1.sign(serialized),
+            null);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> ledgerService.execute(request));
+
+    // Assert
+    assertThat(thrown).isExactlyInstanceOf(MissingSecretException.class);
   }
 
   @Test

--- a/ledger/src/main/java/com/scalar/dl/ledger/crypto/SecretManager.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/crypto/SecretManager.java
@@ -9,6 +9,7 @@ import com.google.inject.Inject;
 import com.scalar.dl.ledger.database.SecretRegistry;
 import com.scalar.dl.ledger.error.CommonError;
 import com.scalar.dl.ledger.exception.DatabaseException;
+import com.scalar.dl.ledger.exception.MissingSecretException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.concurrent.Immutable;
 
@@ -56,11 +57,12 @@ public class SecretManager {
    * @param entry a {@code SecretEntry}
    */
   public void register(SecretEntry entry) {
-    SecretEntry existing = registry.lookup(entry.getKey());
-    if (existing != null) {
+    try {
+      registry.lookup(entry.getKey());
       throw new DatabaseException(CommonError.SECRET_ALREADY_REGISTERED);
+    } catch (MissingSecretException e) {
+      registry.bind(entry);
     }
-    registry.bind(entry);
   }
 
   /**

--- a/ledger/src/main/java/com/scalar/dl/ledger/exception/MissingSecretException.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/exception/MissingSecretException.java
@@ -1,0 +1,19 @@
+package com.scalar.dl.ledger.exception;
+
+import com.scalar.dl.ledger.error.ScalarDlError;
+import com.scalar.dl.ledger.service.StatusCode;
+
+public class MissingSecretException extends DatabaseException {
+
+  public MissingSecretException(String message) {
+    super(message, StatusCode.SECRET_NOT_FOUND);
+  }
+
+  public MissingSecretException(String message, Throwable cause) {
+    super(message, cause, StatusCode.SECRET_NOT_FOUND);
+  }
+
+  public MissingSecretException(ScalarDlError error, Object... args) {
+    super(error.buildMessage(args), error.getStatusCode());
+  }
+}

--- a/ledger/src/test/java/com/scalar/dl/ledger/crypto/SecretManagerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/crypto/SecretManagerTest.java
@@ -13,6 +13,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.scalar.dl.ledger.database.SecretRegistry;
 import com.scalar.dl.ledger.exception.DatabaseException;
+import com.scalar.dl.ledger.exception.MissingSecretException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -43,7 +44,8 @@ public class SecretManagerTest {
   @Test
   public void register_ProperSecretEntryGiven_ShouldCallBind() {
     // Arrange
-    when(registry.lookup(entry.getKey())).thenReturn(null);
+    MissingSecretException toThrow = mock(MissingSecretException.class);
+    when(registry.lookup(entry.getKey())).thenThrow(toThrow);
 
     // Act
     manager.register(entry);

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarSecretRegistryTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarSecretRegistryTest.java
@@ -22,6 +22,7 @@ import com.scalar.db.io.Key;
 import com.scalar.dl.ledger.crypto.Cipher;
 import com.scalar.dl.ledger.crypto.SecretEntry;
 import com.scalar.dl.ledger.exception.DatabaseException;
+import com.scalar.dl.ledger.exception.MissingSecretException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,18 +154,17 @@ public class ScalarSecretRegistryTest {
   }
 
   @Test
-  public void lookup_ValidArgumentGivenButEmptyResultReturned_ShouldReturnNull()
+  public void lookup_ValidArgumentGivenButEmptyResultReturned_ShouldThrowMissingSecretException()
       throws ExecutionException {
     // Arrange
     SecretEntry.Key key = new SecretEntry.Key(SOME_ENTITY_ID, SOME_KEY_VERSION);
     when(storage.get(any(Get.class))).thenReturn(Optional.empty());
 
     // Act Assert
-    SecretEntry actual = registry.lookup(key);
+    assertThatThrownBy(() -> registry.lookup(key)).isInstanceOf(MissingSecretException.class);
 
     // Assert
     verify(storage).get(any(Get.class));
-    assertThat(actual).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR fixes NullPointerException when the Ledger server is configured with HMAC, but the client is configured with a digital signature. From the client's perspective, it is recognized as an unknown error when interacting with Ledger.

The exception has been thrown when looking up an invalid secret in `getValidator()` of `SecretManager`. Basically, the fix follows how we register/lookup certificates in `CertificateManager`.

## Related issues and/or PRs

N/A

## Changes made

* Add the status code, exception, and error message for "secret not found"
* Make the lookup for secret non-nullable

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed NullPointerException when a client is misconfigured with a digital signature.