### PR TITLE
Add create-namespace command

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -124,9 +124,9 @@ task LedgerValidation(type: CreateStartScripts) {
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
 
-task MultiLedgersValidation(type: CreateStartScripts) {
-    mainClass = 'com.scalar.dl.client.tool.MultiLedgersValidation'
-    applicationName = 'validate-ledgers'
+task NamespaceCreation(type: CreateStartScripts) {
+    mainClass = 'com.scalar.dl.client.tool.NamespaceCreation'
+    applicationName = 'create-namespace'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
@@ -169,7 +169,7 @@ applicationDistribution.into('bin') {
     from(ContractsListing)
     from(ContractExecution)
     from(LedgerValidation)
-    from(MultiLedgersValidation)
+    from(NamespaceCreation)
     from(ScalarDl)
     from(ScalarDlGc)
     from(StateUpdaterSimpleBench)

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespaceCreation.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespaceCreation.java
@@ -1,0 +1,29 @@
+package com.scalar.dl.client.tool;
+
+import com.scalar.dl.client.exception.ClientException;
+import com.scalar.dl.client.service.ClientService;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(name = "create-namespace", description = "Create a namespace.")
+public class NamespaceCreation extends AbstractClientCommand {
+
+  @CommandLine.Option(
+      names = {"--namespace"},
+      required = true,
+      paramLabel = "NAMESPACE",
+      description = "A namespace name to create.")
+  private String namespace;
+
+  public static void main(String[] args) {
+    int exitCode = new CommandLine(new NamespaceCreation()).execute(args);
+    System.exit(exitCode);
+  }
+
+  @Override
+  protected Integer execute(ClientService service) throws ClientException {
+    service.createNamespace(namespace);
+    Common.printOutput(null);
+    return 0;
+  }
+}

--- a/client/src/main/java/com/scalar/dl/client/tool/ScalarDlCommandLine.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/ScalarDlCommandLine.java
@@ -27,6 +27,7 @@ import picocli.CommandLine.HelpCommand;
       HelpCommand.class,
       LedgerValidation.class,
       SecretRegistration.class,
+      NamespaceCreation.class,
     },
     description = {"These are ScalarDL commands used in various situations:"})
 public class ScalarDlCommandLine {
@@ -77,6 +78,8 @@ public class ScalarDlCommandLine {
     sections.put(
         "%nexecute and list the registered business logic%n",
         Arrays.asList(ContractExecution.class, ContractsListing.class));
+    // Section: manage namespaces.
+    sections.put("%nmanage namespaces%n", Collections.singletonList(NamespaceCreation.class));
     // Section: validate ledger.
     sections.put("%nvalidate ledger%n", Collections.singletonList(LedgerValidation.class));
     // Section: generic contracts.

--- a/client/src/test/java/com/scalar/dl/client/tool/NamespaceCreationTest.java
+++ b/client/src/test/java/com/scalar/dl/client/tool/NamespaceCreationTest.java
@@ -1,0 +1,153 @@
+package com.scalar.dl.client.tool;
+
+import static com.scalar.dl.client.tool.CommandLineTestUtils.createDefaultClientPropertiesFile;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.dl.client.config.ClientConfig;
+import com.scalar.dl.client.config.GatewayClientConfig;
+import com.scalar.dl.client.exception.ClientException;
+import com.scalar.dl.client.service.ClientService;
+import com.scalar.dl.client.service.ClientServiceFactory;
+import com.scalar.dl.ledger.service.StatusCode;
+import java.io.File;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+public class NamespaceCreationTest {
+  private CommandLine commandLine;
+
+  @BeforeEach
+  void setup() {
+    commandLine = new CommandLine(new NamespaceCreation());
+  }
+
+  @Nested
+  @DisplayName("#call()")
+  class call {
+    @Test
+    @DisplayName("returns 0 as exit code")
+    void returns0AsExitCode() throws ClientException {
+      // Arrange
+      String[] args =
+          new String[] {
+            // Set the required options.
+            "--properties=PROPERTIES_FILE", "--namespace=test_namespace",
+          };
+      NamespaceCreation command = parseArgs(args);
+      ClientService serviceMock = mock(ClientService.class);
+
+      // Act
+      int exitCode = command.execute(serviceMock);
+
+      // Assert
+      assertThat(exitCode).isEqualTo(0);
+      verify(serviceMock).createNamespace("test_namespace");
+    }
+
+    @Nested
+    @DisplayName("where useGateway option is true")
+    class whereUseGatewayOptionIsTrue {
+      @Test
+      @DisplayName("create ClientService with GatewayClientConfig")
+      public void createClientServiceWithGatewayClientConfig(@TempDir Path tempDir)
+          throws Exception {
+        // Arrange
+        File file = createDefaultClientPropertiesFile(tempDir, "client.props");
+        String propertiesOption = String.format("--properties=%s", file.getAbsolutePath());
+        String[] args =
+            new String[] {
+              // Set the required options.
+              propertiesOption,
+              "--namespace=test-namespace",
+              // Enable Gateway.
+              "--use-gateway"
+            };
+        NamespaceCreation command = parseArgs(args);
+        ClientServiceFactory factory = mock(ClientServiceFactory.class);
+        doReturn(mock(ClientService.class)).when(factory).create(any(GatewayClientConfig.class));
+
+        // Act
+        command.call(factory);
+
+        // Verify
+        verify(factory).create(any(GatewayClientConfig.class));
+        verify(factory, never()).create(any(ClientConfig.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("where useGateway option is false")
+    class whereUseGatewayOptionIsFalse {
+      @Test
+      @DisplayName("create ClientService with ClientConfig")
+      public void createClientServiceWithClientConfig(@TempDir Path tempDir) throws Exception {
+        // Arrange
+        File file = createDefaultClientPropertiesFile(tempDir, "client.props");
+        String propertiesOption = String.format("--properties=%s", file.getAbsolutePath());
+        String[] args =
+            new String[] {
+              // Set the required options.
+              propertiesOption, "--namespace=test-namespace",
+              // Gateway is disabled by default.
+            };
+        NamespaceCreation command = parseArgs(args);
+        ClientServiceFactory factory = mock(ClientServiceFactory.class);
+        doReturn(mock(ClientService.class)).when(factory).create(any(ClientConfig.class));
+
+        // Act
+        command.call(factory);
+
+        // Verify
+        verify(factory).create(any(ClientConfig.class));
+        verify(factory, never()).create(any(GatewayClientConfig.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("where ClientService throws ClientException")
+    class whereClientExceptionIsThrownByClientService {
+      @Test
+      @DisplayName("returns 1 as exit code")
+      void returns1AsExitCode(@TempDir Path tempDir) throws Exception {
+        // Arrange
+        File file = createDefaultClientPropertiesFile(tempDir, "client.props");
+        String[] args =
+            new String[] {
+              // Set the required options.
+              "--properties=" + file.getAbsolutePath(), "--namespace=test-namespace",
+            };
+        NamespaceCreation command = parseArgs(args);
+        // Mock service that throws an exception.
+        ClientServiceFactory factoryMock = mock(ClientServiceFactory.class);
+        ClientService serviceMock = mock(ClientService.class);
+        when(factoryMock.create(any(ClientConfig.class))).thenReturn(serviceMock);
+        doThrow(new ClientException("", StatusCode.RUNTIME_ERROR))
+            .when(serviceMock)
+            .createNamespace("test-namespace");
+
+        // Act
+        int exitCode = command.call(factoryMock);
+
+        // Assert
+        assertThat(exitCode).isEqualTo(1);
+        verify(factoryMock).close();
+      }
+    }
+  }
+
+  private NamespaceCreation parseArgs(String[] args) {
+    return CommandLineTestUtils.parseArgs(commandLine, NamespaceCreation.class, args);
+  }
+}

--- a/client/src/test/java/com/scalar/dl/client/tool/ScalarDlCommandLineTest.java
+++ b/client/src/test/java/com/scalar/dl/client/tool/ScalarDlCommandLineTest.java
@@ -57,6 +57,9 @@ public class ScalarDlCommandLineTest {
               "  execute-contract       Execute a specified contract.",
               "  list-contracts         List registered contracts.",
               "",
+              "manage namespaces",
+              "  create-namespace       Create a namespace.",
+              "",
               "validate ledger",
               "  validate-ledger        Validate a specified asset in a ledger.",
               "",
@@ -97,6 +100,7 @@ public class ScalarDlCommandLineTest {
                 CommandLine.HelpCommand.class,
                 LedgerValidation.class,
                 SecretRegistration.class,
+                NamespaceCreation.class,
               });
     }
   }


### PR DESCRIPTION
## Description

This PR adds the `create-namespace` CLI command.

## Related issues and/or PRs

- #322

## Changes made

- Add the `create-namespace` CLI command.
- Remove the obsolete command, MultiLedgersValidation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added the create-namespace command.
