### PR TITLE
Reduce container image size and optimize Dockerfiles for v3

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV DOCKERIZE_VERSION v0.6.1
+ENV DOCKERIZE_VERSION=v0.6.1
 
 # Install dockerize
 RUN set -x && \
@@ -11,7 +11,10 @@ RUN set -x && \
 FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -r --gid 201 scalar \
+ && useradd -r --uid 201 -g scalar scalar
 
 COPY --from=tools dockerize /usr/local/bin/
 
@@ -19,19 +22,17 @@ WORKDIR /scalar
 
 # The path should be relative from build/docker. Running `gradle build`
 # (provided by com.palantir.docker plugin) will copy this Dockerfile and
-# ledger.tar to build/docker.
-ADD ./client.tar .
+# client.tar to build/docker.
+ADD --chown=201:201 ./client.tar .
 
-COPY client.properties.tmpl .
-COPY log4j2.properties.tmpl .
-
-RUN groupadd -r --gid 201 scalar && \
-    useradd -r --uid 201 -g scalar scalar
-RUN chown -R scalar:scalar /scalar
+COPY --chown=201:201 \
+     client.properties.tmpl \
+     log4j2.properties.tmpl \
+     ./
 
 USER 201
 
-ENV JAVA_OPTS -Dlog4j.configurationFile=file:/tmp/log4j2.properties
+ENV JAVA_OPTS='-Dlog4j.configurationFile=file:/tmp/log4j2.properties'
 
 CMD ["dockerize", "-template", "client.properties.tmpl:/tmp/client.properties", \
     "-template", "log4j2.properties.tmpl:/tmp/log4j2.properties", \

--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV DOCKERIZE_VERSION v0.6.1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.47
+ENV DOCKERIZE_VERSION=v0.6.1
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.47
 
 # Install dockerize
 RUN set -x && \
@@ -18,33 +18,36 @@ RUN set -x && \
 FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -r --gid 201 scalar \
+ && useradd -r --uid 201 -g scalar scalar
 
-COPY --from=tools dockerize /usr/local/bin/
-COPY --from=tools grpc_health_probe /usr/local/bin/
+COPY --from=tools \
+     dockerize \
+     grpc_health_probe \
+     /usr/local/bin/
 
 WORKDIR /scalar
 
 # The path should be relative from build/docker. Running `gradle build`
 # (provided by com.palantir.docker plugin) will copy this Dockerfile and
 # ledger.tar to build/docker.
-ADD ./ledger.tar .
+ADD --chown=201:201 ./ledger.tar .
 
-# it needs to CD to ledger to see security.policy
-WORKDIR /scalar/ledger
-
-COPY ledger.properties.tmpl .
-COPY log4j2.properties.tmpl .
-COPY docker-entrypoint.sh .
-
-RUN groupadd -r --gid 201 scalar && \
-    useradd -r --uid 201 -g scalar scalar
-RUN chown -R scalar:scalar /scalar/ledger
+COPY --chown=201:201 \
+     ledger.properties.tmpl \
+     log4j2.properties.tmpl \
+     docker-entrypoint.sh \
+     ./ledger/
 
 USER 201
 
-ENV JAVA_OPT_MAX_RAM_PERCENTAGE '60.0'
-ENV JAVA_OPTS '-Dlog4j.configurationFile=file:/tmp/log4j2.properties'
+ENV JAVA_OPT_MAX_RAM_PERCENTAGE='60.0' \
+    JAVA_OPTS='-Dlog4j.configurationFile=file:/tmp/log4j2.properties'
+
+# it needs to CD to ledger to see security.policy
+WORKDIR /scalar/ledger
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 

--- a/schema-loader/Dockerfile
+++ b/schema-loader/Dockerfile
@@ -2,7 +2,7 @@ ARG SCALARDB_VERSION
 
 FROM docker.io/busybox:1.36 AS tools
 
-ENV DOCKERIZE_VERSION v0.6.1
+ENV DOCKERIZE_VERSION=v0.6.1
 
 # Install dockerize
 # Support for use cases where environment variables are used to configure the database
@@ -24,11 +24,13 @@ USER 201
 WORKDIR /scalardl-schema-loader
 
 # 'ledger' and 'auditor' can be specified
-ENV SCHEMA_TYPE 'ledger'
+ENV SCHEMA_TYPE='ledger'
 
-COPY --chown=201:201 ledger-schema.json .
-COPY --chown=201:201 auditor-schema.json .
-COPY --chown=201:201 entrypoint.sh .
-COPY --chown=201:201 database.properties.tmpl .
+COPY --chown=201:201 \
+     ledger-schema.json \
+     auditor-schema.json \
+     entrypoint.sh \
+     database.properties.tmpl \
+     ./
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## Description

> [!NOTE]
> 
> We applied similar updates to the `main` branch in the previous #446.
> 
> Basically, this PR applies the same updates, but adjusted for v3, to the `3` and `3.x` branches.

This PR updates the Dockerfile to reduce container image size and optimize minor things to reduce the number of container image layers.

For example, the optimized container image size is as follows:

```console
REPOSITORY                            TAG             IMAGE ID       CREATED       SIZE
ghcr.io/scalar-labs/scalardl-ledger   3-reduce-size   edcf6f7d7031   3 hours ago   480MB
ghcr.io/scalar-labs/scalardl-ledger   3.13.0          5adb7b2d05d4   6 weeks ago   667MB
```

Please take a look!

## Related issues and/or PRs

- #446.
  - Updates on the `main` branch (`4.0.0-SNAPSHOT`) side.

## Changes made

- Remove `RUN`, which only runs the `chown` command, and instead of that, use the `--chown` option in `ADD`. This can reduce duplicated layers.
- Use the `--chown` option of `COPY` as well. This can reduce the number of image layers.
- Merge several `COPY` and `ENV` to reduce the number of layers.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I confirmed that the new optimized container images run properly as follows:

```console
$ kubectl get pod -n foo
NAME                                      READY   STATUS    RESTARTS   AGE
postgresql-scalardl-ledger-0              1/1     Running   0          144m
scalardl-example                          1/1     Running   0          114m
scalardl-ledger-ledger-764cc4d645-cwf8d   1/1     Running   0          117m
scalardl-ledger-ledger-764cc4d645-jxzbl   1/1     Running   0          117m
scalardl-ledger-ledger-764cc4d645-m7slg   1/1     Running   0          117m
```
```
root@scalardl-example:/# ./hashstore/bin/scalardl-hashstore bootstrap --properties /scalardl-example/scalardl-example.properties
{
  "status_code" : "OK",
  "output" : null
}
```

## Release notes

N/A

