### PR TITLE
Fix CVE-2025-47907 and CVE-2025-58183

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.40
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.42
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/


### PR DESCRIPTION
## Description

This PR fixes CVE-2025-47907 and CVE-2025-58183.

## Related issues and/or PRs

N/A

## Changes made

- Upgrade the `grpc_health_probe` version

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed CVE-2025-47907 and CVE-2025-58183.