### PR TITLE
Run storage compatibility check tests serially to avoid bucket conflicts

### DIFF
--- a/.github/workflows/scheduled-storage-compatibility-check.yaml
+++ b/.github/workflows/scheduled-storage-compatibility-check.yaml
@@ -4,11 +4,6 @@ on:
   schedule:
     # UTC
     - cron: '0 10 * * SUN'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/scheduled-storage-compatibility-check.yaml'
 
 jobs:
   call-storage-compatibility-check:


### PR DESCRIPTION
## Description

This PR updates the storage compatibility check tests to run serially to avoid bucket conflicts in S3 and GCS.

The workflow runs tests for `master` and `3` branches in parallel. However, those tests use the same buckets, and errors due to conflicts occurred.

## Related issues and/or PRs

- #378 

## Changes made

- Updated the storage compatibility check tests to run serially.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A