### PR TITLE
Fix status code handling

### DIFF
--- a/common/src/main/java/com/scalar/dl/ledger/server/CommonService.java
+++ b/common/src/main/java/com/scalar/dl/ledger/server/CommonService.java
@@ -130,13 +130,13 @@ public class CommonService {
       case CONTRACT_CONTEXTUAL_ERROR:
       case UNLOADABLE_FUNCTION:
       case INVALID_FUNCTION:
-      case INVALID_ARGUMENT:  
+      case INVALID_ARGUMENT:
         return io.grpc.Status.INVALID_ARGUMENT;
       case CERTIFICATE_NOT_FOUND:
-      case SECRET_NOT_FOUND:
       case CONTRACT_NOT_FOUND:
       case ASSET_NOT_FOUND:
       case FUNCTION_NOT_FOUND:
+      case SECRET_NOT_FOUND:
         return io.grpc.Status.NOT_FOUND;
       case CERTIFICATE_ALREADY_REGISTERED:
       case SECRET_ALREADY_REGISTERED:


### PR DESCRIPTION
## Description

This PR adds missing mapping from ScalarDL status code to gRPC status code. Although it doesn't cause a serious issue, i.e., showing warnings like "SECRET_NOT_FOUND is not mapped to gRPC status code" in a log, we should avoid it. I needed to care about it when adding the status code in #302.

## Related issues and/or PRs

- #302

## Changes made

- Added missing status codes

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed status code handling.