### PR TITLE
Upgrade ValidateLedger version number

### DIFF
--- a/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
+++ b/client/src/main/java/com/scalar/dl/client/config/ClientConfig.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.scalar.dl.client.error.ClientError;
-import com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger;
+import com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger;
 import com.scalar.dl.ledger.config.AuthenticationMethod;
 import com.scalar.dl.ledger.config.ConfigUtils;
 import com.scalar.dl.ledger.config.GrpcClientConfig;

--- a/client/src/main/java/com/scalar/dl/client/service/ClientService.java
+++ b/client/src/main/java/com/scalar/dl/client/service/ClientService.java
@@ -2,10 +2,10 @@ package com.scalar.dl.client.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.ASSET_ID_KEY;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.END_AGE_KEY;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.NAMESPACE_KEY;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.START_AGE_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.ASSET_ID_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.END_AGE_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.NAMESPACE_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.START_AGE_KEY;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,7 +18,7 @@ import com.scalar.dl.client.error.ClientError;
 import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.util.Common;
 import com.scalar.dl.client.util.RequestSigner;
-import com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger;
+import com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger;
 import com.scalar.dl.ledger.config.AuthenticationMethod;
 import com.scalar.dl.ledger.model.ContractExecutionResult;
 import com.scalar.dl.ledger.model.LedgerValidationResult;

--- a/client/src/main/java/com/scalar/dl/client/validation/contract/v1_1_0/ValidateLedger.java
+++ b/client/src/main/java/com/scalar/dl/client/validation/contract/v1_1_0/ValidateLedger.java
@@ -1,4 +1,4 @@
-package com.scalar.dl.client.validation.contract.v1_0_0;
+package com.scalar.dl.client.validation.contract.v1_1_0;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/client/src/test/java/com/scalar/dl/client/service/ClientServiceTest.java
+++ b/client/src/test/java/com/scalar/dl/client/service/ClientServiceTest.java
@@ -1,9 +1,9 @@
 package com.scalar.dl.client.service;
 
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.ASSET_ID_KEY;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.END_AGE_KEY;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.NAMESPACE_KEY;
-import static com.scalar.dl.client.validation.contract.v1_0_0.ValidateLedger.START_AGE_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.ASSET_ID_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.END_AGE_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.NAMESPACE_KEY;
+import static com.scalar.dl.client.validation.contract.v1_1_0.ValidateLedger.START_AGE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;

--- a/client/src/test/java/com/scalar/dl/client/validation/contract/v1_1_0/ValidateLedgerTest.java
+++ b/client/src/test/java/com/scalar/dl/client/validation/contract/v1_1_0/ValidateLedgerTest.java
@@ -1,4 +1,4 @@
-package com.scalar.dl.client.validation.contract.v1_0_0;
+package com.scalar.dl.client.validation.contract.v1_1_0;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;


### PR DESCRIPTION
## Description

This PR upgrades the ValidateLedger version number.

In 3.12, when bundling the `ValidateLedger` contract, the package name already included version information (`v1_0_0`). In 3.13, namespace support was implemented for `ValidateLedger`, which required incrementing the version number, but I forgot to do it.

Without this change, during bootstrap, the new namespace-aware `ValidateLedger` contract fails (skips) to register because the old contract is already registered with the same binary name and a different contract ID. This results in the following error:

```
2026-03-06 10:51:48,904 [ERROR com.scalar.dl.ledger.server.CommonService] DL-COMMON-406002: The specified contract binary name has been already registered with a different byte code.
com.scalar.dl.ledger.exception.DatabaseException: DL-COMMON-406002: The specified contract binary name has been already registered with a different byte code.
        at com.scalar.dl.ledger.database.scalardb.ScalarContractRegistry.bind(ScalarContractRegistry.java:91)
        at com.scalar.dl.ledger.contract.ContractManager.register(ContractManager.java:87)
        at com.scalar.dl.ledger.service.BaseService.register(BaseService.java:58)
        at com.scalar.dl.auditor.service.AuditorService.register(AuditorService.java:85)
        at com.scalar.dl.auditor.server.AuditorService.lambda$registerContract$0(AuditorService.java:41)
        at com.scalar.dl.ledger.server.CommonService.serve(CommonService.java:38)
        at com.scalar.dl.auditor.server.AuditorService.registerContract(AuditorService.java:42)
        at com.scalar.dl.rpc.AuditorGrpc$MethodHandlers.invoke(AuditorGrpc.java:453)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

## Related issues and/or PRs

- #370

## Changes made

- Rename `ValidateLedger` contract package from `v1_0_0` to `v1_1_0`
- Update all import references in `ClientConfig`, `ClientService`, and related test files

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A