### PR TITLE
Add asset lock recovery RPC

### DIFF
--- a/client/src/main/java/com/scalar/dl/client/service/AbstractAuditorClient.java
+++ b/client/src/main/java/com/scalar/dl/client/service/AbstractAuditorClient.java
@@ -1,5 +1,6 @@
 package com.scalar.dl.client.service;
 
+import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractExecutionResponse;
 import com.scalar.dl.rpc.ExecutionOrderingResponse;
@@ -10,4 +11,6 @@ public abstract class AbstractAuditorClient implements Client {
   abstract ExecutionOrderingResponse order(ContractExecutionRequest request);
 
   abstract ContractExecutionResponse validate(ExecutionValidationRequest request);
+
+  public abstract void recoverAssetLock(AssetLockRecoveryRequest request);
 }

--- a/client/src/main/java/com/scalar/dl/client/service/AuditorClient.java
+++ b/client/src/main/java/com/scalar/dl/client/service/AuditorClient.java
@@ -7,6 +7,7 @@ import com.scalar.dl.client.rpc.RpcUtil;
 import com.scalar.dl.ledger.config.TargetConfig;
 import com.scalar.dl.ledger.service.ThrowableConsumer;
 import com.scalar.dl.ledger.service.ThrowableFunction;
+import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.rpc.AuditorGrpc;
 import com.scalar.dl.rpc.AuditorPrivilegedGrpc;
 import com.scalar.dl.rpc.CertificateRegistrationRequest;
@@ -138,6 +139,16 @@ public class AuditorClient extends AbstractAuditorClient {
     }
     // Java compiler requires this line even though it won't come here
     return ContractExecutionResponse.getDefaultInstance();
+  }
+
+  @Override
+  public void recoverAssetLock(AssetLockRecoveryRequest request) {
+    ThrowableConsumer<AssetLockRecoveryRequest> f = r -> getAuditorStub().recoverAssetLock(r);
+    try {
+      accept(f, request);
+    } catch (Exception e) {
+      throwExceptionWithStatusCode(e);
+    }
   }
 
   @Override

--- a/client/src/main/java/com/scalar/dl/client/util/RequestSigner.java
+++ b/client/src/main/java/com/scalar/dl/client/util/RequestSigner.java
@@ -3,6 +3,7 @@ package com.scalar.dl.client.util;
 import com.google.inject.Inject;
 import com.google.protobuf.ByteString;
 import com.scalar.dl.ledger.crypto.SignatureSigner;
+import com.scalar.dl.rpc.AssetLockRecoveryRequest;
 import com.scalar.dl.rpc.AssetProofRetrievalRequest;
 import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractRegistrationRequest;
@@ -108,6 +109,18 @@ public class RequestSigner {
     byte[] bytes =
         com.scalar.dl.ledger.model.ExecutionAbortRequest.serialize(
             builder.getNonce(), builder.getEntityId(), builder.getKeyVersion());
+
+    byte[] signature = signer.sign(bytes);
+    return builder.setSignature(ByteString.copyFrom(signature));
+  }
+
+  public AssetLockRecoveryRequest.Builder sign(AssetLockRecoveryRequest.Builder builder) {
+    byte[] bytes =
+        com.scalar.dl.ledger.model.AssetLockRecoveryRequest.serialize(
+            builder.getNamespace(),
+            builder.getAssetId(),
+            builder.getEntityId(),
+            builder.getKeyVersion());
 
     byte[] signature = signer.sign(bytes);
     return builder.setSignature(ByteString.copyFrom(signature));

--- a/common/src/main/java/com/scalar/dl/ledger/model/AssetLockRecoveryRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/AssetLockRecoveryRequest.java
@@ -1,0 +1,98 @@
+package com.scalar.dl.ledger.model;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.scalar.dl.ledger.crypto.SignatureValidator;
+import com.scalar.dl.ledger.error.CommonLedgerError;
+import com.scalar.dl.ledger.exception.SignatureException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class AssetLockRecoveryRequest extends AbstractRequest {
+  @Nullable private final String namespace;
+  private final String assetId;
+  private final byte[] signature;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public AssetLockRecoveryRequest(
+      @Nullable String namespace,
+      String assetId,
+      String entityId,
+      int keyVersion,
+      byte[] signature) {
+    super(null, entityId, keyVersion);
+    checkArgument(assetId != null);
+    this.namespace = namespace;
+    this.assetId = assetId;
+    this.signature = signature;
+  }
+
+  @Nullable
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getAssetId() {
+    return assetId;
+  }
+
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public byte[] getSignature() {
+    return signature;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), namespace, assetId, Arrays.hashCode(signature));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof AssetLockRecoveryRequest)) {
+      return false;
+    }
+    AssetLockRecoveryRequest other = (AssetLockRecoveryRequest) o;
+    return Objects.equals(this.namespace, other.namespace)
+        && this.assetId.equals(other.assetId)
+        && Arrays.equals(this.signature, other.signature);
+  }
+
+  @Override
+  public void validateWith(SignatureValidator validator) {
+    byte[] bytes = serialize(namespace, assetId, getEntityId(), getKeyVersion());
+
+    if (!validator.validate(bytes, signature)) {
+      throw new SignatureException(CommonLedgerError.REQUEST_SIGNATURE_VALIDATION_FAILED);
+    }
+  }
+
+  public static byte[] serialize(
+      @Nullable String namespace, String assetId, String entityId, int keyVersion) {
+    byte[] namespaceBytes =
+        namespace != null ? namespace.getBytes(StandardCharsets.UTF_8) : new byte[0];
+    byte[] assetIdBytes = assetId.getBytes(StandardCharsets.UTF_8);
+    byte[] entityIdBytes = entityId.getBytes(StandardCharsets.UTF_8);
+
+    ByteBuffer buffer =
+        ByteBuffer.allocate(
+            namespaceBytes.length + assetIdBytes.length + entityIdBytes.length + Integer.BYTES);
+    buffer.put(namespaceBytes);
+    buffer.put(assetIdBytes);
+    buffer.put(entityIdBytes);
+    buffer.putInt(keyVersion);
+    buffer.rewind();
+    return buffer.array();
+  }
+}

--- a/common/src/test/java/com/scalar/dl/ledger/model/AssetLockRecoveryRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/AssetLockRecoveryRequestTest.java
@@ -1,0 +1,305 @@
+package com.scalar.dl.ledger.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.dl.ledger.exception.SignatureException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class AssetLockRecoveryRequestTest {
+  private static final String NAMESPACE = "namespace";
+  private static final String ASSET_ID = "asset_id";
+  private static final String ENTITY_ID = "entity_id";
+  private static final int KEY_VERSION = 1;
+  private static final byte[] SIGNATURE = "signature".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] WRONG_SIGNATURE = "wrong_signature".getBytes(StandardCharsets.UTF_8);
+  private static final Object ARBITRARY_OBJECT = new Object();
+
+  @Test
+  public void constructor_ArgumentsGiven_ShouldInstantiate() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(
+            () ->
+                new AssetLockRecoveryRequest(
+                    NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void constructor_NullNamespaceGiven_ShouldInstantiate() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(
+            () -> new AssetLockRecoveryRequest(null, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void constructor_NullEntityIdGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, null, KEY_VERSION, SIGNATURE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_NullAssetIdGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> new AssetLockRecoveryRequest(NAMESPACE, null, ENTITY_ID, KEY_VERSION, SIGNATURE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_ZeroKeyVersionGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(
+            () -> new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, 0, SIGNATURE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void get_ProperRequestGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    String namespace = request.getNamespace();
+    String assetId = request.getAssetId();
+    String entityId = request.getEntityId();
+    int keyVersion = request.getKeyVersion();
+    byte[] signature = request.getSignature();
+
+    // Assert
+    assertThat(namespace).isEqualTo(NAMESPACE);
+    assertThat(assetId).isEqualTo(ASSET_ID);
+    assertThat(entityId).isEqualTo(ENTITY_ID);
+    assertThat(keyVersion).isEqualTo(KEY_VERSION);
+    assertThat(signature).isEqualTo(SIGNATURE);
+  }
+
+  @Test
+  public void get_NullNamespaceGiven_ShouldReturnNull() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(null, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    String namespace = request.getNamespace();
+
+    // Assert
+    assertThat(namespace).isNull();
+  }
+
+  @Test
+  public void equals_OnTheSameObject_ShouldReturnTrue() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other = request;
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equals_OnTheSameData_ShouldReturnTrue() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equals_OnTheSameDataWithNullNamespace_ShouldReturnTrue() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(null, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other =
+        new AssetLockRecoveryRequest(null, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equals_OnAnArbitraryObject_ShouldReturnFalse() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(ARBITRARY_OBJECT);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentNamespace_ShouldReturnFalse() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other =
+        new AssetLockRecoveryRequest(
+            "different_namespace", ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentAssetId_ShouldReturnFalse() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other =
+        new AssetLockRecoveryRequest(
+            NAMESPACE, "different_asset_id", ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentSignature_ShouldReturnFalse() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, WRONG_SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void hashCode_OnTheSameData_ShouldReturnSameHashCode() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    AssetLockRecoveryRequest other =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    int hash1 = request.hashCode();
+    int hash2 = other.hashCode();
+
+    // Assert
+    assertThat(hash1).isEqualTo(hash2);
+  }
+
+  @Test
+  public void validateWith_ValidSignatureGiven_ShouldNotThrowException() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act Assert
+    assertThatCode(() -> request.validateWith((toBeValidated, sig) -> true))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void validateWith_InvalidSignatureGiven_ShouldThrowSignatureException() {
+    // Arrange
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act Assert
+    assertThatThrownBy(() -> request.validateWith((toBeValidated, sig) -> false))
+        .isInstanceOf(SignatureException.class);
+  }
+
+  @Test
+  public void validateWith_ProperBytesAndSignatureGiven_ShouldPassCorrectArguments() {
+    // Arrange
+    byte[] expectedBytes =
+        AssetLockRecoveryRequest.serialize(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION);
+    AssetLockRecoveryRequest request =
+        new AssetLockRecoveryRequest(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act Assert
+    assertThatCode(
+            () ->
+                request.validateWith(
+                    (toBeValidated, sig) -> {
+                      assertThat(toBeValidated).isEqualTo(expectedBytes);
+                      assertThat(sig).isEqualTo(SIGNATURE);
+                      return true;
+                    }))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void serialize_WithNamespace_ShouldReturnCorrectBytes() {
+    // Arrange
+
+    // Act
+    byte[] serialized =
+        AssetLockRecoveryRequest.serialize(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    assertThat(serialized).isNotNull();
+    assertThat(serialized.length).isGreaterThan(0);
+  }
+
+  @Test
+  public void serialize_WithNullNamespace_ShouldReturnCorrectBytes() {
+    // Arrange
+
+    // Act
+    byte[] serialized = AssetLockRecoveryRequest.serialize(null, ASSET_ID, ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    assertThat(serialized).isNotNull();
+    assertThat(serialized.length).isGreaterThan(0);
+  }
+
+  @Test
+  public void serialize_WithDifferentNamespace_ShouldReturnDifferentBytes() {
+    // Arrange
+
+    // Act
+    byte[] serialized1 =
+        AssetLockRecoveryRequest.serialize(NAMESPACE, ASSET_ID, ENTITY_ID, KEY_VERSION);
+    byte[] serialized2 = AssetLockRecoveryRequest.serialize(null, ASSET_ID, ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    assertThat(serialized1).isNotEqualTo(serialized2);
+  }
+}

--- a/rpc/src/main/proto/scalar.proto
+++ b/rpc/src/main/proto/scalar.proto
@@ -53,6 +53,8 @@ service Auditor {
     }
     rpc ValidateExecution(ExecutionValidationRequest) returns (ContractExecutionResponse) {
     }
+    rpc RecoverAssetLock (AssetLockRecoveryRequest) returns (google.protobuf.Empty) {
+    }
 }
 
 service AuditorPrivileged {
@@ -193,6 +195,14 @@ message StateRetrievalRequest {
 message ExecutionValidationRequest {
     ContractExecutionRequest request = 1;
     repeated AssetProof proofs = 2;
+}
+
+message AssetLockRecoveryRequest {
+    string namespace = 1;
+    string asset_id = 2;
+    string entity_id = 3;
+    uint32 key_version = 4;
+    bytes signature = 5;
 }
 
 message NamespaceCreationRequest {


### PR DESCRIPTION
## Description

Add a new RecoverAssetLock RPC to the Auditor service to allow clients to request recovery of locked assets. This RPC is intended for internal use via scalardl-tools and is not exposed in ClientService for direct user access.

## Related issues and/or PRs

- N/A

## Changes made

  - Define RecoverAssetLock RPC and AssetLockRecoveryRequest message in scalar.proto
  - Add AssetLockRecoveryRequest model class with signature validation and serialization
  - Add recoverAssetLock abstract method to AbstractAuditorClient
  - Implement recoverAssetLock in AuditorClient
  - Add sign method for AssetLockRecoveryRequest in RequestSigner
  - Add unit tests
 
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Added asset lock recovery RPC.
