### PR TITLE
Backport to branch(3.10) : Fix to release scalardl-testing snapshot in 3.12 or less

### DIFF
--- a/testing/archive.gradle
+++ b/testing/archive.gradle
@@ -37,4 +37,9 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            url = layout.buildDirectory.dir('staging-deploy')
+        }
+    }
 }


### PR DESCRIPTION
Backport of #485.