### PR TITLE
Add context namespace for register-cert

### DIFF
--- a/client/src/main/java/com/scalar/dl/client/error/ClientError.java
+++ b/client/src/main/java/com/scalar/dl/client/error/ClientError.java
@@ -104,6 +104,10 @@ public enum ClientError implements ScalarDlError {
       ""),
   SERVICE_NAMESPACE_NAME_CANNOT_BE_NULL(
       StatusCode.INVALID_ARGUMENT, "025", "The namespace name cannot be null.", "", ""),
+  SERVICE_ENTITY_ID_CANNOT_BE_NULL(
+      StatusCode.INVALID_ARGUMENT, "026", "The entity ID cannot be null.", "", ""),
+  SERVICE_CERT_PEM_CANNOT_BE_NULL(
+      StatusCode.INVALID_ARGUMENT, "027", "The certificate in PEM format cannot be null.", "", ""),
 
   //
   // Errors for RUNTIME_ERROR(502)

--- a/client/src/main/java/com/scalar/dl/client/service/ClientService.java
+++ b/client/src/main/java/com/scalar/dl/client/service/ClientService.java
@@ -103,16 +103,22 @@ public class ClientService implements AutoCloseable {
    * @throws ClientException if a request fails for some reason
    */
   public void bootstrap() {
-    try {
-      if (config.getAuthenticationMethod().equals(AuthenticationMethod.DIGITAL_SIGNATURE)) {
-        registerCertificate();
-      } else {
-        registerSecret();
-      }
-    } catch (ClientException e) {
-      if (!e.getStatusCode().equals(StatusCode.CERTIFICATE_ALREADY_REGISTERED)
-          && !e.getStatusCode().equals(StatusCode.SECRET_ALREADY_REGISTERED)) {
-        throw e;
+    checkClientMode(ClientMode.CLIENT);
+
+    // Skip identity registration for the non-default context namespace because the privileged port
+    // is assumed to be not accessible from clients for the isolated namespace.
+    if (config.getContextNamespace().equals(Namespaces.DEFAULT)) {
+      try {
+        if (config.getAuthenticationMethod().equals(AuthenticationMethod.DIGITAL_SIGNATURE)) {
+          registerCertificate();
+        } else {
+          registerSecret();
+        }
+      } catch (ClientException e) {
+        if (!e.getStatusCode().equals(StatusCode.CERTIFICATE_ALREADY_REGISTERED)
+            && !e.getStatusCode().equals(StatusCode.SECRET_ALREADY_REGISTERED)) {
+          throw e;
+        }
       }
     }
 
@@ -144,18 +150,39 @@ public class ClientService implements AutoCloseable {
    * @throws ClientException if a request fails for some reason
    */
   public void registerCertificate() {
-    checkClientMode(ClientMode.CLIENT);
     checkState(
         config.getDigitalSignatureIdentityConfig() != null,
         ClientError.CONFIG_DIGITAL_SIGNATURE_AUTHENTICATION_NOT_CONFIGURED.buildMessage());
+    registerCertificate(
+        config.getContextNamespace(),
+        config.getDigitalSignatureIdentityConfig().getEntityId(),
+        config.getDigitalSignatureIdentityConfig().getCertVersion(),
+        config.getDigitalSignatureIdentityConfig().getCert());
+  }
+
+  /**
+   * Registers a certificate to the specified namespace for digital signature authentication.
+   *
+   * @param namespace a namespace
+   * @param entityId an entity ID
+   * @param version a version of the certificate
+   * @param pem a certificate in PEM format
+   * @throws ClientException if a request fails for some reason
+   */
+  public void registerCertificate(
+      @Nullable String namespace, String entityId, int version, String pem) {
+    checkClientMode(ClientMode.CLIENT);
+    checkArgument(entityId != null, ClientError.SERVICE_ENTITY_ID_CANNOT_BE_NULL.buildMessage());
+    checkArgument(pem != null, ClientError.SERVICE_CERT_PEM_CANNOT_BE_NULL.buildMessage());
+
     CertificateRegistrationRequest.Builder builder =
         CertificateRegistrationRequest.newBuilder()
-            .setEntityId(config.getDigitalSignatureIdentityConfig().getEntityId())
-            .setKeyVersion(config.getDigitalSignatureIdentityConfig().getCertVersion())
-            .setCertPem(config.getDigitalSignatureIdentityConfig().getCert());
+            .setEntityId(entityId)
+            .setKeyVersion(version)
+            .setCertPem(pem);
 
-    if (!config.getContextNamespace().equals(Namespaces.DEFAULT)) {
-      builder.setContextNamespace(config.getContextNamespace());
+    if (namespace != null && !namespace.equals(Namespaces.DEFAULT)) {
+      builder.setContextNamespace(namespace);
     }
 
     handler.registerCertificate(builder.build());

--- a/client/src/main/java/com/scalar/dl/client/tool/CertificateRegistration.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/CertificateRegistration.java
@@ -1,12 +1,48 @@
 package com.scalar.dl.client.tool;
 
+import static com.scalar.dl.client.util.Common.fileToString;
+
 import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.ClientService;
 import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 @Command(name = "register-cert", description = "Register a specified certificate.")
 public class CertificateRegistration extends AbstractClientCommand {
+
+  @ArgGroup(exclusive = false)
+  private NamespaceOptions namespaceOptions;
+
+  static class NamespaceOptions {
+    @Option(
+        names = {"--namespace"},
+        required = true,
+        paramLabel = "NAMESPACE",
+        description = "A namespace where the certificate is registered.")
+    String namespace;
+
+    @Option(
+        names = {"--entity-id"},
+        required = true,
+        paramLabel = "ENTITY_ID",
+        description = "An entity ID for the certificate.")
+    String entityId;
+
+    @Option(
+        names = {"--cert-path"},
+        required = true,
+        paramLabel = "CERT_PATH",
+        description = "A path to the certificate file in PEM format.")
+    String certPath;
+
+    @Option(
+        names = {"--cert-version"},
+        paramLabel = "CERT_VERSION",
+        description = "A version of the certificate (default: ${DEFAULT-VALUE}).")
+    int certVersion = 1;
+  }
 
   public static void main(String[] args) {
     int exitCode = new CommandLine(new CertificateRegistration()).execute(args);
@@ -15,7 +51,13 @@ public class CertificateRegistration extends AbstractClientCommand {
 
   @Override
   protected Integer execute(ClientService service) throws ClientException {
-    service.registerCertificate();
+    if (namespaceOptions != null) {
+      String pem = fileToString(namespaceOptions.certPath);
+      service.registerCertificate(
+          namespaceOptions.namespace, namespaceOptions.entityId, namespaceOptions.certVersion, pem);
+    } else {
+      service.registerCertificate();
+    }
     Common.printOutput(null);
     return 0;
   }

--- a/client/src/main/java/com/scalar/dl/client/util/Common.java
+++ b/client/src/main/java/com/scalar/dl/client/util/Common.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 public class Common {
@@ -17,6 +18,10 @@ public class Common {
     } catch (IOException e) {
       throw new ClientException(ClientError.READING_FILE_FAILED, e, filePath, e.getMessage());
     }
+  }
+
+  public static String fileToString(String filePath) {
+    return new String(fileToBytes(filePath), StandardCharsets.UTF_8);
   }
 
   public static byte[] getClassBytes(Class<?> clazz) {

--- a/client/src/test/java/com/scalar/dl/client/service/ClientServiceTest.java
+++ b/client/src/test/java/com/scalar/dl/client/service/ClientServiceTest.java
@@ -217,6 +217,7 @@ public class ClientServiceTest {
   public void bootstrap_OtherExceptionThrown_ShouldThrowException() {
     // Arrange
     ClientException exception = new ClientException("Invalid request", StatusCode.INVALID_REQUEST);
+    when(config.getClientMode()).thenReturn(ClientMode.CLIENT);
     when(config.getAuthenticationMethod()).thenReturn(AuthenticationMethod.DIGITAL_SIGNATURE);
     doThrow(exception).when(service).registerCertificate();
 
@@ -260,6 +261,22 @@ public class ClientServiceTest {
     verify(service).registerCertificate();
     verify(service, never())
         .registerContract(anyString(), anyString(), any(byte[].class), eq((String) null));
+  }
+
+  @Test
+  public void bootstrap_NonDefaultContextNamespaceGiven_ShouldSkipCertificateRegistration() {
+    // Arrange
+    when(config.getClientMode()).thenReturn(ClientMode.CLIENT);
+    when(config.getAuthenticationMethod()).thenReturn(AuthenticationMethod.DIGITAL_SIGNATURE);
+    when(config.getContextNamespace()).thenReturn(ANY_NAMESPACE);
+    when(config.isAuditorEnabled()).thenReturn(false);
+
+    // Act
+    service.bootstrap();
+
+    // Assert
+    verify(service, never()).registerCertificate();
+    verify(service, never()).registerSecret();
   }
 
   @Test
@@ -314,6 +331,44 @@ public class ClientServiceTest {
     InOrder inOrder = inOrder(auditorClient, client);
     inOrder.verify(auditorClient).register(expected);
     inOrder.verify(client).register(expected);
+  }
+
+  @Test
+  public void
+      registerCertificate_WithNamespaceGiven_ShouldRegisterWithContextNamespaceForNonDefaultNamespace() {
+    // Arrange
+    when(config.getClientMode()).thenReturn(ClientMode.CLIENT);
+
+    // Act
+    service.registerCertificate(ANY_NAMESPACE, ANY_ENTITY_ID, ANY_KEY_VERSION, ANY_CERT);
+
+    // Assert
+    CertificateRegistrationRequest expected =
+        CertificateRegistrationRequest.newBuilder()
+            .setEntityId(ANY_ENTITY_ID)
+            .setKeyVersion(ANY_KEY_VERSION)
+            .setCertPem(ANY_CERT)
+            .setContextNamespace(ANY_NAMESPACE)
+            .build();
+    verify(handler).registerCertificate(expected);
+  }
+
+  @Test
+  public void registerCertificate_WithNullArguments_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    when(config.getClientMode()).thenReturn(ClientMode.CLIENT);
+
+    // Act & Assert - entityId is null
+    Throwable thrownForNullEntityId =
+        catchThrowable(
+            () -> service.registerCertificate(ANY_NAMESPACE, null, ANY_KEY_VERSION, ANY_CERT));
+    assertThat(thrownForNullEntityId).isExactlyInstanceOf(IllegalArgumentException.class);
+
+    // Act & Assert - pem is null
+    Throwable thrownForNullPem =
+        catchThrowable(
+            () -> service.registerCertificate(ANY_NAMESPACE, ANY_ENTITY_ID, ANY_KEY_VERSION, null));
+    assertThat(thrownForNullPem).isExactlyInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/common/src/main/java/com/scalar/dl/ledger/contract/ContractManager.java
+++ b/common/src/main/java/com/scalar/dl/ledger/contract/ContractManager.java
@@ -13,6 +13,7 @@ import com.scalar.dl.ledger.exception.DatabaseException;
 import com.scalar.dl.ledger.exception.MissingContractException;
 import com.scalar.dl.ledger.exception.UnloadableContractException;
 import com.scalar.dl.ledger.model.ContractRegistrationRequest;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -153,8 +154,10 @@ public class ContractManager {
 
   @VisibleForTesting
   void validateContract(ContractEntry entry) {
+    // TODO: use context namespace
     SignatureValidator validator =
-        clientKeyValidator.getValidator(entry.getEntityId(), entry.getKeyVersion());
+        clientKeyValidator.getValidator(
+            Namespaces.DEFAULT, entry.getEntityId(), entry.getKeyVersion());
 
     byte[] serialized =
         ContractRegistrationRequest.serialize(

--- a/common/src/main/java/com/scalar/dl/ledger/crypto/CertificateManager.java
+++ b/common/src/main/java/com/scalar/dl/ledger/crypto/CertificateManager.java
@@ -11,6 +11,8 @@ import com.scalar.dl.ledger.error.CommonError;
 import com.scalar.dl.ledger.exception.DatabaseException;
 import com.scalar.dl.ledger.exception.MissingCertificateException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -25,7 +27,8 @@ import javax.annotation.concurrent.Immutable;
 public class CertificateManager {
   private static final int CACHE_SIZE = 131072;
   private final CertificateRegistry registry;
-  private final Cache<CertificateEntry.Key, DigitalSignatureValidator> cache;
+  private final ConcurrentMap<String, Cache<CertificateEntry.Key, DigitalSignatureValidator>>
+      caches;
 
   /**
    * Constructs a {@code CertificateManager} with the specified {@link CertificateRegistry}.
@@ -35,48 +38,57 @@ public class CertificateManager {
   @Inject
   public CertificateManager(CertificateRegistry registry) {
     this.registry = checkNotNull(registry);
-    this.cache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
+    this.caches = new ConcurrentHashMap<>();
   }
 
   @VisibleForTesting
   @SuppressFBWarnings("EI_EXPOSE_REP2")
   public CertificateManager(
-      CertificateRegistry registry, Cache<CertificateEntry.Key, DigitalSignatureValidator> cache) {
+      CertificateRegistry registry,
+      ConcurrentMap<String, Cache<CertificateEntry.Key, DigitalSignatureValidator>> caches) {
     this.registry = registry;
-    this.cache = cache;
+    this.caches = caches;
   }
 
   /**
    * Stores the specified {@code CertificateEntry} in a {@link CertificateRegistry}. Will throw a
    * {@link DatabaseException} if the certificate has already been registered.
    *
+   * @param namespace a namespace to register the certificate
    * @param entry a {@code CertificateEntry}
    */
-  public void register(CertificateEntry entry) {
+  public void register(String namespace, CertificateEntry entry) {
     try {
-      registry.lookup(entry.getKey());
+      registry.lookup(namespace, entry.getKey());
       throw new DatabaseException(CommonError.CERTIFICATE_ALREADY_REGISTERED);
     } catch (MissingCertificateException e) {
-      registry.bind(entry);
+      registry.bind(namespace, entry);
     }
   }
 
   /**
    * Returns a {@link DigitalSignatureValidator} for the given {@link CertificateEntry.Key}.
    *
+   * @param namespace a namespace for the certificate
    * @param key {@link CertificateEntry.Key}
    * @return a {@link DigitalSignatureValidator}
    */
-  public DigitalSignatureValidator getValidator(CertificateEntry.Key key) {
+  public DigitalSignatureValidator getValidator(String namespace, CertificateEntry.Key key) {
+    Cache<CertificateEntry.Key, DigitalSignatureValidator> cache =
+        caches.computeIfAbsent(namespace, this::createCache);
     DigitalSignatureValidator validator = cache.getIfPresent(key);
     if (validator != null) {
       return validator;
     }
 
-    CertificateEntry entry = registry.lookup(key);
+    CertificateEntry entry = registry.lookup(namespace, key);
     validator = new DigitalSignatureValidator(entry.getPem());
     cache.put(key, validator);
 
     return validator;
+  }
+
+  private Cache<CertificateEntry.Key, DigitalSignatureValidator> createCache(String namespace) {
+    return CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
   }
 }

--- a/common/src/main/java/com/scalar/dl/ledger/crypto/ClientKeyValidator.java
+++ b/common/src/main/java/com/scalar/dl/ledger/crypto/ClientKeyValidator.java
@@ -30,9 +30,9 @@ public class ClientKeyValidator {
     this.validators = new ConcurrentHashMap<>();
   }
 
-  public SignatureValidator getValidator(String entityId, int keyVersion) {
+  public SignatureValidator getValidator(String namespace, String entityId, int keyVersion) {
     if (authMethod == AuthenticationMethod.DIGITAL_SIGNATURE) {
-      return certManager.getValidator(new CertificateEntry.Key(entityId, keyVersion));
+      return certManager.getValidator(namespace, new CertificateEntry.Key(entityId, keyVersion));
     } else {
       if (entityId.equals(AUDITOR_ENTITY_ID)) { // from Auditor
         assert hmacAuthenticatable.getServersAuthenticationHmacSecretKey() != null;

--- a/common/src/main/java/com/scalar/dl/ledger/database/CertificateRegistry.java
+++ b/common/src/main/java/com/scalar/dl/ledger/database/CertificateRegistry.java
@@ -4,9 +4,9 @@ import com.scalar.dl.ledger.crypto.CertificateEntry;
 
 public interface CertificateRegistry {
 
-  void bind(CertificateEntry entry);
+  void bind(String namespace, CertificateEntry entry);
 
-  void unbind(CertificateEntry.Key key);
+  void unbind(String namespace, CertificateEntry.Key key);
 
-  CertificateEntry lookup(CertificateEntry.Key key);
+  CertificateEntry lookup(String namespace, CertificateEntry.Key key);
 }

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceIntegrationTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceIntegrationTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -177,7 +178,8 @@ public class LedgerServiceIntegrationTest {
 
     dsSigner = new DigitalSignatureSigner(PRIVATE_KEY_A);
     dsValidator = new DigitalSignatureValidator(CERTIFICATE_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID_A, KEY_VERSION)).thenReturn(dsValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(dsValidator);
   }
 
   private String prepareArgumentForCreate(String assetId, int amount, String nonce) {
@@ -412,7 +414,8 @@ public class LedgerServiceIntegrationTest {
         prepareRegistrationRequest(dsSigner, CREATE_CONTRACT_ID1, CREATE_CONTRACT_ID1, contract);
     // simulate wrong cert id is specified (then wrong certificate is returned)
     dsValidator = new DigitalSignatureValidator(CERTIFICATE_B);
-    when(clientKeyValidator.getValidator(ENTITY_ID_A, KEY_VERSION)).thenReturn(dsValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(dsValidator);
 
     // Act
     assertThatThrownBy(() -> service.register(request)).isInstanceOf(SignatureException.class);
@@ -426,7 +429,8 @@ public class LedgerServiceIntegrationTest {
     // Arrange
     hmacSigner = new HmacSigner(SECRET_KEY_A);
     hmacValidator = new HmacValidator(SECRET_KEY_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID_A, KEY_VERSION)).thenReturn(hmacValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(hmacValidator);
 
     byte[] contract = "create".getBytes(StandardCharsets.UTF_8);
     ContractRegistrationRequest request =
@@ -444,7 +448,8 @@ public class LedgerServiceIntegrationTest {
     // Arrange
     hmacSigner = new HmacSigner(SECRET_KEY_A);
     hmacValidator = new HmacValidator(SECRET_KEY_B);
-    when(clientKeyValidator.getValidator(ENTITY_ID_A, KEY_VERSION)).thenReturn(hmacValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(hmacValidator);
 
     byte[] contract = "create".getBytes(StandardCharsets.UTF_8);
     ContractRegistrationRequest request =
@@ -648,7 +653,8 @@ public class LedgerServiceIntegrationTest {
     // Arrange
     hmacSigner = new HmacSigner(SECRET_KEY_A);
     hmacValidator = new HmacValidator(SECRET_KEY_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID_A, KEY_VERSION)).thenReturn(hmacValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(hmacValidator);
 
     String argument = prepareJacksonArgumentForCreate(SOME_ASSET_ID_1, SOME_AMOUNT_1, SOME_NONCE);
     ContractEntry entry = prepareContractEntry(CREATE_CONTRACT_ID1, ENTITY_ID_A, KEY_VERSION);
@@ -692,7 +698,8 @@ public class LedgerServiceIntegrationTest {
     // Arrange
     hmacSigner = new HmacSigner(SECRET_KEY_A);
     hmacValidator = new HmacValidator(SECRET_KEY_B);
-    when(clientKeyValidator.getValidator(ENTITY_ID_A, KEY_VERSION)).thenReturn(hmacValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(hmacValidator);
 
     String argument = prepareArgumentForCreate(SOME_ASSET_ID_1, SOME_AMOUNT_1, SOME_NONCE);
     ContractExecutionRequest request =

--- a/ledger/src/main/java/com/scalar/dl/ledger/crypto/AuditorKeyValidator.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/crypto/AuditorKeyValidator.java
@@ -2,6 +2,7 @@ package com.scalar.dl.ledger.crypto;
 
 import com.google.inject.Inject;
 import com.scalar.dl.ledger.config.LedgerConfig;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -21,6 +22,7 @@ public class AuditorKeyValidator {
   public SignatureValidator getValidator() {
     if (config.getServersAuthenticationHmacSecretKey() == null) { // use digital signatures
       return certManager.getValidator(
+          Namespaces.DEFAULT,
           new CertificateEntry.Key(
               config.getAuditorCertHolderId(), config.getAuditorCertVersion()));
     } else { // use HMAC

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarCertificateRegistry.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarCertificateRegistry.java
@@ -37,11 +37,14 @@ public class ScalarCertificateRegistry implements CertificateRegistry, TableMeta
           .addClusteringKey(CertificateEntry.VERSION)
           .build();
   private final DistributedStorage storage;
+  private final ScalarNamespaceResolver namespaceResolver;
 
   @Inject
   @SuppressFBWarnings("EI_EXPOSE_REP2")
-  public ScalarCertificateRegistry(DistributedStorage storage) {
+  public ScalarCertificateRegistry(
+      DistributedStorage storage, ScalarNamespaceResolver namespaceResolver) {
     this.storage = checkNotNull(storage);
+    this.namespaceResolver = checkNotNull(namespaceResolver);
   }
 
   @Override
@@ -50,7 +53,7 @@ public class ScalarCertificateRegistry implements CertificateRegistry, TableMeta
   }
 
   @Override
-  public void bind(CertificateEntry entry) {
+  public void bind(String namespace, CertificateEntry entry) {
     Put put =
         new Put(
                 new Key(CertificateEntry.ENTITY_ID, entry.getEntityId()),
@@ -58,6 +61,7 @@ public class ScalarCertificateRegistry implements CertificateRegistry, TableMeta
             .withValue(CertificateEntry.PEM, entry.getPem())
             .withValue(CertificateEntry.REGISTERED_AT, entry.getRegisteredAt())
             .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace(namespaceResolver.resolve(namespace))
             .forTable(TABLE);
 
     try {
@@ -68,12 +72,13 @@ public class ScalarCertificateRegistry implements CertificateRegistry, TableMeta
   }
 
   @Override
-  public void unbind(CertificateEntry.Key key) {
+  public void unbind(String namespace, CertificateEntry.Key key) {
     Delete delete =
         new Delete(
                 new Key(CertificateEntry.ENTITY_ID, key.getEntityId()),
                 new Key(CertificateEntry.VERSION, key.getKeyVersion()))
             .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace(namespaceResolver.resolve(namespace))
             .forTable(TABLE);
 
     try {
@@ -84,12 +89,13 @@ public class ScalarCertificateRegistry implements CertificateRegistry, TableMeta
   }
 
   @Override
-  public CertificateEntry lookup(CertificateEntry.Key key) {
+  public CertificateEntry lookup(String namespace, CertificateEntry.Key key) {
     Get get =
         new Get(
                 new Key(CertificateEntry.ENTITY_ID, key.getEntityId()),
                 new Key(CertificateEntry.VERSION, key.getKeyVersion()))
             .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace(namespaceResolver.resolve(namespace))
             .forTable(TABLE);
 
     Result result;

--- a/ledger/src/main/java/com/scalar/dl/ledger/service/BaseService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/BaseService.java
@@ -18,6 +18,7 @@ import com.scalar.dl.ledger.model.NamespaceDroppingRequest;
 import com.scalar.dl.ledger.model.NamespacesListingRequest;
 import com.scalar.dl.ledger.model.SecretRegistrationRequest;
 import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -44,7 +45,9 @@ public class BaseService {
   }
 
   public void register(CertificateRegistrationRequest request) {
-    certManager.register(CertificateEntry.from(request));
+    String namespace =
+        request.getContextNamespace() == null ? Namespaces.DEFAULT : request.getContextNamespace();
+    certManager.register(namespace, CertificateEntry.from(request));
   }
 
   public void register(SecretRegistrationRequest request) {
@@ -53,7 +56,12 @@ public class BaseService {
 
   public void register(ContractRegistrationRequest request) {
     SignatureValidator validator =
-        clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion());
+        clientKeyValidator.getValidator(
+            request.getContextNamespace() == null
+                ? Namespaces.DEFAULT
+                : request.getContextNamespace(),
+            request.getEntityId(),
+            request.getKeyVersion());
     request.validateWith(validator);
 
     contractManager.register(ContractEntry.from(request));
@@ -61,7 +69,12 @@ public class BaseService {
 
   public List<ContractEntry> list(ContractsListingRequest request) {
     SignatureValidator validator =
-        clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion());
+        clientKeyValidator.getValidator(
+            request.getContextNamespace() == null
+                ? Namespaces.DEFAULT
+                : request.getContextNamespace(),
+            request.getEntityId(),
+            request.getKeyVersion());
     request.validateWith(validator);
 
     return new ContractScanner(contractManager)

--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerService.java
@@ -27,6 +27,7 @@ import com.scalar.dl.ledger.model.NamespacesListingRequest;
 import com.scalar.dl.ledger.model.SecretRegistrationRequest;
 import com.scalar.dl.ledger.model.StateRetrievalRequest;
 import com.scalar.dl.ledger.model.StateRetrievalResult;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -81,7 +82,12 @@ public class LedgerService {
 
   public ContractExecutionResult execute(ContractExecutionRequest request) {
     SignatureValidator validator =
-        clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion());
+        clientKeyValidator.getValidator(
+            request.getContextNamespace() == null
+                ? Namespaces.DEFAULT
+                : request.getContextNamespace(),
+            request.getEntityId(),
+            request.getKeyVersion());
     request.validateWith(validator);
 
     if (config.isAuditorEnabled()) {
@@ -103,8 +109,10 @@ public class LedgerService {
   }
 
   public ExecutionAbortResult abort(ExecutionAbortRequest request) {
+    // always use the default namespace to authenticate Auditor
     SignatureValidator validator =
-        clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion());
+        clientKeyValidator.getValidator(
+            Namespaces.DEFAULT, request.getEntityId(), request.getKeyVersion());
     request.validateWith(validator);
 
     return new ExecutionAbortResult(executor.abort(request.getNonce()));

--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerValidationService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerValidationService.java
@@ -17,6 +17,7 @@ import com.scalar.dl.ledger.model.AssetProofRetrievalRequest;
 import com.scalar.dl.ledger.model.LedgerValidationRequest;
 import com.scalar.dl.ledger.model.LedgerValidationResult;
 import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import com.scalar.dl.ledger.proof.AssetProof;
 import com.scalar.dl.ledger.statemachine.Context;
 import com.scalar.dl.ledger.statemachine.InternalAsset;
@@ -65,7 +66,12 @@ public class LedgerValidationService extends ValidationService {
   @Override
   public LedgerValidationResult validate(LedgerValidationRequest request) {
     SignatureValidator validator =
-        clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion());
+        clientKeyValidator.getValidator(
+            request.getContextNamespace() == null
+                ? Namespaces.DEFAULT
+                : request.getContextNamespace(),
+            request.getEntityId(),
+            request.getKeyVersion());
     request.validateWith(validator);
 
     if (config.isAuditorEnabled()) {
@@ -82,8 +88,10 @@ public class LedgerValidationService extends ValidationService {
   }
 
   public AssetProof retrieve(AssetProofRetrievalRequest request) {
+    // always use the default namespace to authenticate Auditor
     SignatureValidator validator =
-        clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion());
+        clientKeyValidator.getValidator(
+            Namespaces.DEFAULT, request.getEntityId(), request.getKeyVersion());
     request.validateWith(validator);
 
     String namespace =

--- a/ledger/src/main/java/com/scalar/dl/ledger/validation/ContractValidator.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/validation/ContractValidator.java
@@ -8,6 +8,7 @@ import com.scalar.dl.ledger.crypto.SignatureValidator;
 import com.scalar.dl.ledger.error.LedgerError;
 import com.scalar.dl.ledger.exception.ValidationException;
 import com.scalar.dl.ledger.model.ContractExecutionRequest;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.ledger.statemachine.InternalAsset;
 import com.scalar.dl.ledger.statemachine.Ledger;
@@ -29,8 +30,8 @@ public class ContractValidator implements LedgerValidator {
       Ledger<?> ledger, ContractMachine contract, @Nonnull String namespace, InternalAsset record) {
     ClientIdentityKey clientIdentityKey = contract.getClientIdentityKey();
     SignatureValidator validator =
-        clientKeyValidator.getValidator(
-            clientIdentityKey.getEntityId(), clientIdentityKey.getKeyVersion());
+        clientKeyValidator.getValidator( // TODO: use context namespace
+            Namespaces.DEFAULT, clientIdentityKey.getEntityId(), clientIdentityKey.getKeyVersion());
     byte[] serialized =
         ContractExecutionRequest.serialize(
             ContractEntry.Key.deserialize(record.contractId()).getId(),

--- a/ledger/src/permission-test/java/com/scalar/dl/ledger/service/LedgerServicePermissionTest.java
+++ b/ledger/src/permission-test/java/com/scalar/dl/ledger/service/LedgerServicePermissionTest.java
@@ -114,7 +114,7 @@ public class LedgerServicePermissionTest {
             auditorKeyValidator,
             contractExecutor,
             functionManager);
-    when(clientKeyValidator.getValidator(anyString(), anyInt())).thenReturn(validator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt())).thenReturn(validator);
     when(signer.sign(any())).thenReturn("any_bytes".getBytes(StandardCharsets.UTF_8));
     when(validator.validate(any(), any())).thenReturn(true);
 

--- a/ledger/src/test/java/com/scalar/dl/ledger/contract/ContractManagerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/contract/ContractManagerTest.java
@@ -57,7 +57,7 @@ public class ContractManagerTest {
 
     manager = spy(new ContractManager(registry, loader, clientKeyValidator));
 
-    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyInt());
+    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyString(), anyInt());
     when(validator.validate(any(), any())).thenReturn(true);
     prepareContractEntry();
   }
@@ -231,7 +231,7 @@ public class ContractManagerTest {
     // Arrange
     ContractEntry entry = createContractEntryWith();
     DigitalSignatureValidator validator = new DigitalSignatureValidator(CERTIFICATE_A);
-    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyInt());
+    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyString(), anyInt());
     manager = spy(new ContractManager(registry, loader, clientKeyValidator));
     // NOTICE: it doesn't work if TestContract is defined as an inner class of this
     Class<? extends ContractBase<?>> clazz = TestJsonpBasedContract.class;
@@ -255,7 +255,7 @@ public class ContractManagerTest {
     ContractEntry entry = createContractEntryWith();
     // It will happen in case the certificate entry is tampered
     DigitalSignatureValidator validator = new DigitalSignatureValidator(CERTIFICATE_B);
-    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyInt());
+    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyString(), anyInt());
     manager = spy(new ContractManager(registry, loader, clientKeyValidator));
     // NOTICE: it doesn't work if TestContract is defined as an inner class of this
     Class<? extends ContractBase<?>> clazz = TestJsonpBasedContract.class;
@@ -276,7 +276,7 @@ public class ContractManagerTest {
     // Arrange
     ContractEntry entry = createContractEntryWith();
     DigitalSignatureValidator validator = new DigitalSignatureValidator(CERTIFICATE_A);
-    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyInt());
+    doReturn(validator).when(clientKeyValidator).getValidator(anyString(), anyString(), anyInt());
     manager = spy(new ContractManager(registry, loader, clientKeyValidator));
     SecurityException toThrow = mock(SecurityException.class);
     when(toThrow.getMessage()).thenReturn("details");

--- a/ledger/src/test/java/com/scalar/dl/ledger/crypto/AuditorKeyValidatorTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/crypto/AuditorKeyValidatorTest.java
@@ -3,11 +3,13 @@ package com.scalar.dl.ledger.crypto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.dl.ledger.config.LedgerConfig;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -42,7 +44,7 @@ public class AuditorKeyValidatorTest {
     // Assert
     assertThat(validator).isEqualTo(hmacValidator);
     verify(secretManager).getValidator(SOME_SECRET_KEY);
-    verify(certificateManager, never()).getValidator(any(CertificateEntry.Key.class));
+    verify(certificateManager, never()).getValidator(anyString(), any(CertificateEntry.Key.class));
   }
 
   @Test
@@ -53,7 +55,8 @@ public class AuditorKeyValidatorTest {
     when(config.getAuditorCertVersion()).thenReturn(SOME_KEY_VERSION);
     AuditorKeyValidator auditorKeyValidator =
         new AuditorKeyValidator(config, certificateManager, secretManager);
-    when(certificateManager.getValidator(any())).thenReturn(digitalSignatureValidator);
+    when(certificateManager.getValidator(anyString(), any(CertificateEntry.Key.class)))
+        .thenReturn(digitalSignatureValidator);
 
     // Act
     SignatureValidator validator = auditorKeyValidator.getValidator();
@@ -62,8 +65,7 @@ public class AuditorKeyValidatorTest {
     assertThat(validator).isEqualTo(digitalSignatureValidator);
     verify(certificateManager)
         .getValidator(
-            new CertificateEntry.Key(
-                config.getAuditorCertHolderId(), config.getAuditorCertVersion()));
+            eq(Namespaces.DEFAULT), eq(new CertificateEntry.Key(SOME_ENTITY_ID, SOME_KEY_VERSION)));
     verify(secretManager, never()).getValidator(anyString());
   }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/crypto/CertificateManagerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/crypto/CertificateManagerTest.java
@@ -3,6 +3,7 @@ package com.scalar.dl.ledger.crypto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -13,12 +14,16 @@ import com.google.common.cache.CacheBuilder;
 import com.scalar.dl.ledger.database.CertificateRegistry;
 import com.scalar.dl.ledger.exception.DatabaseException;
 import com.scalar.dl.ledger.exception.MissingCertificateException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class CertificateManagerTest {
+  private static final String SOME_NAMESPACE = "some_namespace";
+  private static final String SOME_OTHER_NAMESPACE = "some_other_namespace";
   private static final String SOME_ENTITY_ID = "some_id";
   private static final int SOME_VERSION = 1;
   private static final String SOME_PEM =
@@ -41,68 +46,95 @@ public class CertificateManagerTest {
   private CertificateEntry entry;
   @Mock private CertificateRegistry registry;
   @Mock private DigitalSignatureValidator validator;
-  private Cache<CertificateEntry.Key, DigitalSignatureValidator> cache;
+  private ConcurrentMap<String, Cache<CertificateEntry.Key, DigitalSignatureValidator>> caches;
   private CertificateManager manager;
 
   @BeforeEach
   public void setUp() {
     MockitoAnnotations.openMocks(this);
 
-    cache = CacheBuilder.newBuilder().maximumSize(128).build();
-    manager = new CertificateManager(registry, cache);
+    caches = new ConcurrentHashMap<>();
+    manager = new CertificateManager(registry, caches);
     entry = new CertificateEntry(SOME_ENTITY_ID, SOME_VERSION, SOME_PEM, SOME_TIME);
   }
 
   @Test
   public void register_CertificateRegistrationRequestGiven_ShouldCallBind() {
     // Arrange
-    when(registry.lookup(entry.getKey())).thenThrow(MissingCertificateException.class);
+    when(registry.lookup(SOME_NAMESPACE, entry.getKey()))
+        .thenThrow(MissingCertificateException.class);
 
     // Act
-    manager.register(entry);
+    manager.register(SOME_NAMESPACE, entry);
 
     // Assert
-    verify(registry).lookup(entry.getKey());
-    verify(registry).bind(entry);
+    verify(registry).lookup(SOME_NAMESPACE, entry.getKey());
+    verify(registry).bind(SOME_NAMESPACE, entry);
   }
 
   @Test
   public void register_AlreadyRegisteredCertificateGiven_ShouldThrowDatabaseException() {
     // Arrange
-    when(registry.lookup(entry.getKey())).thenReturn(mock(CertificateEntry.class));
+    when(registry.lookup(SOME_NAMESPACE, entry.getKey())).thenReturn(mock(CertificateEntry.class));
 
     // Act
-    assertThatThrownBy(() -> manager.register(entry)).isInstanceOf(DatabaseException.class);
+    assertThatThrownBy(() -> manager.register(SOME_NAMESPACE, entry))
+        .isInstanceOf(DatabaseException.class);
 
     // Assert
-    verify(registry, never()).bind(entry);
+    verify(registry, never()).bind(eq(SOME_NAMESPACE), eq(entry));
   }
 
   @Test
   public void getValidator_holderIdAndVersionGivenAndValidatorNotCached_ShouldGetFromRegistry() {
     // Arrange
-    when(registry.lookup(entry.getKey())).thenReturn(entry);
+    when(registry.lookup(SOME_NAMESPACE, entry.getKey())).thenReturn(entry);
 
     // Act
-    DigitalSignatureValidator actual = manager.getValidator(entry.getKey());
+    DigitalSignatureValidator actual = manager.getValidator(SOME_NAMESPACE, entry.getKey());
 
     // Assert
-    verify(registry).lookup(entry.getKey());
+    verify(registry).lookup(SOME_NAMESPACE, entry.getKey());
     assertThat(actual).isEqualTo(new DigitalSignatureValidator(SOME_PEM));
-    assertThat(cache.asMap()).containsOnly(entry(entry.getKey(), actual));
+    assertThat(caches.get(SOME_NAMESPACE).asMap()).containsOnly(entry(entry.getKey(), actual));
   }
 
   @Test
   public void getValidator_holderIdAndVersionGivenAndValidatorCached_ShouldGetFromCache() {
     // Arrange
+    Cache<CertificateEntry.Key, DigitalSignatureValidator> cache =
+        CacheBuilder.newBuilder().maximumSize(128).build();
     cache.put(entry.getKey(), validator);
+    caches.put(SOME_NAMESPACE, cache);
 
     // Act
-    DigitalSignatureValidator actual = manager.getValidator(entry.getKey());
+    DigitalSignatureValidator actual = manager.getValidator(SOME_NAMESPACE, entry.getKey());
 
     // Assert
-    verify(registry, never()).lookup(entry.getKey());
+    verify(registry, never()).lookup(SOME_NAMESPACE, entry.getKey());
     assertThat(actual).isEqualTo(validator);
-    assertThat(cache.asMap()).containsOnly(entry(entry.getKey(), actual));
+    assertThat(caches.get(SOME_NAMESPACE).asMap()).containsOnly(entry(entry.getKey(), actual));
+  }
+
+  @Test
+  public void getValidator_DifferentNamespacesGiven_ShouldUseSeparateCaches() {
+    // Arrange
+    CertificateEntry otherEntry =
+        new CertificateEntry(SOME_ENTITY_ID, SOME_VERSION, SOME_PEM, SOME_TIME);
+    when(registry.lookup(SOME_NAMESPACE, entry.getKey())).thenReturn(entry);
+    when(registry.lookup(SOME_OTHER_NAMESPACE, otherEntry.getKey())).thenReturn(otherEntry);
+
+    // Act
+    DigitalSignatureValidator validator1 = manager.getValidator(SOME_NAMESPACE, entry.getKey());
+    DigitalSignatureValidator validator2 =
+        manager.getValidator(SOME_OTHER_NAMESPACE, otherEntry.getKey());
+
+    // Assert
+    verify(registry).lookup(SOME_NAMESPACE, entry.getKey());
+    verify(registry).lookup(SOME_OTHER_NAMESPACE, otherEntry.getKey());
+    assertThat(caches).hasSize(2);
+    assertThat(caches.get(SOME_NAMESPACE).asMap()).containsOnly(entry(entry.getKey(), validator1));
+    assertThat(caches.get(SOME_OTHER_NAMESPACE).asMap())
+        .containsOnly(entry(otherEntry.getKey(), validator2));
   }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/crypto/ClientKeyValidatorTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/crypto/ClientKeyValidatorTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ClientKeyValidatorTest {
+  private static final String SOME_NAMESPACE = "some_namespace";
   private static final String SOME_ENTITY_ID = "entity_id";
   private static final int SOME_KEY_VERSION = 1;
   private static final String SOME_SECRET_KEY = "secret_key";
@@ -40,17 +41,17 @@ public class ClientKeyValidatorTest {
             AuthenticationMethod.DIGITAL_SIGNATURE,
             certificateManager,
             secretManager);
-    when(certificateManager.getValidator(any(CertificateEntry.Key.class)))
+    when(certificateManager.getValidator(anyString(), any(CertificateEntry.Key.class)))
         .thenReturn(digitalSignatureValidator);
 
     // Act
     SignatureValidator validator =
-        clientKeyValidator.getValidator(SOME_ENTITY_ID, SOME_KEY_VERSION);
+        clientKeyValidator.getValidator(SOME_NAMESPACE, SOME_ENTITY_ID, SOME_KEY_VERSION);
 
     // Assert
     assertThat(validator).isEqualTo(digitalSignatureValidator);
     verify(certificateManager)
-        .getValidator(new CertificateEntry.Key(SOME_ENTITY_ID, SOME_KEY_VERSION));
+        .getValidator(SOME_NAMESPACE, new CertificateEntry.Key(SOME_ENTITY_ID, SOME_KEY_VERSION));
     verify(secretManager, never()).getValidator(anyString());
   }
 
@@ -67,12 +68,12 @@ public class ClientKeyValidatorTest {
 
     // Act
     SignatureValidator validator =
-        clientKeyValidator.getValidator(SOME_ENTITY_ID, SOME_KEY_VERSION);
+        clientKeyValidator.getValidator(SOME_NAMESPACE, SOME_ENTITY_ID, SOME_KEY_VERSION);
 
     // Assert
     assertThat(validator).isEqualTo(hmacValidator);
     verify(secretManager).getValidator(new SecretEntry.Key(SOME_ENTITY_ID, SOME_KEY_VERSION));
-    verify(certificateManager, never()).getValidator(any(CertificateEntry.Key.class));
+    verify(certificateManager, never()).getValidator(anyString(), any(CertificateEntry.Key.class));
   }
 
   @Test
@@ -92,12 +93,13 @@ public class ClientKeyValidatorTest {
 
     // Act
     SignatureValidator validator =
-        clientKeyValidator.getValidator(ClientKeyValidator.AUDITOR_ENTITY_ID, SOME_KEY_VERSION);
+        clientKeyValidator.getValidator(
+            SOME_NAMESPACE, ClientKeyValidator.AUDITOR_ENTITY_ID, SOME_KEY_VERSION);
 
     // Assert
     assertThat(validator).isEqualTo(hmacValidator);
     verify(secretManager, never()).getValidator(any(SecretEntry.Key.class));
-    verify(certificateManager, never()).getValidator(any(CertificateEntry.Key.class));
+    verify(certificateManager, never()).getValidator(anyString(), any(CertificateEntry.Key.class));
     verify(clientKeyValidator).createHmacValidator(SOME_SECRET_KEY);
   }
 
@@ -115,16 +117,18 @@ public class ClientKeyValidatorTest {
     when(serversHmacAuthenticatable.getServersAuthenticationHmacSecretKey())
         .thenReturn(SOME_SECRET_KEY);
     doReturn(hmacValidator).when(clientKeyValidator).createHmacValidator(anyString());
-    clientKeyValidator.getValidator(ClientKeyValidator.AUDITOR_ENTITY_ID, SOME_KEY_VERSION);
+    clientKeyValidator.getValidator(
+        SOME_NAMESPACE, ClientKeyValidator.AUDITOR_ENTITY_ID, SOME_KEY_VERSION);
 
     // Act
     SignatureValidator validator2 =
-        clientKeyValidator.getValidator(ClientKeyValidator.AUDITOR_ENTITY_ID, SOME_KEY_VERSION);
+        clientKeyValidator.getValidator(
+            SOME_NAMESPACE, ClientKeyValidator.AUDITOR_ENTITY_ID, SOME_KEY_VERSION);
 
     // Assert
     assertThat(validator2).isEqualTo(hmacValidator);
     verify(secretManager, never()).getValidator(any(SecretEntry.Key.class));
-    verify(certificateManager, never()).getValidator(any(CertificateEntry.Key.class));
+    verify(certificateManager, never()).getValidator(anyString(), any(CertificateEntry.Key.class));
     verify(clientKeyValidator).createHmacValidator(SOME_SECRET_KEY);
   }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarCertificateRegistryTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarCertificateRegistryTest.java
@@ -29,7 +29,6 @@ import com.scalar.dl.ledger.exception.MissingCertificateException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -38,12 +37,17 @@ public class ScalarCertificateRegistryTest {
   private static final int ANY_VERSION = 1;
   private static final String ANY_PEM = "pem";
   private static final long ANY_TIME = 1L;
+  private static final String ANY_NAMESPACE = "test_namespace";
+  private static final String RESOLVED_NAMESPACE = "resolved_namespace";
   @Mock private DistributedStorage storage;
-  @InjectMocks private ScalarCertificateRegistry registry;
+  @Mock private ScalarNamespaceResolver namespaceResolver;
+  private ScalarCertificateRegistry registry;
 
   @BeforeEach
   public void setUp() {
     MockitoAnnotations.openMocks(this);
+    when(namespaceResolver.resolve(ANY_NAMESPACE)).thenReturn(RESOLVED_NAMESPACE);
+    registry = new ScalarCertificateRegistry(storage, namespaceResolver);
   }
 
   private Optional<Result> configureResult(CertificateEntry entry) {
@@ -70,7 +74,7 @@ public class ScalarCertificateRegistryTest {
     doNothing().when(storage).put(any(Put.class));
 
     // Act Assert
-    assertThatCode(() -> registry.bind(entry)).doesNotThrowAnyException();
+    assertThatCode(() -> registry.bind(ANY_NAMESPACE, entry)).doesNotThrowAnyException();
 
     // Assert
     Put expected =
@@ -80,6 +84,7 @@ public class ScalarCertificateRegistryTest {
             .withValue(CertificateEntry.PEM, ANY_PEM)
             .withValue(CertificateEntry.REGISTERED_AT, ANY_TIME)
             .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace(RESOLVED_NAMESPACE)
             .forTable(ScalarCertificateRegistry.TABLE);
     verify(storage).put(expected);
   }
@@ -91,7 +96,9 @@ public class ScalarCertificateRegistryTest {
 
     // Act Assert
     assertThatThrownBy(
-            () -> registry.bind(new CertificateEntry(null, ANY_VERSION, ANY_PEM, ANY_TIME)))
+            () ->
+                registry.bind(
+                    ANY_NAMESPACE, new CertificateEntry(null, ANY_VERSION, ANY_PEM, ANY_TIME)))
         .isInstanceOf(NullPointerException.class);
 
     // Assert
@@ -107,7 +114,7 @@ public class ScalarCertificateRegistryTest {
     doThrow(toThrow).when(storage).put(any(Put.class));
 
     // Act Assert
-    assertThatThrownBy(() -> registry.bind(entry))
+    assertThatThrownBy(() -> registry.bind(ANY_NAMESPACE, entry))
         .isInstanceOf(DatabaseException.class)
         .hasCause(toThrow);
   }
@@ -119,7 +126,7 @@ public class ScalarCertificateRegistryTest {
     doNothing().when(storage).delete(any(Delete.class));
 
     // Act Assert
-    assertThatCode(() -> registry.unbind(key)).doesNotThrowAnyException();
+    assertThatCode(() -> registry.unbind(ANY_NAMESPACE, key)).doesNotThrowAnyException();
 
     // Assert
     Delete expected =
@@ -127,6 +134,7 @@ public class ScalarCertificateRegistryTest {
                 new Key(CertificateEntry.ENTITY_ID, ANY_ENTITY_ID),
                 new Key(CertificateEntry.VERSION, ANY_VERSION))
             .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace(RESOLVED_NAMESPACE)
             .forTable(ScalarCertificateRegistry.TABLE);
     verify(storage).delete(expected);
   }
@@ -137,7 +145,8 @@ public class ScalarCertificateRegistryTest {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> registry.unbind(new CertificateEntry.Key(null, ANY_VERSION)))
+    assertThatThrownBy(
+            () -> registry.unbind(ANY_NAMESPACE, new CertificateEntry.Key(null, ANY_VERSION)))
         .isInstanceOf(NullPointerException.class);
 
     // Assert
@@ -153,7 +162,7 @@ public class ScalarCertificateRegistryTest {
     doThrow(toThrow).when(storage).delete(any(Delete.class));
 
     // Act Assert
-    assertThatThrownBy(() -> registry.unbind(key))
+    assertThatThrownBy(() -> registry.unbind(ANY_NAMESPACE, key))
         .isInstanceOf(DatabaseException.class)
         .hasCause(toThrow);
   }
@@ -166,7 +175,7 @@ public class ScalarCertificateRegistryTest {
     when(storage.get(any(Get.class))).thenReturn(result);
 
     // Act Assert
-    CertificateEntry actual = registry.lookup(entry.getKey());
+    CertificateEntry actual = registry.lookup(ANY_NAMESPACE, entry.getKey());
 
     // Assert
     assertThat(actual).isEqualTo(entry);
@@ -175,6 +184,7 @@ public class ScalarCertificateRegistryTest {
                 new Key(CertificateEntry.ENTITY_ID, ANY_ENTITY_ID),
                 new Key(CertificateEntry.VERSION, ANY_VERSION))
             .withConsistency(Consistency.SEQUENTIAL)
+            .forNamespace(RESOLVED_NAMESPACE)
             .forTable(ScalarCertificateRegistry.TABLE);
     verify(storage).get(expected);
   }
@@ -185,7 +195,8 @@ public class ScalarCertificateRegistryTest {
     // Arrange
 
     // Act Assert
-    assertThatThrownBy(() -> registry.lookup(new CertificateEntry.Key(null, ANY_VERSION)))
+    assertThatThrownBy(
+            () -> registry.lookup(ANY_NAMESPACE, new CertificateEntry.Key(null, ANY_VERSION)))
         .isInstanceOf(NullPointerException.class);
 
     // Assert
@@ -201,7 +212,8 @@ public class ScalarCertificateRegistryTest {
     when(storage.get(any(Get.class))).thenReturn(Optional.empty());
 
     // Act Assert
-    assertThatThrownBy(() -> registry.lookup(key)).isInstanceOf(MissingCertificateException.class);
+    assertThatThrownBy(() -> registry.lookup(ANY_NAMESPACE, key))
+        .isInstanceOf(MissingCertificateException.class);
 
     // Assert
     verify(storage).get(any(Get.class));
@@ -216,7 +228,7 @@ public class ScalarCertificateRegistryTest {
     when(storage.get(any(Get.class))).thenThrow(toThrow);
 
     // Act Assert
-    assertThatThrownBy(() -> registry.lookup(key))
+    assertThatThrownBy(() -> registry.lookup(ANY_NAMESPACE, key))
         .isInstanceOf(DatabaseException.class)
         .hasCause(toThrow);
 
@@ -233,7 +245,8 @@ public class ScalarCertificateRegistryTest {
     when(storage.get(any(Get.class))).thenReturn(result);
 
     // Act Assert
-    assertThatThrownBy(() -> registry.lookup(key)).isInstanceOf(MissingCertificateException.class);
+    assertThatThrownBy(() -> registry.lookup(ANY_NAMESPACE, key))
+        .isInstanceOf(MissingCertificateException.class);
 
     // Assert
     verify(storage).get(any(Get.class));

--- a/ledger/src/test/java/com/scalar/dl/ledger/service/BaseServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/service/BaseServiceTest.java
@@ -17,6 +17,7 @@ import com.scalar.dl.ledger.contract.ContractManager;
 import com.scalar.dl.ledger.crypto.CertificateManager;
 import com.scalar.dl.ledger.crypto.ClientKeyValidator;
 import com.scalar.dl.ledger.crypto.DigitalSignatureValidator;
+import com.scalar.dl.ledger.crypto.SecretEntry;
 import com.scalar.dl.ledger.crypto.SecretManager;
 import com.scalar.dl.ledger.exception.SignatureException;
 import com.scalar.dl.ledger.model.AbstractRequest;
@@ -97,8 +98,7 @@ public class BaseServiceTest {
   }
 
   private void configureRequestValidation(AbstractRequest request, boolean isValid) {
-    when(clientKeyValidator.getValidator(request.getEntityId(), request.getKeyVersion()))
-        .thenReturn(validator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt())).thenReturn(validator);
     if (isValid) {
       doNothing().when(request).validateWith(validator);
     } else {
@@ -120,26 +120,26 @@ public class BaseServiceTest {
   public void register_ProperCertificateGiven_ShouldRegisterCertificate() {
     // Arrange
     configureCertificateRegistrationRequest(certRegistrationRequest);
-    doNothing().when(certManager).register(any());
+    doNothing().when(certManager).register(anyString(), any());
 
     // Act
     service.register(certRegistrationRequest);
 
     // Assert
-    verify(certManager).register(any());
+    verify(certManager).register(anyString(), any());
   }
 
   @Test
   public void register_ProperSecretGiven_ShouldRegisterSecret() {
     // Arrange
     configureSecretRegistrationRequest(secretRegistrationRequest);
-    doNothing().when(secretManager).register(any());
+    doNothing().when(secretManager).register(any(SecretEntry.class));
 
     // Act
     service.register(secretRegistrationRequest);
 
     // Assert
-    verify(secretManager).register(any());
+    verify(secretManager).register(any(SecretEntry.class));
   }
 
   @Test

--- a/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerServiceTest.java
@@ -114,7 +114,8 @@ public class LedgerServiceTest {
   }
 
   private void configureRequestValidation(AbstractRequest request, boolean isValid) {
-    when(clientKeyValidator.getValidator(anyString(), anyInt())).thenReturn(signatureValidator);
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
+        .thenReturn(signatureValidator);
     if (isValid) {
       doNothing().when(request).validateWith(signatureValidator);
     } else {

--- a/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerValidationServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerValidationServiceTest.java
@@ -282,7 +282,7 @@ public class LedgerValidationServiceTest {
         LedgerValidationRequest.serialize(
             null, ID, 0, Integer.MAX_VALUE, null, ENTITY_ID, KEY_VERSION);
     DigitalSignatureSigner signer = new DigitalSignatureSigner(PRIVATE_KEY_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID, KEY_VERSION))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     JsonpBasedLedgerTracer tracer = mock(JsonpBasedLedgerTracer.class);
     doNothing().when(tracer).setInput(anyString());
@@ -315,7 +315,7 @@ public class LedgerValidationServiceTest {
         LedgerValidationRequest.serialize(
             null, ID, 0, Integer.MAX_VALUE, null, ENTITY_ID, KEY_VERSION);
     DigitalSignatureSigner signer = new DigitalSignatureSigner(PRIVATE_KEY_B);
-    when(clientKeyValidator.getValidator(ENTITY_ID, KEY_VERSION))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     service =
         spy(
@@ -350,7 +350,7 @@ public class LedgerValidationServiceTest {
     byte[] serialized =
         LedgerValidationRequest.serialize(null, ID, 0, AGE, null, ENTITY_ID, KEY_VERSION);
     DigitalSignatureSigner signer = new DigitalSignatureSigner(PRIVATE_KEY_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID, KEY_VERSION))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     when(config.isAuditorEnabled()).thenReturn(true);
     service =
@@ -388,7 +388,7 @@ public class LedgerValidationServiceTest {
         LedgerValidationRequest.serialize(
             NAMESPACE, ID, 0, Integer.MAX_VALUE, null, ENTITY_ID, KEY_VERSION);
     DigitalSignatureSigner signer = new DigitalSignatureSigner(PRIVATE_KEY_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID, KEY_VERSION))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     JsonpBasedLedgerTracer tracer = mock(JsonpBasedLedgerTracer.class);
     doNothing().when(tracer).setInput(anyString());
@@ -568,7 +568,7 @@ public class LedgerValidationServiceTest {
     List<LedgerValidator> validators = createValidators();
     byte[] serialized = AssetProofRetrievalRequest.serialize(null, ID, AGE, ENTITY_ID, KEY_VERSION);
     DigitalSignatureSigner signer = new DigitalSignatureSigner(PRIVATE_KEY_A);
-    when(clientKeyValidator.getValidator(ENTITY_ID, KEY_VERSION))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     service =
         spy(
@@ -594,7 +594,7 @@ public class LedgerValidationServiceTest {
     // Arrange
     byte[] serialized = AssetProofRetrievalRequest.serialize(null, ID, AGE, ENTITY_ID, KEY_VERSION);
     DigitalSignatureSigner signer = new DigitalSignatureSigner(PRIVATE_KEY_B);
-    when(clientKeyValidator.getValidator(ENTITY_ID, KEY_VERSION))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     service =
         spy(

--- a/ledger/src/test/java/com/scalar/dl/ledger/validation/ContractValidatorTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/validation/ContractValidatorTest.java
@@ -63,7 +63,7 @@ public class ContractValidatorTest {
     when(clientIdentityKey.getEntityId()).thenReturn(ENTITY_ID);
     when(clientIdentityKey.getKeyVersion()).thenReturn(CERT_VERSION);
     when(contract.getClientIdentityKey()).thenReturn(clientIdentityKey);
-    when(clientKeyValidator.getValidator(anyString(), anyInt()))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     byte[] signature =
         dsSigner.sign(
@@ -84,7 +84,7 @@ public class ContractValidatorTest {
     when(clientIdentityKey.getEntityId()).thenReturn(ENTITY_ID);
     when(clientIdentityKey.getKeyVersion()).thenReturn(CERT_VERSION);
     when(contract.getClientIdentityKey()).thenReturn(clientIdentityKey);
-    when(clientKeyValidator.getValidator(anyString(), anyInt()))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     String tamperedContractId = CONTRACT_ID_IN_ASSET + "x";
     byte[] signature =
@@ -107,7 +107,7 @@ public class ContractValidatorTest {
     when(clientIdentityKey.getEntityId()).thenReturn(ENTITY_ID);
     when(clientIdentityKey.getKeyVersion()).thenReturn(CERT_VERSION);
     when(contract.getClientIdentityKey()).thenReturn(clientIdentityKey);
-    when(clientKeyValidator.getValidator(anyString(), anyInt()))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     byte[] signature =
         dsSigner.sign(
@@ -130,7 +130,7 @@ public class ContractValidatorTest {
     when(clientIdentityKey.getEntityId()).thenReturn(ENTITY_ID);
     when(clientIdentityKey.getKeyVersion()).thenReturn(CERT_VERSION);
     when(contract.getClientIdentityKey()).thenReturn(clientIdentityKey);
-    when(clientKeyValidator.getValidator(anyString(), anyInt()))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_A));
     dsSigner = new DigitalSignatureSigner(PRIVATE_KEY_B);
     byte[] tampered =
@@ -154,7 +154,7 @@ public class ContractValidatorTest {
     when(clientIdentityKey.getKeyVersion()).thenReturn(CERT_VERSION);
     when(contract.getClientIdentityKey()).thenReturn(clientIdentityKey);
     // tampered certificate B
-    when(clientKeyValidator.getValidator(anyString(), anyInt()))
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt()))
         .thenReturn(new DigitalSignatureValidator(CERTIFICATE_B));
     byte[] signature =
         dsSigner.sign(


### PR DESCRIPTION
## Description

This PR adds a context namespace for register-cert. We assume an admin client creates a namespace and registers a certificate (or secret) of the tenant to the namespace so that the tenant client can register and execute contracts and validate assets on the namespace. This PR enables such a use case.

## Related issues and/or PRs

- #411

## Changes made

- Set a context namespace (if necessary) in `ClientService`.
- Skip auto certificate registration in bootstrap when a context namespace is specified.
- Add the namespace option to the register-cert command.
- Make `CertificateManager` and `CertificateRegistry` namespace-aware

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A