### PR TITLE
Fix dependency conflict between Jreleaser and Spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,25 @@
-plugins {
-    id("com.diffplug.spotless") version "8.1.0"
-    id("org.jreleaser") version "1.21.0"
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("com.diffplug.spotless:spotless-plugin-gradle:8.1.0") {
+            // Jreleaser and Spotless plugins have a conflict on this dependency.
+            // Jreleaser requires an older version but Spotless requires a newer version for some
+            // feature we are not using.
+            // See https://github.com/jreleaser/jreleaser/issues/1989.
+            //
+            // We can reconsider this exclusion if Jreleaser updates this dependency in the future.
+            exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
+        }
+    }
 }
+
+plugins {
+    id "org.jreleaser" version "1.22.0"
+}
+
+apply plugin: 'com.diffplug.spotless'
 
 ext {
     projectGroup = 'com.scalar-labs'


### PR DESCRIPTION
## Description

This PR fixes the dependency conflict between Jreleaser and Spotless. The changes are basically the same as scalar-labs/scalardb-cluster#1456. I've confirmed if it works by manually releasing snapshots (and blocked CIs passed successfully).

## Related issues and/or PRs

- scalar-labs/scalardb-cluster#1456

## Changes made

- Exclude `org.eclipse.jgit` dependency of the Gradle spotless plugin that conflicts with the version required by the Jreleaser plugin.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A