### PR TITLE
Backport to branch(3) : Fix to specify Java 8 when building v3.10, v3.11 and v3.12

### DIFF
--- a/.github/workflows/manual-vuln-check.yaml
+++ b/.github/workflows/manual-vuln-check.yaml
@@ -2,11 +2,28 @@ name: Manual Vulnerability Check Trigger
 
 on:
   workflow_dispatch:
+    inputs:
+      target-ref:
+        description: 'Target ref (branch, tag, release) to scan'
+        required: false
+        type: string
+      find-latest-release:
+        description: 'Flag to find the latest version for specified `target-ref`'
+        required: false
+        type: boolean
+        default: false
+      java-versions:
+        description: 'Java version to use for building'
+        required: false
+        type: number
+        default: 21
 
 jobs:
   call-vuln-check:
     uses: ./.github/workflows/vuln-check.yaml
     with:
-      target-ref: ${{ github.ref_name }}
+      target-ref: ${{ inputs.target-ref || github.ref_name }}
+      find-latest-release: ${{ inputs.find-latest-release }}
+      java-versions: ${{ fromJSON(inputs.java-versions) }}
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}

--- a/.github/workflows/scheduled-vuln-check.yaml
+++ b/.github/workflows/scheduled-vuln-check.yaml
@@ -19,6 +19,7 @@ jobs:
     with:
       target-ref: v3.8
       find-latest-release: true
+      java-versions: 8
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
@@ -28,6 +29,7 @@ jobs:
     with:
       target-ref: v3.9
       find-latest-release: true
+      java-versions: 8
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}

--- a/.github/workflows/vuln-check.yaml
+++ b/.github/workflows/vuln-check.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      java-versions:
+        description: 'Java version to use for building'
+        required: false
+        type: number
+        default: 21
     secrets:
       CR_PAT:
         required: true
@@ -26,7 +31,7 @@ jobs:
       target-ref: ${{ inputs.target-ref }}
       find-latest-release: ${{ inputs.find-latest-release }}
       images: '[["ScalarDL Ledger", "scalardl-ledger"], ["ScalarDL Client", "scalardl-client"]]'
-      java-versions: 21
+      java-versions: ${{ inputs.java-versions }}
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
       SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/443
- **Commit to backport:** 7c3cd7d1e87a29237bb8e1a7c2df3b6de5ab043d

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3-pull-443 &&
git cherry-pick --no-rerere-autoupdate -m1 7c3cd7d1e87a29237bb8e1a7c2df3b6de5ab043d
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!