### PR TITLE
Fix AssetProof backward compatibility issues

### DIFF
--- a/common/src/main/java/com/scalar/dl/ledger/namespace/Namespaces.java
+++ b/common/src/main/java/com/scalar/dl/ledger/namespace/Namespaces.java
@@ -1,0 +1,9 @@
+package com.scalar.dl.ledger.namespace;
+
+/** Constants related to namespaces. */
+public final class Namespaces {
+  /** The default namespace name. */
+  public static final String DEFAULT = "default";
+
+  private Namespaces() {}
+}

--- a/common/src/main/java/com/scalar/dl/ledger/proof/AssetProof.java
+++ b/common/src/main/java/com/scalar/dl/ledger/proof/AssetProof.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ComparisonChain;
 import com.scalar.dl.ledger.crypto.SignatureValidator;
 import com.scalar.dl.ledger.error.CommonError;
 import com.scalar.dl.ledger.exception.SignatureException;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -262,20 +263,25 @@ public class AssetProof {
       String input,
       byte[] hash,
       byte[] prevHash) {
+    // For backward compatibility, the default namespace is not included in the serialization.
+    byte[] namespaceBytes =
+        Namespaces.DEFAULT.equals(namespace)
+            ? new byte[0]
+            : namespace.getBytes(StandardCharsets.UTF_8);
     int prevHashLength = 0;
     if (prevHash != null) {
       prevHashLength = prevHash.length;
     }
     ByteBuffer buffer =
         ByteBuffer.allocate(
-            namespace.getBytes(StandardCharsets.UTF_8).length
+            namespaceBytes.length
                 + id.getBytes(StandardCharsets.UTF_8).length
                 + Integer.BYTES
                 + nonce.getBytes(StandardCharsets.UTF_8).length
                 + input.getBytes(StandardCharsets.UTF_8).length
                 + hash.length
                 + prevHashLength);
-    buffer.put(namespace.getBytes(StandardCharsets.UTF_8));
+    buffer.put(namespaceBytes);
     buffer.put(id.getBytes(StandardCharsets.UTF_8));
     buffer.putInt(age);
     buffer.put(nonce.getBytes(StandardCharsets.UTF_8));

--- a/common/src/test/java/com/scalar/dl/ledger/proof/AssetProofTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/proof/AssetProofTest.java
@@ -1,0 +1,118 @@
+package com.scalar.dl.ledger.proof;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.scalar.dl.ledger.namespace.Namespaces;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class AssetProofTest {
+
+  /**
+   * This test verifies backward compatibility of the serialize() method. Before namespace support
+   * was added, the serialization format was: id + age + nonce + input + hash + prevHash (without
+   * namespace). For the default namespace, we must maintain this legacy format to ensure
+   * compatibility with older Auditor versions that don't include namespace in signature
+   * verification.
+   */
+  @Test
+  public void serialize_withDefaultNamespace_shouldMatchLegacyFormatWithoutNamespace() {
+    // Arrange
+    String id = "asset-id";
+    int age = 1;
+    String nonce = "nonce123";
+    String input = "input-data";
+    byte[] hash = new byte[] {0x01, 0x02, 0x03, 0x04};
+    byte[] prevHash = new byte[] {0x05, 0x06, 0x07, 0x08};
+
+    // Build expected bytes in legacy format (without namespace)
+    byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
+    byte[] nonceBytes = nonce.getBytes(StandardCharsets.UTF_8);
+    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    ByteBuffer expectedBuffer =
+        ByteBuffer.allocate(
+            idBytes.length
+                + Integer.BYTES
+                + nonceBytes.length
+                + inputBytes.length
+                + hash.length
+                + prevHash.length);
+    expectedBuffer.put(idBytes);
+    expectedBuffer.putInt(age);
+    expectedBuffer.put(nonceBytes);
+    expectedBuffer.put(inputBytes);
+    expectedBuffer.put(hash);
+    expectedBuffer.put(prevHash);
+    byte[] expected = expectedBuffer.array();
+
+    // Act
+    byte[] actual = AssetProof.serialize(Namespaces.DEFAULT, id, age, nonce, input, hash, prevHash);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void serialize_withNonDefaultNamespace_shouldIncludeNamespaceInSerialization() {
+    // Arrange
+    String namespace = "custom-namespace";
+    String id = "asset-id";
+    int age = 1;
+    String nonce = "nonce123";
+    String input = "input-data";
+    byte[] hash = new byte[] {0x01, 0x02, 0x03, 0x04};
+    byte[] prevHash = new byte[] {0x05, 0x06, 0x07, 0x08};
+
+    // Build expected bytes with namespace included
+    byte[] namespaceBytes = namespace.getBytes(StandardCharsets.UTF_8);
+    byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
+    byte[] nonceBytes = nonce.getBytes(StandardCharsets.UTF_8);
+    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    ByteBuffer expectedBuffer =
+        ByteBuffer.allocate(
+            namespaceBytes.length
+                + idBytes.length
+                + Integer.BYTES
+                + nonceBytes.length
+                + inputBytes.length
+                + hash.length
+                + prevHash.length);
+    expectedBuffer.put(namespaceBytes);
+    expectedBuffer.put(idBytes);
+    expectedBuffer.putInt(age);
+    expectedBuffer.put(nonceBytes);
+    expectedBuffer.put(inputBytes);
+    expectedBuffer.put(hash);
+    expectedBuffer.put(prevHash);
+    byte[] expected = expectedBuffer.array();
+
+    // Act
+    byte[] actual = AssetProof.serialize(namespace, id, age, nonce, input, hash, prevHash);
+
+    // Assert
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void serialize_withDefaultNamespace_shouldBeShorterThanNonDefaultNamespace() {
+    // Arrange
+    String nonDefaultNamespace = "custom";
+    String id = "asset-id";
+    int age = 0;
+    String nonce = "nonce";
+    String input = "input";
+    byte[] hash = new byte[] {0x01, 0x02};
+    byte[] prevHash = null;
+
+    // Act
+    byte[] defaultResult =
+        AssetProof.serialize(Namespaces.DEFAULT, id, age, nonce, input, hash, prevHash);
+    byte[] nonDefaultResult =
+        AssetProof.serialize(nonDefaultNamespace, id, age, nonce, input, hash, prevHash);
+
+    // Assert
+    assertThat(defaultResult.length + nonDefaultNamespace.length())
+        .isEqualTo(nonDefaultResult.length);
+  }
+}

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/DefaultTamperEvidentAssetComposerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/DefaultTamperEvidentAssetComposerTest.java
@@ -1,8 +1,6 @@
 package com.scalar.dl.ledger.database.scalardb;
 
-import static com.scalar.dl.ledger.statemachine.AssetInput.INPUT_FORMAT_VERSION;
 import static com.scalar.dl.ledger.statemachine.AssetInput.KEY_AGE;
-import static com.scalar.dl.ledger.statemachine.AssetInput.KEY_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -116,13 +114,11 @@ public class DefaultTamperEvidentAssetComposerTest {
     // Assert
     assertThat(puts).hasSize(1);
     Put put = puts.get(ASSET_KEY1);
+    // V1 format (flat structure without namespace hierarchy) is used for backward compatibility
+    // when all assets are in the default namespace
     JsonObject expected =
         Json.createObjectBuilder()
-            .add(
-                DEFAULT_NAMESPACE,
-                Json.createObjectBuilder()
-                    .add(ANY_ID1, Json.createObjectBuilder().add(KEY_AGE, ANY_AGE)))
-            .add(KEY_VERSION, INPUT_FORMAT_VERSION)
+            .add(ANY_ID1, Json.createObjectBuilder().add(KEY_AGE, ANY_AGE))
             .build();
     assertThat(put.getValues().get(AssetAttribute.INPUT))
         .isEqualTo(new TextValue(AssetAttribute.INPUT, new JsonpSerDe().serialize(expected)));
@@ -171,14 +167,12 @@ public class DefaultTamperEvidentAssetComposerTest {
 
     // Assert
     assertThat(puts).hasSize(2);
+    // V1 format (flat structure without namespace hierarchy) is used for backward compatibility
+    // when all assets are in the default namespace
     JsonObject expectedInput =
         Json.createObjectBuilder()
-            .add(
-                DEFAULT_NAMESPACE,
-                Json.createObjectBuilder()
-                    .add(ANY_ID1, Json.createObjectBuilder().add(KEY_AGE, ANY_AGE).build())
-                    .add(ANY_ID2, Json.createObjectBuilder().add(KEY_AGE, ANY_AGE).build()))
-            .add(KEY_VERSION, INPUT_FORMAT_VERSION)
+            .add(ANY_ID1, Json.createObjectBuilder().add(KEY_AGE, ANY_AGE).build())
+            .add(ANY_ID2, Json.createObjectBuilder().add(KEY_AGE, ANY_AGE).build())
             .build();
 
     Put put1 = puts.get(ASSET_KEY1);


### PR DESCRIPTION
## Description

This PR fixes backward compatibility issues between namespace-enabled Ledger and older Auditor versions (e.g., 3.12.x) that don't support namespaces. Note that the following issues happen with the Ph.1 namespace feature (i.e., happen without depending on the isolated namespace feature).

### 1. AssetProof Signature Verification Failure

**Problem:** When a new Ledger includes the default namespace in `AssetProof.serialize()`, old Auditors fail signature verification because they serialize proofs without the namespace field.

**Solution:** Modified `AssetProof.serialize()` to exclude the namespace from serialization when the namespace is "default". This ensures the serialized bytes match what old Auditors expect for signature verification. I think this approach is better than making `namespace` in `AssetProof` nullable, since doing so affects many places, requiring "default"-"null" conversion.

### 2. AssetInput Format Mismatch

**Problem:** When a new Ledger returns V2 format input in `AssetProof`, old Auditors' `LockOrderValidator.validate()` throws `INVALID_ASSET_PROOF` error because they store V1 format input in `AssetLockEntry` and perform string comparison.

**V1 format** (without namespace):
```json
{"assetId1":{"age":1},"assetId2":{"age":2}}
```

**V2 format** (with namespace):
```json
{"_version":2,"default":{"assetId1":{"age":1},"assetId2":{"age":2}}}
```

**Solution:** Modified `AssetInput.toString()` to return V1 format when all entries are in the default namespace:
- **Default namespace only**: Returns V1 format (flat structure)
- **Multiple namespaces** or **non-default namespace**: Returns V2 format

## Related issues and/or PRs

- scalar-labs/scalardl-enterprise#1578

## Changes made

- Add a new utility class with a default namespace constant
- Exclude default namespace from signature serialization
- Return V1 format for default namespace entries

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The E2E tests for the fix will be introduced in another PR scalar-labs/scalardl-enterprise#1578. I was able to confirm the fix works by locally using the branch.

## Release notes

Fixed the AssetProof backward compatibility issue in the namespace feature.