### PR TITLE
Add finish execution RPC

### DIFF
--- a/client/src/main/java/com/scalar/dl/client/service/AbstractLedgerClient.java
+++ b/client/src/main/java/com/scalar/dl/client/service/AbstractLedgerClient.java
@@ -9,6 +9,7 @@ import com.scalar.dl.rpc.AssetProofRetrievalRequest;
 import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractExecutionResponse;
 import com.scalar.dl.rpc.ExecutionAbortRequest;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.FunctionRegistrationRequest;
 import com.scalar.dl.rpc.LedgerValidationRequest;
 import com.scalar.dl.rpc.SignedFunctionRegistrationRequest;
@@ -33,4 +34,6 @@ public abstract class AbstractLedgerClient implements Client {
   abstract Optional<AssetProof> retrieve(AssetProofRetrievalRequest request);
 
   abstract TransactionState abort(ExecutionAbortRequest request);
+
+  abstract void finish(ExecutionFinishRequest request);
 }

--- a/client/src/main/java/com/scalar/dl/client/service/LedgerClient.java
+++ b/client/src/main/java/com/scalar/dl/client/service/LedgerClient.java
@@ -23,6 +23,7 @@ import com.scalar.dl.rpc.ContractRegistrationRequest;
 import com.scalar.dl.rpc.ContractsListingRequest;
 import com.scalar.dl.rpc.ExecutionAbortRequest;
 import com.scalar.dl.rpc.ExecutionAbortResponse;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.FunctionRegistrationRequest;
 import com.scalar.dl.rpc.LedgerGrpc;
 import com.scalar.dl.rpc.LedgerPrivilegedGrpc;
@@ -243,6 +244,15 @@ public class LedgerClient extends AbstractLedgerClient {
     }
     // Java compiler requires this line even though it won't come here
     return TransactionState.UNKNOWN;
+  }
+
+  @Override
+  public void finish(ExecutionFinishRequest request) {
+    try {
+      getLedgerStub().finishExecution(request);
+    } catch (Exception e) {
+      throwExceptionWithStatusCode(e);
+    }
   }
 
   @Override

--- a/client/src/main/java/com/scalar/dl/client/util/RequestSigner.java
+++ b/client/src/main/java/com/scalar/dl/client/util/RequestSigner.java
@@ -8,6 +8,7 @@ import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractRegistrationRequest;
 import com.scalar.dl.rpc.ContractsListingRequest;
 import com.scalar.dl.rpc.ExecutionAbortRequest;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.LedgerValidationRequest;
 import com.scalar.dl.rpc.SignedFunctionRegistrationRequest;
 import javax.annotation.concurrent.Immutable;
@@ -107,6 +108,15 @@ public class RequestSigner {
   public ExecutionAbortRequest.Builder sign(ExecutionAbortRequest.Builder builder) {
     byte[] bytes =
         com.scalar.dl.ledger.model.ExecutionAbortRequest.serialize(
+            builder.getNonce(), builder.getEntityId(), builder.getKeyVersion());
+
+    byte[] signature = signer.sign(bytes);
+    return builder.setSignature(ByteString.copyFrom(signature));
+  }
+
+  public ExecutionFinishRequest.Builder sign(ExecutionFinishRequest.Builder builder) {
+    byte[] bytes =
+        com.scalar.dl.ledger.model.ExecutionFinishRequest.serialize(
             builder.getNonce(), builder.getEntityId(), builder.getKeyVersion());
 
     byte[] signature = signer.sign(bytes);

--- a/client/src/test/java/com/scalar/dl/client/service/LedgerClientTest.java
+++ b/client/src/test/java/com/scalar/dl/client/service/LedgerClientTest.java
@@ -17,6 +17,7 @@ import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.rpc.AssetProof;
 import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractExecutionResponse;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.LedgerGrpc;
 import com.scalar.dl.rpc.Status;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -148,5 +149,36 @@ public class LedgerClientTest {
     assertThat(((ClientException) thrown).getStatusCode())
         .isEqualTo(StatusCode.UNKNOWN_TRANSACTION_STATUS);
     assertThat(thrown.getMessage()).isEqualTo(io.grpc.Status.INTERNAL.getCode().toString());
+  }
+
+  @Test
+  public void finish_CorrectRequestGiven_ShouldCallFinishExecution() {
+    // Arrange
+    ExecutionFinishRequest request = ExecutionFinishRequest.newBuilder().build();
+    when(ledgerStub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(anotherStub);
+
+    // Act
+    client.finish(request);
+
+    // Assert
+    verify(ledgerStub).withDeadlineAfter(ANY_DEADLINE_MILLIS, TimeUnit.MILLISECONDS);
+    verify(anotherStub).finishExecution(request);
+  }
+
+  @Test
+  public void finish_ExceptionThrown_ShouldThrowClientException() {
+    // Arrange
+    ExecutionFinishRequest request = ExecutionFinishRequest.newBuilder().build();
+    StatusRuntimeException toThrow = new StatusRuntimeException(io.grpc.Status.INTERNAL);
+    when(ledgerStub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(anotherStub);
+    when(anotherStub.finishExecution(request)).thenThrow(toThrow);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> client.finish(request));
+
+    // Assert
+    verify(ledgerStub).withDeadlineAfter(ANY_DEADLINE_MILLIS, TimeUnit.MILLISECONDS);
+    verify(anotherStub).finishExecution(request);
+    assertThat(thrown).isInstanceOf(ClientException.class).hasCause(toThrow);
   }
 }

--- a/common/src/main/java/com/scalar/dl/ledger/model/ExecutionFinishRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/ExecutionFinishRequest.java
@@ -1,0 +1,75 @@
+package com.scalar.dl.ledger.model;
+
+import com.scalar.dl.ledger.crypto.SignatureValidator;
+import com.scalar.dl.ledger.error.CommonLedgerError;
+import com.scalar.dl.ledger.exception.SignatureException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class ExecutionFinishRequest extends AbstractRequest {
+  private final String nonce;
+  private final byte[] signature;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public ExecutionFinishRequest(String nonce, String entityId, int keyVersion, byte[] signature) {
+    super(null, entityId, keyVersion);
+    this.nonce = nonce;
+    this.signature = signature;
+  }
+
+  public String getNonce() {
+    return nonce;
+  }
+
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public byte[] getSignature() {
+    return signature;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), nonce, Arrays.hashCode(signature));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof ExecutionFinishRequest)) {
+      return false;
+    }
+    ExecutionFinishRequest other = (ExecutionFinishRequest) o;
+    return this.nonce.equals(other.nonce) && Arrays.equals(this.signature, other.signature);
+  }
+
+  @Override
+  public void validateWith(SignatureValidator validator) {
+    byte[] bytes = serialize(nonce, getEntityId(), getKeyVersion());
+
+    if (!validator.validate(bytes, signature)) {
+      throw new SignatureException(CommonLedgerError.REQUEST_SIGNATURE_VALIDATION_FAILED);
+    }
+  }
+
+  public static byte[] serialize(String nonce, String entityId, int keyVersion) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(
+            nonce.getBytes(StandardCharsets.UTF_8).length
+                + entityId.getBytes(StandardCharsets.UTF_8).length
+                + Integer.BYTES);
+    buffer.put(nonce.getBytes(StandardCharsets.UTF_8));
+    buffer.put(entityId.getBytes(StandardCharsets.UTF_8));
+    buffer.putInt(keyVersion);
+    buffer.rewind();
+    return buffer.array();
+  }
+}

--- a/common/src/main/java/com/scalar/dl/ledger/model/ExecutionFinishRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/ExecutionFinishRequest.java
@@ -12,6 +12,10 @@ import javax.annotation.concurrent.Immutable;
 
 @Immutable
 public class ExecutionFinishRequest extends AbstractRequest {
+  // A domain separator prepended to the signed bytes so that a signature for this request type
+  // cannot be reused for another request type that signs the same values. For example,
+  // ExecutionAbortRequest signs the same nonce + entityId + keyVersion.
+  private static final byte[] REQUEST_TYPE_TAG = "finish".getBytes(StandardCharsets.UTF_8);
   private final String nonce;
   private final byte[] signature;
 
@@ -63,9 +67,11 @@ public class ExecutionFinishRequest extends AbstractRequest {
   public static byte[] serialize(String nonce, String entityId, int keyVersion) {
     ByteBuffer buffer =
         ByteBuffer.allocate(
-            nonce.getBytes(StandardCharsets.UTF_8).length
+            REQUEST_TYPE_TAG.length
+                + nonce.getBytes(StandardCharsets.UTF_8).length
                 + entityId.getBytes(StandardCharsets.UTF_8).length
                 + Integer.BYTES);
+    buffer.put(REQUEST_TYPE_TAG);
     buffer.put(nonce.getBytes(StandardCharsets.UTF_8));
     buffer.put(entityId.getBytes(StandardCharsets.UTF_8));
     buffer.putInt(keyVersion);

--- a/common/src/test/java/com/scalar/dl/ledger/model/ExecutionFinishRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ExecutionFinishRequestTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.scalar.dl.ledger.crypto.SignatureValidator;
 import com.scalar.dl.ledger.exception.SignatureException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
@@ -235,5 +236,40 @@ public class ExecutionFinishRequestTest {
 
     // Assert
     assertThat(serialized1).isNotEqualTo(serialized2);
+  }
+
+  @Test
+  public void serialize_ArgumentsGiven_ShouldBePrefixedWithRequestTypeTag() {
+    // Arrange
+    byte[] tag = "finish".getBytes(StandardCharsets.UTF_8);
+    byte[] nonce = NONCE.getBytes(StandardCharsets.UTF_8);
+    byte[] entityId = ENTITY_ID.getBytes(StandardCharsets.UTF_8);
+    byte[] expected =
+        ByteBuffer.allocate(tag.length + nonce.length + entityId.length + Integer.BYTES)
+            .put(tag)
+            .put(nonce)
+            .put(entityId)
+            .putInt(KEY_VERSION)
+            .array();
+
+    // Act
+    byte[] serialized = ExecutionFinishRequest.serialize(NONCE, ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    assertThat(serialized).isEqualTo(expected);
+  }
+
+  @Test
+  public void serialize_SameValuesAsAbortRequest_ShouldReturnDifferentBytes() {
+    // Arrange
+
+    // Act
+    byte[] finish = ExecutionFinishRequest.serialize(NONCE, ENTITY_ID, KEY_VERSION);
+    byte[] abort = ExecutionAbortRequest.serialize(NONCE, ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    // The domain separator ensures a captured abort signature cannot be reused as a finish
+    // signature (and vice versa) even when the signed values are identical.
+    assertThat(finish).isNotEqualTo(abort);
   }
 }

--- a/common/src/test/java/com/scalar/dl/ledger/model/ExecutionFinishRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ExecutionFinishRequestTest.java
@@ -1,0 +1,239 @@
+package com.scalar.dl.ledger.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.dl.ledger.crypto.SignatureValidator;
+import com.scalar.dl.ledger.exception.SignatureException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class ExecutionFinishRequestTest {
+  private static final String NONCE = "nonce";
+  private static final String ENTITY_ID = "entity_id";
+  private static final int KEY_VERSION = 1;
+  private static final byte[] SIGNATURE = "signature".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] WRONG_SIGNATURE = "wrong_signature".getBytes(StandardCharsets.UTF_8);
+  private static final Object ARBITRARY_OBJECT = new Object();
+
+  @Test
+  public void constructor_ArgumentsGiven_ShouldInstantiate() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void constructor_NullEntityIdGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> new ExecutionFinishRequest(NONCE, null, KEY_VERSION, SIGNATURE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructor_NonPositiveKeyVersionGiven_ShouldThrowIllegalArgumentException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> new ExecutionFinishRequest(NONCE, ENTITY_ID, 0, SIGNATURE))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void get_ProperRequestGiven_ShouldReturnWhatsSet() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    String nonce = request.getNonce();
+    String entityId = request.getEntityId();
+    int keyVersion = request.getKeyVersion();
+    byte[] signature = request.getSignature();
+
+    // Assert
+    assertThat(nonce).isEqualTo(NONCE);
+    assertThat(entityId).isEqualTo(ENTITY_ID);
+    assertThat(keyVersion).isEqualTo(KEY_VERSION);
+    assertThat(signature).isEqualTo(SIGNATURE);
+  }
+
+  @Test
+  public void equals_OnTheSameObject_ShouldReturnTrue() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other = request;
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equals_OnTheSameData_ShouldReturnTrue() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equals_OnAnArbitraryObject_ShouldReturnFalse() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(ARBITRARY_OBJECT);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentNonce_ShouldReturnFalse() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other =
+        new ExecutionFinishRequest("different_nonce", ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentEntityId_ShouldReturnFalse() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other =
+        new ExecutionFinishRequest(NONCE, "different_entity_id", KEY_VERSION, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentKeyVersion_ShouldReturnFalse() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other = new ExecutionFinishRequest(NONCE, ENTITY_ID, 99, SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equals_OnDifferentSignature_ShouldReturnFalse() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, WRONG_SIGNATURE);
+
+    // Act
+    boolean result = request.equals(other);
+
+    // Assert
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void hashCode_OnTheSameData_ShouldReturnSameHashCode() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    ExecutionFinishRequest other =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+
+    // Act
+    int hash1 = request.hashCode();
+    int hash2 = other.hashCode();
+
+    // Assert
+    assertThat(hash1).isEqualTo(hash2);
+  }
+
+  @Test
+  public void validateWith_ValidSignatureGiven_ShouldNotThrowAnyException() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    SignatureValidator validator = mock(SignatureValidator.class);
+    when(validator.validate(any(byte[].class), any(byte[].class))).thenReturn(true);
+
+    // Act Assert
+    assertThatCode(() -> request.validateWith(validator)).doesNotThrowAnyException();
+
+    byte[] expected = ExecutionFinishRequest.serialize(NONCE, ENTITY_ID, KEY_VERSION);
+    verify(validator).validate(expected, SIGNATURE);
+  }
+
+  @Test
+  public void validateWith_InvalidSignatureGiven_ShouldThrowSignatureException() {
+    // Arrange
+    ExecutionFinishRequest request =
+        new ExecutionFinishRequest(NONCE, ENTITY_ID, KEY_VERSION, SIGNATURE);
+    SignatureValidator validator = mock(SignatureValidator.class);
+    when(validator.validate(any(byte[].class), any(byte[].class))).thenReturn(false);
+
+    // Act Assert
+    assertThatThrownBy(() -> request.validateWith(validator))
+        .isInstanceOf(SignatureException.class);
+  }
+
+  @Test
+  public void serialize_ArgumentsGiven_ShouldReturnCorrectBytes() {
+    // Arrange
+
+    // Act
+    byte[] serialized = ExecutionFinishRequest.serialize(NONCE, ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    assertThat(serialized).isNotNull();
+    assertThat(serialized.length).isGreaterThan(0);
+  }
+
+  @Test
+  public void serialize_WithDifferentNonce_ShouldReturnDifferentBytes() {
+    // Arrange
+
+    // Act
+    byte[] serialized1 = ExecutionFinishRequest.serialize(NONCE, ENTITY_ID, KEY_VERSION);
+    byte[] serialized2 =
+        ExecutionFinishRequest.serialize("different_nonce", ENTITY_ID, KEY_VERSION);
+
+    // Assert
+    assertThat(serialized1).isNotEqualTo(serialized2);
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/contract/ContractExecutor.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/contract/ContractExecutor.java
@@ -93,6 +93,10 @@ public class ContractExecutor {
     return transactionManager.abort(nonce);
   }
 
+  public void finish(String nonce) {
+    transactionManager.finish(nonce);
+  }
+
   private List<FunctionMachine> getFunctions(String namespace, List<String> functionIds) {
     if (!config.isFunctionEnabled()) {
       return Collections.emptyList();

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/TransactionManager.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/TransactionManager.java
@@ -14,5 +14,7 @@ public interface TransactionManager {
 
   TransactionState abort(String transactionId);
 
+  void finish(String transactionId);
+
   void recover(Map<AssetKey, Integer> assetIds);
 }

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTransactionManager.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTransactionManager.java
@@ -142,6 +142,15 @@ public class ScalarTransactionManager implements TransactionManager, TableMetada
   }
 
   @Override
+  public void finish(String transactionId) {
+    if (config.isTxStateManagementEnabled()) {
+      stateManager.deleteState(transactionId);
+    }
+    // TODO: Call manager.finishTransaction(transactionId) when ScalarDB PR #3567 is merged
+    // https://github.com/scalar-labs/scalardb/pull/3567
+  }
+
+  @Override
   public void recover(Map<AssetKey, Integer> assetKeys) {
     if (manager instanceof ConsensusCommitManager) {
       /*

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/TransactionStateManager.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/TransactionStateManager.java
@@ -5,6 +5,7 @@ import static com.scalar.dl.ledger.database.TransactionState.COMMITTED;
 import static com.scalar.dl.ledger.database.TransactionState.UNKNOWN;
 
 import com.google.inject.Inject;
+import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
@@ -19,6 +20,7 @@ import com.scalar.db.io.TextValue;
 import com.scalar.dl.ledger.database.TransactionState;
 import com.scalar.dl.ledger.error.LedgerError;
 import com.scalar.dl.ledger.exception.ConflictException;
+import com.scalar.dl.ledger.exception.DatabaseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +92,26 @@ public class TransactionStateManager {
       LOGGER.warn(
           "could not get the state of transaction " + transactionId + " for some reason.", e);
       return UNKNOWN;
+    }
+  }
+
+  public void deleteState(String transactionId) {
+    DistributedTransaction transaction = null;
+    try {
+      transaction = manager.start();
+      Delete delete =
+          Delete.newBuilder().table(TABLE).partitionKey(Key.ofText(ID, transactionId)).build();
+      transaction.delete(delete);
+      transaction.commit();
+    } catch (TransactionException e) {
+      if (transaction != null) {
+        try {
+          transaction.abort();
+        } catch (AbortException ignored) {
+          // ignore it since the transaction state is eventually settled
+        }
+      }
+      throw new DatabaseException(LedgerError.FINISHING_TRANSACTION_FAILED, e, e.getMessage());
     }
   }
 

--- a/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
@@ -257,6 +257,12 @@ public enum LedgerError implements ScalarDlError {
       "The database operation in the function failed due to a database error. Details: %s",
       "",
       "Check the error details in the logs and verify your database configuration and connection."),
+  FINISHING_TRANSACTION_FAILED(
+      StatusCode.DATABASE_ERROR,
+      "012",
+      "Finishing the transaction failed. Details: %s",
+      "",
+      "Check the error details in the logs and verify your database configuration and connection."),
 
   //
   // Errors for UNKNOWN_TRANSACTION_STATUS(501)

--- a/ledger/src/main/java/com/scalar/dl/ledger/server/LedgerService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/server/LedgerService.java
@@ -22,6 +22,7 @@ import com.scalar.dl.rpc.ContractsListingRequest;
 import com.scalar.dl.rpc.ContractsListingResponse;
 import com.scalar.dl.rpc.ExecutionAbortRequest;
 import com.scalar.dl.rpc.ExecutionAbortResponse;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.LedgerGrpc;
 import com.scalar.dl.rpc.LedgerValidationRequest;
 import com.scalar.dl.rpc.LedgerValidationResponse;
@@ -128,6 +129,14 @@ public class LedgerService extends LedgerGrpc.LedgerImplBase {
               .setState(TransactionState.forNumber(result.getState().get()))
               .build();
         };
+
+    commonService.serve(f, request, responseObserver);
+  }
+
+  @Override
+  public void finishExecution(
+      ExecutionFinishRequest request, StreamObserver<Empty> responseObserver) {
+    ThrowableConsumer<ExecutionFinishRequest> f = r -> ledger.finish(convert(r));
 
     commonService.serve(f, request, responseObserver);
   }

--- a/ledger/src/main/java/com/scalar/dl/ledger/server/TypeConverter.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/server/TypeConverter.java
@@ -11,6 +11,7 @@ import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractRegistrationRequest;
 import com.scalar.dl.rpc.ContractsListingRequest;
 import com.scalar.dl.rpc.ExecutionAbortRequest;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.FunctionRegistrationRequest;
 import com.scalar.dl.rpc.LedgerValidationRequest;
 import com.scalar.dl.rpc.NamespaceCreationRequest;
@@ -131,6 +132,12 @@ public class TypeConverter {
   public static com.scalar.dl.ledger.model.ExecutionAbortRequest convert(
       ExecutionAbortRequest req) {
     return new com.scalar.dl.ledger.model.ExecutionAbortRequest(
+        req.getNonce(), req.getEntityId(), req.getKeyVersion(), req.getSignature().toByteArray());
+  }
+
+  public static com.scalar.dl.ledger.model.ExecutionFinishRequest convert(
+      ExecutionFinishRequest req) {
+    return new com.scalar.dl.ledger.model.ExecutionFinishRequest(
         req.getNonce(), req.getEntityId(), req.getKeyVersion(), req.getSignature().toByteArray());
   }
 

--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerService.java
@@ -21,6 +21,7 @@ import com.scalar.dl.ledger.model.ContractRegistrationRequest;
 import com.scalar.dl.ledger.model.ContractsListingRequest;
 import com.scalar.dl.ledger.model.ExecutionAbortRequest;
 import com.scalar.dl.ledger.model.ExecutionAbortResult;
+import com.scalar.dl.ledger.model.ExecutionFinishRequest;
 import com.scalar.dl.ledger.model.FunctionRegistrationRequest;
 import com.scalar.dl.ledger.model.NamespaceCreationRequest;
 import com.scalar.dl.ledger.model.NamespaceDroppingRequest;
@@ -137,6 +138,16 @@ public class LedgerService {
     request.validateWith(validator);
 
     return new ExecutionAbortResult(executor.abort(request.getNonce()));
+  }
+
+  public void finish(ExecutionFinishRequest request) {
+    // always use the default namespace to authenticate Auditor
+    SignatureValidator validator =
+        clientKeyValidator.getValidator(
+            Namespaces.DEFAULT, request.getEntityId(), request.getKeyVersion());
+    request.validateWith(validator);
+
+    executor.finish(request.getNonce());
   }
 
   public void create(NamespaceCreationRequest request) {

--- a/ledger/src/test/java/com/scalar/dl/ledger/contract/ContractExecutorTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/contract/ContractExecutorTest.java
@@ -285,4 +285,16 @@ public class ContractExecutorTest {
         .invoke(any(Database.class), nullable(String.class), anyString(), nullable(String.class));
     assertThat(thrown).isEqualTo(toThrow);
   }
+
+  @Test
+  public void finish_NonceGiven_ShouldCallTransactionManagerFinish() {
+    // Arrange
+    String nonce = "some_nonce";
+
+    // Act
+    executor.finish(nonce);
+
+    // Assert
+    verify(transactionManager).finish(nonce);
+  }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarTransactionManagerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarTransactionManagerTest.java
@@ -255,6 +255,36 @@ public class ScalarTransactionManagerTest {
   }
 
   @Test
+  public void finish_StateManagementEnabled_ShouldCallDeleteState() {
+    // Arrange
+    when(config.isTxStateManagementEnabled()).thenReturn(true);
+    transactionManager =
+        new ScalarTransactionManager(
+            manager, assetComposer, proofComposer, stateManager, namespaceResolver, config);
+
+    // Act
+    transactionManager.finish(NONCE);
+
+    // Assert
+    verify(stateManager).deleteState(NONCE);
+  }
+
+  @Test
+  public void finish_StateManagementDisabled_ShouldNotCallDeleteState() {
+    // Arrange
+    when(config.isTxStateManagementEnabled()).thenReturn(false);
+    transactionManager =
+        new ScalarTransactionManager(
+            manager, assetComposer, proofComposer, stateManager, namespaceResolver, config);
+
+    // Act
+    transactionManager.finish(NONCE);
+
+    // Assert
+    verify(stateManager, never()).deleteState(NONCE);
+  }
+
+  @Test
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void recover_AssetKeysGivenAndConsensusCommitManagerUsed_ShouldRecoverAssetIds() {
     // Arrange

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/TransactionStateManagerTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/TransactionStateManagerTest.java
@@ -3,12 +3,14 @@ package com.scalar.dl.ledger.database.scalardb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
@@ -19,6 +21,7 @@ import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.IntValue;
 import com.scalar.dl.ledger.database.TransactionState;
 import com.scalar.dl.ledger.exception.ConflictException;
+import com.scalar.dl.ledger.exception.DatabaseException;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -324,5 +327,42 @@ public class TransactionStateManagerTest {
     verify(transaction).abort();
     verify(transaction, never()).commit();
     assertThat(state).isEqualTo(TransactionState.UNKNOWN);
+  }
+
+  @Test
+  public void deleteState_TransactionIdGiven_ShouldDeleteAndCommit() throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    when(manager.start()).thenReturn(transaction);
+
+    // Act
+    stateManager.deleteState(SOME_TX_ID);
+
+    // Assert
+    verify(transaction).commit();
+    verify(transaction, never()).abort();
+    ArgumentCaptor<Delete> deleteCaptor = ArgumentCaptor.forClass(Delete.class);
+    verify(transaction).delete(deleteCaptor.capture());
+    Delete deleteCaptured = deleteCaptor.getValue();
+    assertThat(deleteCaptured.getPartitionKey().getColumns().getFirst().getTextValue())
+        .isEqualTo(SOME_TX_ID);
+  }
+
+  @Test
+  public void deleteState_TransactionExceptionThrown_ShouldAbortAndThrowDatabaseException()
+      throws TransactionException {
+    // Arrange
+    DistributedTransaction transaction = mock(DistributedTransaction.class);
+    when(manager.start()).thenReturn(transaction);
+    CrudException toThrow = mock(CrudException.class);
+    doThrow(toThrow).when(transaction).delete(any(Delete.class));
+
+    // Act
+    Throwable thrown = catchThrowable(() -> stateManager.deleteState(SOME_TX_ID));
+
+    // Assert
+    verify(transaction, never()).commit();
+    verify(transaction).abort();
+    assertThat(thrown).isExactlyInstanceOf(DatabaseException.class);
   }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/server/LedgerServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/server/LedgerServiceTest.java
@@ -3,6 +3,7 @@ package com.scalar.dl.ledger.server;
 import static com.scalar.dl.ledger.server.TypeConverter.convert;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,6 +22,7 @@ import com.scalar.dl.rpc.AssetProofRetrievalResponse;
 import com.scalar.dl.rpc.ContractExecutionRequest;
 import com.scalar.dl.rpc.ContractExecutionResponse;
 import com.scalar.dl.rpc.ContractRegistrationRequest;
+import com.scalar.dl.rpc.ExecutionFinishRequest;
 import com.scalar.dl.rpc.LedgerValidationRequest;
 import com.scalar.dl.rpc.LedgerValidationResponse;
 import io.grpc.stub.StreamObserver;
@@ -291,6 +293,50 @@ public class LedgerServiceTest {
     // Assert
     verify(validation).retrieve(convert(request));
     // Can't compare since StatusRuntimeException doesn't implement equals
+    verify(observer).onError(any());
+  }
+
+  @Test
+  public void finishExecution_ExecutionFinishRequestGiven_ShouldCallFinishAndOnCompleted() {
+    // Arrange
+    ExecutionFinishRequest request =
+        ExecutionFinishRequest.newBuilder()
+            .setNonce(SOME_NONCE)
+            .setEntityId(SOME_ENTITY_ID)
+            .setKeyVersion(SOME_KEY_VERSION)
+            .setSignature(ByteString.copyFrom(SOME_SIGNATURE))
+            .build();
+    doNothing().when(ledger).finish(convert(request));
+    StreamObserver<Empty> observer = mock(StreamObserver.class);
+
+    // Act
+    grpc.finishExecution(request, observer);
+
+    // Assert
+    verify(ledger).finish(convert(request));
+    verify(observer).onNext(any(Empty.class));
+    verify(observer).onCompleted();
+  }
+
+  @Test
+  public void finishExecution_LedgerExceptionThrown_ShouldCallOnError() {
+    // Arrange
+    ExecutionFinishRequest request =
+        ExecutionFinishRequest.newBuilder()
+            .setNonce(SOME_NONCE)
+            .setEntityId(SOME_ENTITY_ID)
+            .setKeyVersion(SOME_KEY_VERSION)
+            .setSignature(ByteString.copyFrom(SOME_SIGNATURE))
+            .build();
+    LedgerException toThrow = new LedgerException(SOME_MESSAGE, StatusCode.DATABASE_ERROR);
+    doThrow(toThrow).when(ledger).finish(convert(request));
+    StreamObserver<Empty> observer = mock(StreamObserver.class);
+
+    // Act
+    grpc.finishExecution(request, observer);
+
+    // Assert
+    verify(ledger).finish(convert(request));
     verify(observer).onError(any());
   }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/service/LedgerServiceTest.java
@@ -29,6 +29,7 @@ import com.scalar.dl.ledger.model.CertificateRegistrationRequest;
 import com.scalar.dl.ledger.model.ContractExecutionRequest;
 import com.scalar.dl.ledger.model.ContractRegistrationRequest;
 import com.scalar.dl.ledger.model.ContractsListingRequest;
+import com.scalar.dl.ledger.model.ExecutionFinishRequest;
 import com.scalar.dl.ledger.model.FunctionRegistrationRequest;
 import com.scalar.dl.ledger.model.NamespaceCreationRequest;
 import com.scalar.dl.ledger.model.NamespaceDroppingRequest;
@@ -537,5 +538,33 @@ public class LedgerServiceTest {
 
     // Assert
     verify(functionManager).register(anyString(), any(FunctionEntry.class));
+  }
+
+  @Test
+  public void finish_ProperRequestGiven_ShouldCallFinish() {
+    // Arrange
+    ExecutionFinishRequest request = mock(ExecutionFinishRequest.class);
+    when(request.getEntityId()).thenReturn(SOME_ENTITY_ID);
+    when(request.getKeyVersion()).thenReturn(SOME_KEY_VERSION);
+    when(request.getNonce()).thenReturn("some_nonce");
+    configureRequestValidation(request, true);
+
+    // Act
+    service.finish(request);
+
+    // Assert
+    verify(contractExecutor).finish("some_nonce");
+  }
+
+  @Test
+  public void finish_InvalidSignatureGiven_ShouldThrowSignatureException() {
+    // Arrange
+    ExecutionFinishRequest request = mock(ExecutionFinishRequest.class);
+    when(request.getEntityId()).thenReturn(SOME_ENTITY_ID);
+    when(request.getKeyVersion()).thenReturn(SOME_KEY_VERSION);
+    configureRequestValidation(request, false);
+
+    // Act & Assert
+    assertThatThrownBy(() -> service.finish(request)).isInstanceOf(SignatureException.class);
   }
 }

--- a/rpc/src/main/proto/scalar.proto
+++ b/rpc/src/main/proto/scalar.proto
@@ -25,6 +25,8 @@ service Ledger {
     }
     rpc AbortExecution (ExecutionAbortRequest) returns (ExecutionAbortResponse) {
     }
+    rpc FinishExecution (ExecutionFinishRequest) returns (google.protobuf.Empty) {
+    }
 }
 
 service LedgerPrivileged {
@@ -182,6 +184,13 @@ message AssetProofRetrievalRequest {
 }
 
 message ExecutionAbortRequest {
+    string nonce = 1;
+    string entity_id = 2;
+    uint32 key_version = 3;
+    bytes signature = 4;
+}
+
+message ExecutionFinishRequest {
     string nonce = 1;
     string entity_id = 2;
     uint32 key_version = 3;

--- a/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcTransactionTestBase.java
+++ b/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcTransactionTestBase.java
@@ -1,16 +1,68 @@
 package com.scalar.dl.testing.testcase;
 
+import static com.scalar.dl.testing.contract.Constants.AMOUNT_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.ASSETS_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.ASSET_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.CREATE_CONTRACT_ID3;
+import static com.scalar.dl.testing.contract.Constants.PAYMENT_CONTRACT_ID3;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.scalar.dl.client.exception.ClientException;
+import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.testing.config.TransactionMode;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base class for Ledger integration tests with JDBC transaction mode (tx_state_management=true).
+ *
+ * <p>In this mode, duplicate nonces are rejected at commit time with a conflict error.
  *
  * <p>Subclasses should override {@link #getAuthenticationMethod()}.
  */
 public abstract class LedgerJdbcTransactionTestBase extends LedgerOnlyIntegrationTestBase {
 
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Override
   protected TransactionMode getTransactionMode() {
     return TransactionMode.JDBC;
+  }
+
+  @Test
+  void executeContract_ContractWithDuplicateNonce_ShouldThrowClientExceptionWithConflict() {
+    // Arrange: Generate a nonce that will be reused
+    String duplicateNonce = java.util.UUID.randomUUID().toString();
+
+    // Create asset A with the nonce (using Jackson-based contract)
+    ObjectNode createArg1 = mapper.createObjectNode();
+    createArg1.put(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_1);
+    createArg1.put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1);
+    getClientServiceA().executeContract(duplicateNonce, CREATE_CONTRACT_ID3, createArg1);
+
+    // Create asset B with a different nonce
+    ObjectNode createArg2 = mapper.createObjectNode();
+    createArg2.put(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_2);
+    createArg2.put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1);
+    getClientServiceA().executeContract(CREATE_CONTRACT_ID3, createArg2);
+
+    // Act & Assert: Attempt to perform payment with the SAME nonce (duplicate)
+    // In JDBC transaction mode, this should fail with CONFLICT
+    ObjectNode paymentArg = mapper.createObjectNode();
+    paymentArg.putArray(ASSETS_ATTRIBUTE_NAME).add(SOME_ASSET_ID_1).add(SOME_ASSET_ID_2);
+    paymentArg.put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_2);
+
+    assertThatThrownBy(
+            () ->
+                getClientServiceA()
+                    .executeContract(duplicateNonce, PAYMENT_CONTRACT_ID3, paymentArg))
+        .isInstanceOfSatisfying(
+            ClientException.class,
+            e -> {
+              // CONFLICT status is expected when tx_state_management is enabled
+              assertThat(e.getStatusCode()).isEqualTo(StatusCode.CONFLICT);
+            });
   }
 }

--- a/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcTransactionTestBase.java
+++ b/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcTransactionTestBase.java
@@ -1,68 +1,16 @@
 package com.scalar.dl.testing.testcase;
 
-import static com.scalar.dl.testing.contract.Constants.AMOUNT_ATTRIBUTE_NAME;
-import static com.scalar.dl.testing.contract.Constants.ASSETS_ATTRIBUTE_NAME;
-import static com.scalar.dl.testing.contract.Constants.ASSET_ATTRIBUTE_NAME;
-import static com.scalar.dl.testing.contract.Constants.CREATE_CONTRACT_ID3;
-import static com.scalar.dl.testing.contract.Constants.PAYMENT_CONTRACT_ID3;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.scalar.dl.client.exception.ClientException;
-import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.testing.config.TransactionMode;
-import org.junit.jupiter.api.Test;
 
 /**
  * Base class for Ledger integration tests with JDBC transaction mode (tx_state_management=true).
- *
- * <p>In this mode, duplicate nonces are rejected at commit time with a conflict error.
  *
  * <p>Subclasses should override {@link #getAuthenticationMethod()}.
  */
 public abstract class LedgerJdbcTransactionTestBase extends LedgerOnlyIntegrationTestBase {
 
-  private static final ObjectMapper mapper = new ObjectMapper();
-
   @Override
   protected TransactionMode getTransactionMode() {
     return TransactionMode.JDBC;
-  }
-
-  @Test
-  void executeContract_ContractWithDuplicateNonce_ShouldThrowClientExceptionWithConflict() {
-    // Arrange: Generate a nonce that will be reused
-    String duplicateNonce = java.util.UUID.randomUUID().toString();
-
-    // Create asset A with the nonce (using Jackson-based contract)
-    ObjectNode createArg1 = mapper.createObjectNode();
-    createArg1.put(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_1);
-    createArg1.put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1);
-    getClientServiceA().executeContract(duplicateNonce, CREATE_CONTRACT_ID3, createArg1);
-
-    // Create asset B with a different nonce
-    ObjectNode createArg2 = mapper.createObjectNode();
-    createArg2.put(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_2);
-    createArg2.put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1);
-    getClientServiceA().executeContract(CREATE_CONTRACT_ID3, createArg2);
-
-    // Act & Assert: Attempt to perform payment with the SAME nonce (duplicate)
-    // In JDBC transaction mode, this should fail with CONFLICT
-    ObjectNode paymentArg = mapper.createObjectNode();
-    paymentArg.putArray(ASSETS_ATTRIBUTE_NAME).add(SOME_ASSET_ID_1).add(SOME_ASSET_ID_2);
-    paymentArg.put(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_2);
-
-    assertThatThrownBy(
-            () ->
-                getClientServiceA()
-                    .executeContract(duplicateNonce, PAYMENT_CONTRACT_ID3, paymentArg))
-        .isInstanceOfSatisfying(
-            ClientException.class,
-            e -> {
-              // CONFLICT status is expected when tx_state_management is enabled
-              assertThat(e.getStatusCode()).isEqualTo(StatusCode.CONFLICT);
-            });
   }
 }


### PR DESCRIPTION
## Description

This PR adds the `FinishExecution` RPC to the (non-privileged) `Ledger` service to delete the coordinator state or transaction state record after finishing a transaction. This RPC is intended to be called by the Auditor when the state record is no longer necessary for the Auditor. When `tx_state_management` is enabled, the corresponding state record is deleted; the `ScalarDB.finishTransaction` call itself is left as a TODO until ScalarDB PR [#3567](https://github.com/scalar-labs/scalardb/pull/3567) is merged.

This PR is part of a PR series for the coordinator state auto-deletion feature. The following PRs will be created later.

- Call finish execution from Auditor after successfully releasing locks in its validation phase (Enterprise side scalar-labs/scalardl-enterprise#1710)
- Add periodic (auto) transaction state purge for remaining transactions that might need lock recovery (both Core and Enterprise sides)
- Manual transaction state purge command (both Core and Enterprise sides)

## Related issues and/or PRs

- ScalarDB PR https://github.com/scalar-labs/scalardb/pull/3567 (provides `finishTransaction`, not yet merged)
- ScalarDL Enterprise PR scalar-labs/scalardl-enterprise#1710

## Changes made

- Add the `FinishExecution` RPC and `ExecutionFinishRequest` message to the proto.
- Wire `finish` through the gRPC handler, service (signature validation), executor, and transaction manager layers, and add `LedgerClient.finish()` for the Auditor.
- Delete the corresponding `tx_state` record via `TransactionStateManager.deleteState()` when TX State Management is enabled (the `ScalarDB.finishTransaction` call remains a TODO until #3567 is merged).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- The actual `ScalarDB.finishTransaction(transactionId)` call is left as a TODO until ScalarDB PR 3567 is merged. All ScalarDL layers (Proto → Server → Service → Executor → TransactionManager → Client) are complete; only the ScalarDB call needs to be connected afterwards.
- Integration tests are intended to be covered on the Auditor (Enterprise) side, since `FinishExecution` is issued from the Auditor. This PR adds unit tests only.

## Release notes

Added the `FinishExecution` RPC to the Ledger service for cleaning up the state of a finished transaction.