### PR TITLE
Fix to specify key path instead of key itself

### DIFF
--- a/.github/workflows/scalar.yml
+++ b/.github/workflows/scalar.yml
@@ -161,7 +161,6 @@ jobs:
       - name: Write private key to file
         run: |
           echo "${{ secrets.LEDGER_PROOF_PRIVATE_KEY_PEM }}" > /tmp/ledger-key.pem
-          chmod 600 /tmp/ledger-key.pem
 
       - name: Start Ledger server
         run: |
@@ -229,7 +228,6 @@ jobs:
       - name: Write private key to file
         run: |
           echo "${{ secrets.LEDGER_PROOF_PRIVATE_KEY_PEM }}" > /tmp/ledger-key.pem
-          chmod 600 /tmp/ledger-key.pem
 
       - name: Start Ledger server
         run: |
@@ -297,7 +295,6 @@ jobs:
       - name: Write private key to file
         run: |
           echo "${{ secrets.LEDGER_PROOF_PRIVATE_KEY_PEM }}" > /tmp/ledger-key.pem
-          chmod 600 /tmp/ledger-key.pem
 
       - name: Start Ledger server
         run: |


### PR DESCRIPTION
## Description

This PR fixes the CI setting to specify a key path instead of the key itself to resolve a CI failure issue in v3 branches.

The CI of v3 branches uses `dockerize` as a template engine, and it cannot handle multi-line strings properly. Therefore, this PR changes the setting to specify a key path instead of the key itself, which includes multiple lines.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/385

## Changes made

- Updated the integration test workflow to specify a key path instead of the key itself.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A