### PR TITLE
Fix parameter name for client entity ID

### DIFF
--- a/client/conf/client.properties.for.docker
+++ b/client/conf/client.properties.for.docker
@@ -8,7 +8,7 @@ scalar.dl.client.server.port=${env:SCALAR_DL_CLIENT_SERVER_PORT:-}
 # Optional. A port number of the server for privileged services. Use 50052 by default if not specified.
 scalar.dl.client.server.privileged_port=${env:SCALAR_DL_CLIENT_SERVER_PRIVILEGED_PORT:-}
 
-# This will be deleted in release 5.0.0. Use scalar.dl.client.entity_id instead.
+# This will be deleted in release 5.0.0. Use scalar.dl.client.entity.id instead.
 scalar.dl.client.cert_holder_id=${env:SCALAR_DL_CLIENT_CERT_HOLDER_ID:-}
 
 # This will be deleted in release 5.0.0. Use scalar.dl.client.entity.identity.digital_signature.cert_version instead.
@@ -27,7 +27,7 @@ scalar.dl.client.private_key_path=${env:SCALAR_DL_CLIENT_PRIVATE_KEY_PATH:-}
 scalar.dl.client.private_key_pem=${env:SCALAR_DL_CLIENT_PRIVATE_KEY_PEM:-}
 
 # A unique ID of a requester (e.g., a user or a device).
-scalar.dl.client.entity_id=${env:SCALAR_DL_CLIENT_ENTITY_ID:-}
+scalar.dl.client.entity.id=${env:SCALAR_DL_CLIENT_ENTITY_ID:-}
 
 # A secret key for HMAC, which is required if HMAC is used for authentication.
 scalar.dl.client.entity.identity.hmac.secret_key=${env:SCALAR_DL_CLIENT_ENTITY_IDENTITY_HMAC_SECRET_KEY:-}

--- a/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
@@ -62,11 +62,11 @@ public class ClientConfig {
   public static final String SERVER_PRIVILEGED_PORT = PREFIX + "server.privileged_port";
   /**
    * <code>scalar.dl.client.cert_holder_id</code><br>
-   * If both {@code scalar.dl.client.cert_holder_id} and {@code scalar.dl.client.entity_id} are
-   * specified, {@code scalar.dl.client.entity_id} will be used.
+   * If both {@code scalar.dl.client.cert_holder_id} and {@code scalar.dl.client.entity.id} are
+   * specified, {@code scalar.dl.client.entity.id} will be used.
    *
    * @deprecated This variable will be deleted in release 5.0.0. Use {@code
-   *     scalar.dl.client.entity_id} instead.
+   *     scalar.dl.client.entity.id} instead.
    */
   @Deprecated public static final String CERT_HOLDER_ID = PREFIX + "cert_holder_id";
   /**


### PR DESCRIPTION
## Description

This PR fixes the parameter name for the client entity ID, which affects client Docker configurations and Javadoc. The doc site has already been fixed, as far as I checked. Thank you, @KodaiD.



## Related issues and/or PRs

N/A

## Changes made

- Fix the parameter name in the template file.
- Fix Javadoc comments in `ClientConfig`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed parameter name for client entity ID.