### PR TITLE
Specify --skipApiVersionCheck when running Azurite in CI

### DIFF
--- a/.github/workflows/storage-compatibility-check.yaml
+++ b/.github/workflows/storage-compatibility-check.yaml
@@ -173,14 +173,6 @@ jobs:
     name: Integration testing with the Consensus Commit transaction manager on Blob Storage
     runs-on: ubuntu-latest
 
-    services:
-      blob-storage:
-        image: mcr.microsoft.com/azure-storage/azurite
-        env:
-          AZURITE_ACCOUNTS: "test:test"
-        ports:
-          - 10000:10000
-
     steps:
       - name: Checkout the target repository
         uses: actions/checkout@v6
@@ -195,6 +187,15 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+
+      # Start Azurite with `--skipApiVersionCheck` to avoid API version check issues
+      - name: Start Azurite
+        run: |
+          docker run -d --name azurite \
+            -e AZURITE_ACCOUNTS=test:test \
+            -p 10000:10000 \
+            mcr.microsoft.com/azure-storage/azurite \
+            azurite --blobHost 0.0.0.0 --location /data --skipApiVersionCheck
 
       - name: Create Blob Storage container
         run: |


### PR DESCRIPTION
## Description

This PR fixes CI to specify `--skipApiVersionCheck`  when running Azurite (Blob Storage emulator) in the storage compatibility check workflow.

This fix is the same as https://github.com/scalar-labs/scalardb/pull/3337.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3337

## Changes made

- Updated `.github/workflows/storage-compatibility-check.yaml` to specify `--skipApiVersionCheck` when running Azurite.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A