### PR TITLE
Refactor default namespace usage

### DIFF
--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceEndToEndTest.java
@@ -79,7 +79,7 @@ import com.scalar.dl.ledger.model.ContractExecutionRequest;
 import com.scalar.dl.ledger.model.ContractExecutionResult;
 import com.scalar.dl.ledger.model.LedgerValidationRequest;
 import com.scalar.dl.ledger.model.LedgerValidationResult;
-import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import com.scalar.dl.ledger.proof.AssetProof;
 import com.scalar.dl.ledger.service.function.CreateFunction;
 import com.scalar.dl.ledger.service.function.CreateFunctionWithJackson;
@@ -2193,7 +2193,7 @@ public class LedgerServiceEndToEndTest extends LedgerServiceEndToEndTestBase {
     AssetProof proof = result.getLedgerProofs().get(0);
     byte[] toBeValidated =
         AssetProof.serialize(
-            NamespaceManager.DEFAULT_NAMESPACE,
+            Namespaces.DEFAULT,
             proof.getId(),
             proof.getAge(),
             proof.getNonce(),

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceNamespaceEndToEndTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/service/LedgerServiceNamespaceEndToEndTest.java
@@ -50,7 +50,7 @@ import com.scalar.dl.ledger.model.LedgerValidationResult;
 import com.scalar.dl.ledger.model.NamespaceCreationRequest;
 import com.scalar.dl.ledger.model.NamespaceDroppingRequest;
 import com.scalar.dl.ledger.model.NamespacesListingRequest;
-import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import com.scalar.dl.ledger.proof.AssetProof;
 import com.scalar.dl.ledger.util.Argument;
 import com.scalar.dl.ledger.util.JacksonSerDe;
@@ -718,8 +718,7 @@ public class LedgerServiceNamespaceEndToEndTest extends LedgerServiceEndToEndTes
     List<String> actual = ledgerService.list(request);
 
     // Assert
-    assertThat(actual)
-        .containsExactly(NamespaceManager.DEFAULT_NAMESPACE, SOME_NAMESPACE1, SOME_NAMESPACE2);
+    assertThat(actual).containsExactly(Namespaces.DEFAULT, SOME_NAMESPACE1, SOME_NAMESPACE2);
   }
 
   @Test
@@ -750,8 +749,7 @@ public class LedgerServiceNamespaceEndToEndTest extends LedgerServiceEndToEndTes
   @Test
   public void drop_DefaultNamespaceGiven_ShouldThrowException() {
     // Arrange
-    NamespaceDroppingRequest request =
-        new NamespaceDroppingRequest(NamespaceManager.DEFAULT_NAMESPACE);
+    NamespaceDroppingRequest request = new NamespaceDroppingRequest(Namespaces.DEFAULT);
 
     // Act
     Throwable thrown = catchThrowable(() -> ledgerService.drop(request));

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarNamespaceResolver.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarNamespaceResolver.java
@@ -2,7 +2,7 @@ package com.scalar.dl.ledger.database.scalardb;
 
 import com.google.inject.Inject;
 import com.scalar.dl.ledger.config.ServerConfig;
-import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -38,7 +38,7 @@ public class ScalarNamespaceResolver {
    * @return the physical ScalarDB namespace name
    */
   public String resolve(String logicalNamespace) {
-    if (logicalNamespace.equals(NamespaceManager.DEFAULT_NAMESPACE)) {
+    if (logicalNamespace.equals(Namespaces.DEFAULT)) {
       return baseNamespace;
     }
     return baseNamespace + NAMESPACE_NAME_SEPARATOR + logicalNamespace;

--- a/ledger/src/main/java/com/scalar/dl/ledger/namespace/NamespaceManager.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/namespace/NamespaceManager.java
@@ -19,7 +19,6 @@ import javax.annotation.Nonnull;
  * <p>A {@code NamespaceManager} manages namespaces in a {@link NamespaceRegistry}.
  */
 public class NamespaceManager {
-  public static final String DEFAULT_NAMESPACE = "default";
   public static final Pattern NAMESPACE_NAME_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*");
   private final NamespaceRegistry registry;
 
@@ -44,7 +43,7 @@ public class NamespaceManager {
     if (!isValidNamespaceName(namespace)) {
       throw new LedgerException(CommonError.INVALID_NAMESPACE_NAME, namespace);
     }
-    if (namespace.equals(DEFAULT_NAMESPACE)) {
+    if (namespace.equals(Namespaces.DEFAULT)) {
       throw new LedgerException(CommonError.RESERVED_NAMESPACE, namespace);
     }
     registry.create(namespace);
@@ -60,7 +59,7 @@ public class NamespaceManager {
     if (!isValidNamespaceName(namespace)) {
       throw new LedgerException(CommonError.INVALID_NAMESPACE_NAME, namespace);
     }
-    if (namespace.equals(DEFAULT_NAMESPACE)) {
+    if (namespace.equals(Namespaces.DEFAULT)) {
       throw new LedgerException(CommonError.RESERVED_NAMESPACE, namespace);
     }
     registry.drop(namespace);
@@ -79,8 +78,8 @@ public class NamespaceManager {
    */
   public List<String> scan(@Nonnull String pattern) {
     Set<String> namespaces = new TreeSet<>(registry.scan(pattern));
-    if (DEFAULT_NAMESPACE.contains(pattern)) {
-      namespaces.add(DEFAULT_NAMESPACE);
+    if (Namespaces.DEFAULT.contains(pattern)) {
+      namespaces.add(Namespaces.DEFAULT);
     }
     return new ArrayList<>(namespaces);
   }

--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerValidationService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerValidationService.java
@@ -17,7 +17,6 @@ import com.scalar.dl.ledger.exception.ValidationException;
 import com.scalar.dl.ledger.model.AssetProofRetrievalRequest;
 import com.scalar.dl.ledger.model.LedgerValidationRequest;
 import com.scalar.dl.ledger.model.LedgerValidationResult;
-import com.scalar.dl.ledger.namespace.NamespaceManager;
 import com.scalar.dl.ledger.namespace.Namespaces;
 import com.scalar.dl.ledger.proof.AssetProof;
 import com.scalar.dl.ledger.statemachine.Context;
@@ -91,10 +90,7 @@ public class LedgerValidationService extends ValidationService {
             Namespaces.DEFAULT, request.getEntityId(), request.getKeyVersion());
     request.validateWith(validator);
 
-    String namespace =
-        request.getNamespace() == null
-            ? NamespaceManager.DEFAULT_NAMESPACE
-            : request.getNamespace();
+    String namespace = request.getNamespace() == null ? Namespaces.DEFAULT : request.getNamespace();
     InternalAsset asset = retrieve(namespace, request.getAssetId(), request.getAge());
     return proofComposer.create(namespace, asset);
   }
@@ -106,7 +102,7 @@ public class LedgerValidationService extends ValidationService {
       namespace = context.getNamespace();
     }
 
-    if (!context.getNamespace().equals(NamespaceManager.DEFAULT_NAMESPACE)
+    if (!context.getNamespace().equals(Namespaces.DEFAULT)
         && !context.getNamespace().equals(namespace)) {
       throw new LedgerException(
           CommonError.ACCESSING_NAMESPACE_NOT_ALLOWED, namespace, context.getNamespace());

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarNamespaceResolverTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarNamespaceResolverTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.scalar.dl.ledger.config.ServerConfig;
-import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -28,7 +28,7 @@ public class ScalarNamespaceResolverTest {
   @Test
   public void resolve_DefaultNamespaceGiven_ShouldReturnBaseNamespace() {
     // Act
-    String actual = resolver.resolve(NamespaceManager.DEFAULT_NAMESPACE);
+    String actual = resolver.resolve(Namespaces.DEFAULT);
 
     // Assert
     assertThat(actual).isEqualTo(BASE_NAMESPACE);

--- a/ledger/src/test/java/com/scalar/dl/ledger/namespace/NamespaceManagerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/namespace/NamespaceManagerTest.java
@@ -131,7 +131,7 @@ public class NamespaceManagerTest {
   @Test
   public void create_DefaultNamespaceGiven_ShouldThrowLedgerException() {
     // Arrange
-    String namespace = NamespaceManager.DEFAULT_NAMESPACE;
+    String namespace = Namespaces.DEFAULT;
 
     // Act Assert
     assertThatThrownBy(() -> manager.create(namespace))
@@ -282,7 +282,7 @@ public class NamespaceManagerTest {
   @Test
   public void drop_DefaultNamespaceGiven_ShouldThrowLedgerException() {
     // Arrange
-    String namespace = NamespaceManager.DEFAULT_NAMESPACE;
+    String namespace = Namespaces.DEFAULT;
 
     // Act Assert
     assertThatThrownBy(() -> manager.drop(namespace))

--- a/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerValidationServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerValidationServiceTest.java
@@ -81,7 +81,6 @@ public class LedgerValidationServiceTest {
   @Mock private Transaction transaction;
   @Mock private TamperEvidentAssetLedger ledger;
   private LedgerValidationService service;
-  private static final String DEFAULT_NAMESPACE = Namespaces.DEFAULT;
   private static final String BASE_NAMESPACE = "scalar";
   private static final String NAMESPACE = "namespace";
   private static final String ID = "id";
@@ -98,7 +97,7 @@ public class LedgerValidationServiceTest {
   private static final ObjectMapper mapper = new ObjectMapper();
   private static final JacksonSerDe jacksonSerDe = new JacksonSerDe(mapper);
   private static final JsonpSerDe jsonpSerDe = new JsonpSerDe();
-  private static final Context context = Context.withNamespace(DEFAULT_NAMESPACE);
+  private static final Context context = Context.withNamespace(Namespaces.DEFAULT);
 
   @BeforeEach
   public void init() {
@@ -183,14 +182,14 @@ public class LedgerValidationServiceTest {
     // Assert
     assertThat(result.getCode()).isEqualTo(StatusCode.OK);
     ContractEntry.Key expected = new ContractEntry.Key(CONTRACT_ID, ENTITY_ID, KEY_VERSION);
-    verify(contractManager, times(2)).get(DEFAULT_NAMESPACE, expected);
+    verify(contractManager, times(2)).get(Namespaces.DEFAULT, expected);
     verify(contract, times(2)).invoke(tracer, CONTRACT_ARGUMENT, null);
     for (LedgerValidator v : validators) {
-      verify(v).validate(tracer, contract, DEFAULT_NAMESPACE, assets.get(0));
-      verify(v).validate(tracer, contract, DEFAULT_NAMESPACE, assets.get(1));
+      verify(v).validate(tracer, contract, Namespaces.DEFAULT, assets.get(0));
+      verify(v).validate(tracer, contract, Namespaces.DEFAULT, assets.get(1));
     }
     AssetFilter filter =
-        new AssetFilter(DEFAULT_NAMESPACE, ID)
+        new AssetFilter(Namespaces.DEFAULT, ID)
             .withStartAge(0, true)
             .withEndAge(Integer.MAX_VALUE, true)
             .withAgeOrder(AgeOrder.ASC);
@@ -240,10 +239,10 @@ public class LedgerValidationServiceTest {
     // Assert
     assertThat(result.getCode()).isEqualTo(StatusCode.INVALID_CONTRACT);
     ContractEntry.Key expected = new ContractEntry.Key(CONTRACT_ID, ENTITY_ID, KEY_VERSION);
-    verify(contractManager).get(DEFAULT_NAMESPACE, expected);
+    verify(contractManager).get(Namespaces.DEFAULT, expected);
     verify(contract).invoke(tracer, CONTRACT_ARGUMENT, null);
     for (LedgerValidator v : validators) {
-      verify(v).validate(tracer, contract, DEFAULT_NAMESPACE, assets.get(0));
+      verify(v).validate(tracer, contract, Namespaces.DEFAULT, assets.get(0));
     }
     verify(transaction).commit();
   }
@@ -429,7 +428,7 @@ public class LedgerValidationServiceTest {
     when(transactionManager.startWith()).thenReturn(transaction);
     doReturn(ledger).when(transaction).getLedger();
     AssetFilter filter =
-        new AssetFilter(DEFAULT_NAMESPACE, ID)
+        new AssetFilter(Namespaces.DEFAULT, ID)
             .withStartAge(age, true)
             .withEndAge(age, true)
             .withAgeOrder(AssetFilter.AgeOrder.ASC);
@@ -442,7 +441,7 @@ public class LedgerValidationServiceTest {
                 config, transactionManager, clientKeyValidator, contractManager, proofComposer));
 
     // Act
-    InternalAsset actual = service.retrieve(DEFAULT_NAMESPACE, ID, age);
+    InternalAsset actual = service.retrieve(Namespaces.DEFAULT, ID, age);
 
     // Assert
     assertThat(actual.id()).isEqualTo(ID);
@@ -459,19 +458,19 @@ public class LedgerValidationServiceTest {
     when(transactionManager.startWith()).thenReturn(transaction);
     doReturn(ledger).when(transaction).getLedger();
     InternalAsset asset = createAssetMocks().get(1);
-    doReturn(Optional.of(asset)).when(ledger).get(DEFAULT_NAMESPACE, ID);
+    doReturn(Optional.of(asset)).when(ledger).get(Namespaces.DEFAULT, ID);
     service =
         spy(
             new LedgerValidationService(
                 config, transactionManager, clientKeyValidator, contractManager, proofComposer));
 
     // Act
-    InternalAsset actual = service.retrieve(DEFAULT_NAMESPACE, ID, -1);
+    InternalAsset actual = service.retrieve(Namespaces.DEFAULT, ID, -1);
 
     // Assert
     assertThat(actual.id()).isEqualTo(ID);
     assertThat(actual.age()).isEqualTo(age);
-    verify(ledger).get(DEFAULT_NAMESPACE, ID);
+    verify(ledger).get(Namespaces.DEFAULT, ID);
     verify(transaction).commit();
   }
 
@@ -483,7 +482,7 @@ public class LedgerValidationServiceTest {
     when(transactionManager.startWith()).thenReturn(transaction);
     doReturn(ledger).when(transaction).getLedger();
     InternalAsset asset = createAssetMocks().get(1);
-    doReturn(Optional.of(asset)).when(ledger).get(DEFAULT_NAMESPACE, ID);
+    doReturn(Optional.of(asset)).when(ledger).get(Namespaces.DEFAULT, ID);
     proofComposer = new AssetProofComposer(new DigitalSignatureSigner(PRIVATE_KEY_A));
     service =
         spy(
@@ -491,12 +490,12 @@ public class LedgerValidationServiceTest {
                 config, transactionManager, clientKeyValidator, contractManager, proofComposer));
 
     // Act
-    InternalAsset actual = service.retrieve(DEFAULT_NAMESPACE, ID, Integer.MAX_VALUE);
+    InternalAsset actual = service.retrieve(Namespaces.DEFAULT, ID, Integer.MAX_VALUE);
 
     // Assert
     assertThat(actual.id()).isEqualTo(ID);
     assertThat(actual.age()).isEqualTo(age);
-    verify(ledger).get(DEFAULT_NAMESPACE, ID);
+    verify(ledger).get(Namespaces.DEFAULT, ID);
     verify(transaction).commit();
   }
 
@@ -511,11 +510,11 @@ public class LedgerValidationServiceTest {
             config, transactionManager, clientKeyValidator, contractManager, proofComposer);
 
     // Act
-    Throwable thrown = catchThrowable(() -> service.retrieve(DEFAULT_NAMESPACE, ID, -1));
+    Throwable thrown = catchThrowable(() -> service.retrieve(Namespaces.DEFAULT, ID, -1));
 
     // Assert
     assertThat(thrown).isEqualTo(toThrow);
-    verify(ledger).get(DEFAULT_NAMESPACE, ID);
+    verify(ledger).get(Namespaces.DEFAULT, ID);
     verify(transaction).abort();
   }
 
@@ -533,7 +532,7 @@ public class LedgerValidationServiceTest {
                 config, transactionManager, clientKeyValidator, contractManager, proofComposer));
 
     // Act
-    Throwable thrown = catchThrowable(() -> service.retrieve(DEFAULT_NAMESPACE, ID, age));
+    Throwable thrown = catchThrowable(() -> service.retrieve(Namespaces.DEFAULT, ID, age));
 
     // Assert
     assertThat(thrown).isInstanceOf(ValidationException.class);
@@ -554,7 +553,7 @@ public class LedgerValidationServiceTest {
                 config, transactionManager, clientKeyValidator, contractManager, proofComposer));
 
     // Act
-    Throwable thrown = catchThrowable(() -> service.retrieve(DEFAULT_NAMESPACE, ID, -1));
+    Throwable thrown = catchThrowable(() -> service.retrieve(Namespaces.DEFAULT, ID, -1));
 
     // Assert
     assertThat(thrown).isInstanceOf(ValidationException.class);
@@ -587,7 +586,7 @@ public class LedgerValidationServiceTest {
             null, ID, AGE, ENTITY_ID, KEY_VERSION, signer.sign(serialized)));
 
     // Assert
-    verify(service).retrieve(DEFAULT_NAMESPACE, ID, AGE);
+    verify(service).retrieve(Namespaces.DEFAULT, ID, AGE);
   }
 
   @Test
@@ -611,7 +610,7 @@ public class LedgerValidationServiceTest {
         .isInstanceOf(SignatureException.class);
 
     // Assert
-    verify(service, never()).retrieve(DEFAULT_NAMESPACE, ID, AGE);
+    verify(service, never()).retrieve(Namespaces.DEFAULT, ID, AGE);
   }
 
   @Test
@@ -642,12 +641,12 @@ public class LedgerValidationServiceTest {
         .thenReturn((LedgerTracerBase) tracer);
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, jsonpSerDe.serialize(contractArgument), null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test
@@ -682,12 +681,12 @@ public class LedgerValidationServiceTest {
             any(Context.class), ArgumentMatchers.eq(DeserializationType.DEPRECATED));
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, jsonpSerDe.serialize(contractArgument), null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test
@@ -718,12 +717,12 @@ public class LedgerValidationServiceTest {
         .thenReturn((LedgerTracerBase) tracer);
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, jsonpSerDe.serialize(contractArgument), null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test
@@ -756,12 +755,12 @@ public class LedgerValidationServiceTest {
         .thenReturn((LedgerTracerBase) tracer);
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, jsonpSerDe.serialize(contractArgument), null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test
@@ -792,12 +791,12 @@ public class LedgerValidationServiceTest {
         .thenReturn((LedgerTracerBase) tracer);
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, jacksonSerDe.serialize(contractArgument), null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test
@@ -830,12 +829,12 @@ public class LedgerValidationServiceTest {
         .thenReturn((LedgerTracerBase) tracer);
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, jacksonSerDe.serialize(contractArgument), null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test
@@ -868,12 +867,12 @@ public class LedgerValidationServiceTest {
         .thenReturn((LedgerTracerBase) tracer);
 
     // Act
-    StatusCode status = service.validateEach(context, validators, DEFAULT_NAMESPACE, asset);
+    StatusCode status = service.validateEach(context, validators, Namespaces.DEFAULT, asset);
 
     // Assert
     assertThat(status).isEqualTo(StatusCode.OK);
     verify(contract).invoke(tracer, contractArgument, null);
-    verify(validator).validate(tracer, contract, DEFAULT_NAMESPACE, asset);
+    verify(validator).validate(tracer, contract, Namespaces.DEFAULT, asset);
   }
 
   @Test

--- a/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerValidationServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerValidationServiceTest.java
@@ -42,7 +42,7 @@ import com.scalar.dl.ledger.exception.ValidationException;
 import com.scalar.dl.ledger.model.AssetProofRetrievalRequest;
 import com.scalar.dl.ledger.model.LedgerValidationRequest;
 import com.scalar.dl.ledger.model.LedgerValidationResult;
-import com.scalar.dl.ledger.namespace.NamespaceManager;
+import com.scalar.dl.ledger.namespace.Namespaces;
 import com.scalar.dl.ledger.statemachine.Context;
 import com.scalar.dl.ledger.statemachine.DeserializationType;
 import com.scalar.dl.ledger.statemachine.InternalAsset;
@@ -81,7 +81,7 @@ public class LedgerValidationServiceTest {
   @Mock private Transaction transaction;
   @Mock private TamperEvidentAssetLedger ledger;
   private LedgerValidationService service;
-  private static final String DEFAULT_NAMESPACE = NamespaceManager.DEFAULT_NAMESPACE;
+  private static final String DEFAULT_NAMESPACE = Namespaces.DEFAULT;
   private static final String BASE_NAMESPACE = "scalar";
   private static final String NAMESPACE = "namespace";
   private static final String ID = "id";


### PR DESCRIPTION
## Description

This PR refactors the default namespace usage, the same as scalar-labs/scalardl-enterprise#1673.

## Related issues and/or PRs

- scalar-labs/scalardl-enterprise#1673

## Changes made

- Use `Namespaces.DEFAULT` instead of `NamespaceManager.DEFAULT`
- Remove `NamespaceManager.DEFAULT`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
