### PR TITLE
Backport to branch(3.12) : Fix parameter name for client entity ID

### DIFF
--- a/client/conf/client.properties.tmpl
+++ b/client/conf/client.properties.tmpl
@@ -8,7 +8,7 @@ scalar.dl.client.server.port={{ default .Env.SCALAR_DL_CLIENT_SERVER_PORT "" }}
 # Optional. A port number of the server for privileged services. Use 50052 by default if not specified.
 scalar.dl.client.server.privileged_port={{ default .Env.SCALAR_DL_CLIENT_SERVER_PRIVILEGED_PORT "" }}
 
-# This will be deleted in release 5.0.0. Use scalar.dl.client.entity_id instead.
+# This will be deleted in release 5.0.0. Use scalar.dl.client.entity.id instead.
 scalar.dl.client.cert_holder_id={{ default .Env.SCALAR_DL_CLIENT_CERT_HOLDER_ID "" }}
 
 # This will be deleted in release 5.0.0. Use scalar.dl.client.entity.identity.digital_signature.cert_version instead.
@@ -27,7 +27,7 @@ scalar.dl.client.private_key_path={{ default .Env.SCALAR_DL_CLIENT_PRIVATE_KEY_P
 scalar.dl.client.private_key_pem={{ default .Env.SCALAR_DL_CLIENT_PRIVATE_KEY_PEM "" }}
 
 # A unique ID of a requester (e.g., a user or a device).
-scalar.dl.client.entity_id={{ default .Env.SCALAR_DL_CLIENT_ENTITY_ID "" }}
+scalar.dl.client.entity.id={{ default .Env.SCALAR_DL_CLIENT_ENTITY_ID "" }}
 
 # A secret key for HMAC, which is required if HMAC is used for authentication.
 scalar.dl.client.entity.identity.hmac.secret_key={{ default .Env.SCALAR_DL_CLIENT_ENTITY_IDENTITY_HMAC_SECRET_KEY "" }}

--- a/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
@@ -62,11 +62,11 @@ public class ClientConfig {
   public static final String SERVER_PRIVILEGED_PORT = PREFIX + "server.privileged_port";
   /**
    * <code>scalar.dl.client.cert_holder_id</code><br>
-   * If both {@code scalar.dl.client.cert_holder_id} and {@code scalar.dl.client.entity_id} are
-   * specified, {@code scalar.dl.client.entity_id} will be used.
+   * If both {@code scalar.dl.client.cert_holder_id} and {@code scalar.dl.client.entity.id} are
+   * specified, {@code scalar.dl.client.entity.id} will be used.
    *
    * @deprecated This variable will be deleted in release 5.0.0. Use {@code
-   *     scalar.dl.client.entity_id} instead.
+   *     scalar.dl.client.entity.id} instead.
    */
   @Deprecated public static final String CERT_HOLDER_ID = PREFIX + "cert_holder_id";
   /**


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/376
- **Commit to backport:** 1a2257be086a0c8e07d584b34fff93357c3681c1

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.12-pull-376 &&
git cherry-pick --no-rerere-autoupdate -m1 1a2257be086a0c8e07d584b34fff93357c3681c1
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!