### PR TITLE
Add permissions for ScalarDB on JDBC databases to the contract ProtectionDomain

### DIFF
--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerModule.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerModule.java
@@ -51,6 +51,7 @@ import java.net.SocketPermission;
 import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.security.ProtectionDomain;
+import java.sql.SQLPermission;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.PropertyPermission;
@@ -200,6 +201,15 @@ public class LedgerModule extends AbstractModule {
     // (null, null) means that it denies all if java.security.manager is enabled
     PermissionCollection permissionCollection = new Permissions();
     permissionCollection.add(new RuntimePermission("createClassLoader"));
+    // For ScalarDB on JDBC databases
+    if (databaseConfig.getStorage().toLowerCase(Locale.ROOT).equals("jdbc")) {
+      permissionCollection.add(new SocketPermission("*", "connect,resolve"));
+      // The PostgreSQL JDBC driver reads this property to decide SOCKS proxy resolution.
+      permissionCollection.add(new PropertyPermission("socksProxyHost", "read"));
+      // HikariCP calls these methods when validating/closing connections.
+      permissionCollection.add(new SQLPermission("setNetworkTimeout"));
+      permissionCollection.add(new SQLPermission("callAbort"));
+    }
     // For ScalarDB on Cosmos DB
     permissionCollection.add(new RuntimePermission("getenv.*"));
     permissionCollection.add(new PropertyPermission("log4j2.flowMessageFactory", "read"));


### PR DESCRIPTION
## Description

When the SecurityManager is enabled, contracts are executed in a restricted `ProtectionDomain` defined in `LedgerModule.getProtectionDomain()`. This domain only granted the permissions required by the Cosmos DB, DynamoDB, and Cloud Storage backends, but had no entry for JDBC databases.

After upgrading ScalarDB, connecting to a JDBC database (e.g., PostgreSQL, MySQL) from within a contract fails with `AccessControlException` because the JDBC driver and HikariCP need additional permissions that were never granted. This PR adds the missing permissions for the `jdbc` storage so that ScalarDL on JDBC databases works under the SecurityManager.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made

- Add a `jdbc` branch to `getProtectionDomain()` that grants `SocketPermission` (connect/resolve), the `socksProxyHost` read property used by the PostgreSQL JDBC driver, and the `setNetworkTimeout` / `callAbort` `SQLPermission`s used by HikariCP.
- Place the JDBC block above the Cosmos DB settings for readability.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The exact set of required permissions can differ per JDBC driver. For example, the PostgreSQL driver (pgjdbc) reads the `socksProxyHost` system property and enforces the `setNetworkTimeout` `SQLPermission`, whereas the MariaDB Connector/J driver (used for MySQL since ScalarDB 3.18) does not perform the `SQLPermission` check and only requires `SocketPermission` when a new physical connection is opened. The current set covers the common TCP-socket RDBMS paths (MySQL/MariaDB, PostgreSQL, YugabyteDB, TiDB, and the basic connect path of SQL Server/Db2/Oracle), but it may not be exhaustive for every driver (e.g., SQLite native-library extraction, Oracle wallet/tnsnames, Kerberos).

How to verify the required permissions per database under the SecurityManager is still under consideration. We plan to run each supported JDBC backend with the SecurityManager enabled and collect any remaining `AccessControlException`s to finalize the permission set.

## Release notes

Fixed an issue where contracts could not access a JDBC database (e.g., PostgreSQL) when the SecurityManager was enabled.