### PR TITLE
Backport to branch(3.12) : Fix CVE-2025-47907 and CVE-2025-58183

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/busybox:1.36 AS tools
 
 ENV DOCKERIZE_VERSION v0.6.1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.40
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.42
 
 # Install dockerize
 RUN set -x && \


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/364
- **Commit to backport:** 9ff92d9c4bdd6b78d55c9be2864b0f6a970aebda

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.12-pull-364 &&
git cherry-pick --no-rerere-autoupdate -m1 9ff92d9c4bdd6b78d55c9be2864b0f6a970aebda
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!