### PR TITLE
Bump ScalarDB to 3.17.3 and switch to MariaDB Connector/J for testing

### DIFF
--- a/.github/workflows/scalar.yml
+++ b/.github/workflows/scalar.yml
@@ -79,7 +79,7 @@ jobs:
         run: >-
           ./gradlew :ledger:integrationTest
           -Dscalardb.storage=jdbc
-          -Dscalardb.contact_points=jdbc:mysql://localhost/
+          -Dscalardb.contact_points=jdbc:mysql://localhost/?sslMode=REQUIRED
           -Dscalardb.username=root
           -Dscalardb.password=mysql
 
@@ -111,7 +111,7 @@ jobs:
         run: >-
           ./gradlew :ledger:integrationTest
           -Dscalardb.storage=jdbc
-          -Dscalardb.contact_points=jdbc:mysql://localhost/
+          -Dscalardb.contact_points=jdbc:mysql://localhost/?sslMode=REQUIRED
           -Dscalardb.username=root
           -Dscalardb.password=mysql
           -Dscalardb.transaction_manager=jdbc
@@ -190,7 +190,7 @@ jobs:
             --network host \
             -v /tmp/ledger-key.pem:/keys/ledger-key.pem:ro \
             -e SCALAR_DB_STORAGE=jdbc \
-            -e SCALAR_DB_CONTACT_POINTS="jdbc:mysql://localhost:3306/" \
+            -e SCALAR_DB_CONTACT_POINTS="jdbc:mysql://localhost:3306/?sslMode=REQUIRED" \
             -e SCALAR_DB_USERNAME=root \
             -e SCALAR_DB_PASSWORD=mysql \
             -e SCALAR_DB_TRANSACTION_MANAGER=consensus-commit \
@@ -257,7 +257,7 @@ jobs:
             --network host \
             -v /tmp/ledger-key.pem:/keys/ledger-key.pem:ro \
             -e SCALAR_DB_STORAGE=jdbc \
-            -e SCALAR_DB_CONTACT_POINTS="jdbc:mysql://localhost:3306/" \
+            -e SCALAR_DB_CONTACT_POINTS="jdbc:mysql://localhost:3306/?sslMode=REQUIRED" \
             -e SCALAR_DB_USERNAME=root \
             -e SCALAR_DB_PASSWORD=mysql \
             -e SCALAR_DB_TRANSACTION_MANAGER=consensus-commit \
@@ -324,7 +324,7 @@ jobs:
             --network host \
             -v /tmp/ledger-key.pem:/keys/ledger-key.pem:ro \
             -e SCALAR_DB_STORAGE=jdbc \
-            -e SCALAR_DB_CONTACT_POINTS="jdbc:mysql://localhost:3306/" \
+            -e SCALAR_DB_CONTACT_POINTS="jdbc:mysql://localhost:3306/?sslMode=REQUIRED" \
             -e SCALAR_DB_USERNAME=root \
             -e SCALAR_DB_PASSWORD=mysql \
             -e SCALAR_DB_TRANSACTION_MANAGER=consensus-commit \

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
         jsonpVersion = '1.1.4'
         jacksonVersion = '2.21.2'
         toml4jVersion = '0.7.2'
-        scalarDbVersion = '3.17.2'
+        scalarDbVersion = '3.17.3'
         scalarAdminVersion = '2.2.1'
         resilience4jRetryVersion = '1.7.1'
         dropwizardMetricsVersion = '4.2.38'

--- a/testing/src/main/java/com/scalar/dl/testing/config/StorageConfig.java
+++ b/testing/src/main/java/com/scalar/dl/testing/config/StorageConfig.java
@@ -145,7 +145,7 @@ public class StorageConfig {
       props.put(DatabaseConfig.STORAGE, STORAGE_JDBC);
       props.put(
           DatabaseConfig.CONTACT_POINTS,
-          "jdbc:mysql://" + containerNetworkAlias + ":" + MYSQL_PORT + "/?permitMysqlScheme=true");
+          "jdbc:mysql://" + containerNetworkAlias + ":" + MYSQL_PORT + "/");
       props.put(DatabaseConfig.USERNAME, MYSQL_USERNAME);
       props.put(DatabaseConfig.PASSWORD, MYSQL_PASSWORD);
     } else if (contactPoints != null) {

--- a/testing/src/main/java/com/scalar/dl/testing/config/StorageConfig.java
+++ b/testing/src/main/java/com/scalar/dl/testing/config/StorageConfig.java
@@ -145,7 +145,7 @@ public class StorageConfig {
       props.put(DatabaseConfig.STORAGE, STORAGE_JDBC);
       props.put(
           DatabaseConfig.CONTACT_POINTS,
-          "jdbc:mysql://" + containerNetworkAlias + ":" + MYSQL_PORT + "/");
+          "jdbc:mysql://" + containerNetworkAlias + ":" + MYSQL_PORT + "/?permitMysqlScheme=true");
       props.put(DatabaseConfig.USERNAME, MYSQL_USERNAME);
       props.put(DatabaseConfig.PASSWORD, MYSQL_PASSWORD);
     } else if (contactPoints != null) {

--- a/testing/src/main/java/com/scalar/dl/testing/container/AbstractTestCluster.java
+++ b/testing/src/main/java/com/scalar/dl/testing/container/AbstractTestCluster.java
@@ -114,11 +114,16 @@ public abstract class AbstractTestCluster implements AutoCloseable {
       case "jdbc":
         logger.info("Starting MySQL container");
         mysqlContainer =
-            new MySQLContainer(MYSQL_IMAGE)
-                .withNetwork(network)
+            new MySQLContainer(MYSQL_IMAGE) {
+              @Override
+              public String getDriverClassName() {
+                return "org.mariadb.jdbc.Driver";
+              }
+            }.withNetwork(network)
                 .withNetworkAliases(MYSQL_NETWORK_ALIAS)
                 .withUsername("root")
                 .withPassword("mysql")
+                .withUrlParam("permitMysqlScheme", "true")
                 .withLogConsumer(new Slf4jLogConsumer(logger).withPrefix("mysql"));
         mysqlContainer.start();
         logger.info(


### PR DESCRIPTION
## Description

ScalarDB 3.17.3 replaced MySQL Connector/J with MariaDB Connector/J due to licensing concerns (scalar-labs/scalardb#3428). This broke integration tests because Testcontainers' `MySQLContainer` could not find the MySQL JDBC driver on the classpath, and MariaDB Connector/J requires SSL for MySQL's `caching_sha2_password` authentication.

## Related issues and/or PRs

- scalar-labs/scalardb#3428 — Replace MySQL Connector/J with MariaDB Connector/J to resolve licensing issues
- scalar-labs/scalardl-enterprise#1679 — Dependabot PR that exposed this issue

## Changes made

- Bump ScalarDB from 3.17.2 to 3.17.3 and update the testing module's `MySQLContainer` to use MariaDB Connector/J driver with `permitMysqlScheme=true`
- Add `sslMode=REQUIRED` to all MySQL JDBC URLs in the CI workflow to support MariaDB driver's `caching_sha2_password` authentication

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The `MySQLContainer` still uses the `mysql:8.0` Docker image. Only the JDBC driver used by Testcontainers for health checks and by ScalarDB for connections is changed to MariaDB Connector/J (available transitively via ScalarDB 3.17.3).

## Release notes

Bumped ScalarDB to 3.17.3, which replaces MySQL Connector/J with MariaDB Connector/J.
