### PR TITLE
Revive imported classes for Javadoc

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -193,8 +193,30 @@ task sourcesJar(type: Jar) {
 javadoc {
     title = "ScalarDL Java Client SDK ${version}"
     source += sourceSets.main.java
+    source += project(':common').sourceSets.main.java
     include "com/scalar/dl/client/**"
-    options.links = ["https://javadoc.io/doc/com.scalar-labs/scalardl-common/${version}/".toString()]
+    include "com/scalar/dl/ledger/asset/Asset.java"
+    include "com/scalar/dl/ledger/asset/AssetMetadata.java"
+    include "com/scalar/dl/ledger/contract/Contract.java"
+    include "com/scalar/dl/ledger/contract/JacksonBasedContract.java"
+    include "com/scalar/dl/ledger/contract/JsonpBasedContract.java"
+    include "com/scalar/dl/ledger/contract/StringBasedContract.java"
+    include "com/scalar/dl/ledger/crypto/CertificateEntry.java"
+    include "com/scalar/dl/ledger/crypto/ClientIdentityKey.java"
+    include "com/scalar/dl/ledger/database/AssetFilter.java"
+    include "com/scalar/dl/ledger/database/Database.java"
+    include "com/scalar/dl/ledger/database/Ledger.java"
+    include "com/scalar/dl/ledger/exception/*.java"
+    include "com/scalar/dl/ledger/function/Function.java"
+    include "com/scalar/dl/ledger/function/JacksonBasedFunction.java"
+    include "com/scalar/dl/ledger/function/JsonpBasedFunction.java"
+    include "com/scalar/dl/ledger/function/StringBasedFunction.java"
+    include "com/scalar/dl/ledger/model/*.java"
+    include "com/scalar/dl/ledger/proof/AssetProof.java"
+    include "com/scalar/dl/ledger/service/StatusCode.java"
+    include "com/scalar/dl/ledger/statemachine/Asset.java"
+    include "com/scalar/dl/ledger/statemachine/AssetMetadata.java"
+    include "com/scalar/dl/ledger/statemachine/Ledger.java"
 }
 
 task testJar(type: Jar) {


### PR DESCRIPTION
## Description

This PR revives importing several `common` classes into `client` for Javadoc, so that they are listed in the list of all classes shown on the left of the Javadoc page for better usability. We tried to use the `links` feature, but it doesn't work well for that purpose.

Also, I updated the docs site to only use the `scalardl-java-client-sdk` Javadoc.

## Related issues and/or PRs

- scalar-labs/docs-internal-scalardl#824

## Changes made

- Revive importing classes for Javadoc
- Remove unnecessary classes, e.g., `ContractMachine`, which are not seen by users.
- Add missing classes: `StatusCode` and `AssetProof`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

 - Originally, it includes the following classes in v3.12.2: https://github.com/scalar-labs/scalardl/blob/cc80391a8c104aa279a8ce81657f4037c3289c08/client/build.gradle#L247-L278

## Release notes

N/A