### PR TITLE
Build UBI based container image for OpenShift

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -64,9 +64,14 @@ jobs:
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: ./gradlew docker
 
+      - name: Create UBI-based SNAPSHOT container images
+        if: contains(steps.version.outputs.version, '-SNAPSHOT')
+        run: ./gradlew :ledger:docker -Pubi
+
       - name: Push SNAPSHOT container images
         if: contains(steps.version.outputs.version, '-SNAPSHOT')
         run: |
           docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-ledger-ubi:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,9 +63,13 @@ jobs:
       - name: Create containers
         run: ./gradlew docker
 
+      - name: Create UBI-based containers
+        run: ./gradlew :ledger:docker -Pubi
+
       - name: Push containers to private GitHub Packages
         run: |
           docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-ledger-ubi:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}
 

--- a/.github/workflows/remove-untagged-images.yaml
+++ b/.github/workflows/remove-untagged-images.yaml
@@ -21,6 +21,12 @@ jobs:
           github-token: ${{ secrets.CR_PAT }}
           package-name: scalardl-ledger
 
+      - name: scalardl-ledger-ubi
+        uses: camargo/delete-untagged-action@v1
+        with:
+          github-token: ${{ secrets.CR_PAT }}
+          package-name: scalardl-ledger-ubi
+
       - name: scalardl-client
         uses: camargo/delete-untagged-action@v1
         with:

--- a/.github/workflows/scalar.yml
+++ b/.github/workflows/scalar.yml
@@ -34,6 +34,11 @@ jobs:
           client:dockerfileLint \
           ledger:dockerfileLint \
 
+    - name: Lint Dockerfile for UBI-based images
+      run: |
+        ./gradlew \
+          ledger:dockerfileLint -Pubi
+
     - name: Run unit tests
       run: ./gradlew check
 
@@ -117,8 +122,18 @@ jobs:
           -Dscalardb.transaction_manager=jdbc
 
   e2e-integration-test-for-ledger:
-    name: End-to-end integration test for Ledger
+    name: End-to-end integration test for Ledger (${{ matrix.image-type }})
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - image-type: temurin
+            build-args: ""
+            image-suffix: ""
+          - image-type: ubi
+            build-args: "-Pubi"
+            image-suffix: "-ubi"
 
     steps:
       - uses: actions/checkout@v6
@@ -132,17 +147,25 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Get the project version
+        id: set-version
+        run: |
+          VERSION=$(./gradlew :common:properties -q | grep "version:" | awk '{print $2}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Build Docker images
-        run: ./gradlew :ledger:docker
+        run: ./gradlew :ledger:docker ${{ matrix.build-args }}
 
       - name: Run integration tests
-        run: ./gradlew :testing:integrationTest
+        run: |
+          ./gradlew :testing:integrationTest \
+            -Dscalardl.ledger.image=ghcr.io/scalar-labs/scalardl-ledger${{ matrix.image-suffix }}:${{ steps.set-version.outputs.version }}
 
       - name: Upload Gradle test reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: integration_test_reports_for_ledger_e2e
+          name: integration_test_reports_for_ledger_e2e_${{ matrix.image-type }}
           path: testing/build/reports/tests/integrationTest
 
   e2e-integration-test-for-generic-contracts:

--- a/build.gradle
+++ b/build.gradle
@@ -141,8 +141,9 @@ subprojects {
     }
 
     task dockerfileLint(type: Exec) {
+        def dockerfileSuffix = project.hasProperty("ubi") ? ".ubi" : ""
         description 'Lint the Dockerfile'
-        executable "${rootDir}/scripts/docker/lint.sh"
+        commandLine "${rootDir}/scripts/docker/lint.sh", "Dockerfile${dockerfileSuffix}"
     }
 
     // Configure publishing repositories for all subprojects using maven-publish plugin

--- a/ledger/Dockerfile.ubi
+++ b/ledger/Dockerfile.ubi
@@ -8,13 +8,17 @@ RUN set -x && \
     wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64" && \
     chmod +x grpc_health_probe
 
-FROM eclipse-temurin:21-jre-jammy
+# hadolint ignore=DL3007
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
-RUN apt-get update && apt-get upgrade -y --no-install-recommends \
- && apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/* \
+# hadolint ignore=DL3041
+RUN microdnf update -y \
+ && microdnf install java-21-openjdk-headless shadow-utils --setopt install_weak_deps=0 --nodocs -y \
  && groupadd -r --gid 201 scalar \
- && useradd -r --uid 201 -g scalar scalar
+ && useradd -r --uid 201 -g scalar scalar \
+ && microdnf remove shadow-utils -y \
+ && microdnf clean all \
+ && rm -rf /var/cache/yum
 
 COPY --from=tools grpc_health_probe /usr/local/bin/
 

--- a/ledger/build.gradle
+++ b/ledger/build.gradle
@@ -108,6 +108,7 @@ task copyFilesToDockerBuildContextDir(type: Copy) {
     description = 'Copy files to a temporary folder to build the Docker image'
     dependsOn distTar
     from('Dockerfile')
+    from('Dockerfile.ubi')
     from('conf') {
         include 'ledger.properties'
         include 'log4j2.properties'
@@ -117,11 +118,23 @@ task copyFilesToDockerBuildContextDir(type: Copy) {
     into('build/docker')
 }
 
+def ubiSuffix = project.hasProperty("ubi") ? "-ubi" : ""
+def dockerfileSuffix = project.hasProperty("ubi") ? ".ubi" : ""
+def imageName = "scalardl-ledger${ubiSuffix}"
+def imageVersion = dockerVersion
+def imageRelease = System.currentTimeMillis().toString()
+
 task docker(type: Exec) {
     description = 'Build ScalarDL Ledger Docker image'
     dependsOn copyFilesToDockerBuildContextDir
     workingDir 'build/docker'
-    commandLine 'docker', 'build', '--tag', "ghcr.io/scalar-labs/scalardl-ledger:${dockerVersion}", '.'
+    commandLine 'docker', 'build',
+    '--build-arg', "IMAGE_NAME=${imageName}",
+    '--build-arg', "IMAGE_VERSION=${imageVersion}",
+    '--build-arg', "IMAGE_RELEASE=${imageRelease}",
+    '-f', "Dockerfile${dockerfileSuffix}",
+    '--tag', "ghcr.io/scalar-labs/${imageName}:${imageVersion}",
+    '.'
 }
 
 def integrationTestBase = {

--- a/scripts/docker/lint.sh
+++ b/scripts/docker/lint.sh
@@ -4,8 +4,9 @@ set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
 
 SCRIPT_ROOT="$(cd "$(dirname "$0")"; pwd)"
 
+DOCKERFILE_NAME=$1
 HADOLINT_VERSION="v2.12.0"
 HADOLINT="${HADOLINT:-docker run --rm -i -v "$(pwd):/mnt" -w "/mnt" "hadolint/hadolint:${HADOLINT_VERSION}" hadolint}"
 
-exec ${HADOLINT} ./Dockerfile
+exec ${HADOLINT} ./${DOCKERFILE_NAME:-Dockerfile}
 # vim: ai ts=2 sw=2 et sts=2 ft=sh


### PR DESCRIPTION
## Description

> [!NOTE]
> 
> We will merge this PR to the `main` branch, but we don't backport it to the `3` branch. Instead of that, I will create another PR against the `3` branch to apply the same updates. This is because there are several backward-incompatible changes between `main (4.0.0-SNAPSHOT)` and `3` from the container image perspective.

This PR adds a new container image based on UBI.

The UBI-based container image is required to lint ScalarDL on the Red Hat Ecosystem Catalog.

Also, this PR updates the existing integration test to run the integration test with a UBI-based container image.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made

- Container image-related updates
  - Add a new Dockerfile to build a UBI-based container image.
  - Update the existing Dockerfile to add LABEL. The purpose of this update is to keep consistency between the Temurin-based container image and the UBI-based container image.
  - Update `build.gradle` to switch to Temurin-based or UBI-based by using the `-Pubi` option and to add proper labels by using variables.
- Test-related updates
  - Update `lint.sh` and `build.gradle` to run the linter for both Temurin-based Dockerfile and UBI-based Dockerfile.
  - Update `scalar.yaml` (existing integration test). I added `strategy.matrix` configuration to run two integration tests in parallel. One is an integration test by using a Temurin-based container image. Another is an integration test by using a UBI-based container image.
- Release-related updates
  - Update existing release flow to publish the new UBI-based container image.
  - Update `remove-untagged-images.yaml` to remove untagged images of UBI-based container images.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I was able to run the integration test by using the newly built UBI-based container image in my local environment as follows:

```console
$ ./gradlew :testing:integrationTest -Dscalardl.ledger.image=ghcr.io/scalar-labs/scalardl-ledger-ubi:4.0.0-SNAPSHOT

(omit)

BUILD SUCCESSFUL in 7m 58s
16 actionable tasks: 4 executed, 12 up-to-date
```

I could see the UBI-based container image is used in the above integration test as follows:

```console
$ docker ps
CONTAINER ID   IMAGE                                                    COMMAND                  CREATED              STATUS              PORTS                                                                                              NAMES
4dfcce340ba1   ghcr.io/scalar-labs/scalardl-ledger-ubi:4.0.0-SNAPSHOT   "./docker-entrypoint…"   26 seconds ago       Up 25 seconds       0.0.0.0:44623->50051/tcp, [::]:44623->50051/tcp, 0.0.0.0:44624->50052/tcp, [::]:44624->50052/tcp   jolly_lederberg
fe6ce8837814   testcontainers/sshd:1.3.0                                "sh -c 'echo ${USERN…"   27 seconds ago       Up 26 seconds       0.0.0.0:44622->22/tcp, [::]:44622->22/tcp                                                          infallible_varahamihira
03e9160b6861   mysql:8.0                                                "docker-entrypoint.s…"   48 seconds ago       Up 47 seconds       33060/tcp, 0.0.0.0:44621->3306/tcp, [::]:44621->3306/tcp                                           adoring_hawking
d3225dc06678   testcontainers/ryuk:0.14.0                               "/bin/ryuk"              About a minute ago   Up About a minute   0.0.0.0:44620->8080/tcp, [::]:44620->8080/tcp                                                      testcontainers-ryuk-f36748a1-7fe0-487f-b48e-c530f2b026d8
```

## Release notes

Provide a UBI-based container image to support OpenShift as a platform.
