### PR TITLE
Extend new E2E integration test to run with with various java versions

### DIFF
--- a/.github/workflows/backward-compatibility-check.yaml
+++ b/.github/workflows/backward-compatibility-check.yaml
@@ -1,0 +1,46 @@
+name: Backward Compatibility Check
+
+on:
+  workflow_call:
+    inputs:
+      target-ref:
+        description: 'Target ref (branch, tag, release) to check'
+        required: true
+        type: string
+        default: 'master'
+      java-version:
+        description: 'Java version to build the client with'
+        required: true
+        type: string
+
+jobs:
+  client-server-backward-compatibility-test:
+    name: Client-server backward compatibility test for Ledger built with Java 21 (Client built with Java ${{ inputs.java-version }})
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target-ref }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Build Docker images
+        run: ./gradlew :ledger:docker
+
+      - name: Run integration tests
+        run: ./gradlew :testing:integrationTest -PtestingJavaVersion=${{ inputs.java-version }}
+
+      - name: Upload Gradle test reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: backward_compatibility_test_reports_java${{ inputs.java-version }}
+          path: testing/build/reports/tests/integrationTest

--- a/.github/workflows/manual-backward-compatibility-check.yaml
+++ b/.github/workflows/manual-backward-compatibility-check.yaml
@@ -1,0 +1,15 @@
+name: Manual Backward Compatibility Check Trigger
+
+on:
+  workflow_dispatch:
+
+jobs:
+  call-backward-compatibility-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['8', '11', '17', '21']
+    uses: ./.github/workflows/backward-compatibility-check.yaml
+    with:
+      target-ref: ${{ github.ref_name }}
+      java-version: ${{ matrix.java-version }}

--- a/.github/workflows/scalar.yml
+++ b/.github/workflows/scalar.yml
@@ -117,13 +117,8 @@ jobs:
           -Dscalardb.transaction_manager=jdbc
 
   e2e-integration-test-for-ledger:
-    name: End-to-end integration test for Ledger (Client built with Java ${{ matrix.java-version }})
+    name: End-to-end integration test for Ledger
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version: [8, 11, 17, 21]
 
     steps:
       - uses: actions/checkout@v6
@@ -141,13 +136,13 @@ jobs:
         run: ./gradlew :ledger:docker
 
       - name: Run integration tests
-        run: ./gradlew :testing:integrationTest -PtestingJavaVersion=${{ matrix.java-version }}
+        run: ./gradlew :testing:integrationTest
 
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: integration_test_reports_for_ledger_e2e_java${{ matrix.java-version }}
+          name: integration_test_reports_for_ledger_e2e
           path: testing/build/reports/tests/integrationTest
 
   e2e-integration-test-for-generic-contracts:

--- a/.github/workflows/scheduled-backward-compatibility-check.yaml
+++ b/.github/workflows/scheduled-backward-compatibility-check.yaml
@@ -1,0 +1,18 @@
+name: Scheduled Backward Compatibility Check
+
+on:
+  schedule:
+    # UTC Sunday 16:00 (Monday 01:00 JST)
+    - cron: '0 16 * * SUN'
+
+jobs:
+  call-backward-compatibility-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        target-ref: [master, 3]
+        java-version: ['8', '11', '17', '21']
+    uses: ./.github/workflows/backward-compatibility-check.yaml
+    with:
+      target-ref: ${{ matrix.target-ref }}
+      java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
## Description

This PR expands the new E2E test to run across all supported Java versions for better coverage.

## Related issues and/or PRs

- #442 

## Changes made

- Update `.github/workflows/scalar.yml` to run with Java 8, 11, 17, and 21.
- Update `testing/build.gradle` to retrieve JDK version from Gradle project property for building `testing` subproject.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A