### PR TITLE
Add lease primitive

### DIFF
--- a/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
+++ b/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
@@ -427,6 +427,30 @@ public enum CommonError implements ScalarDlError {
       "Dropping the namespace failed. Details: %s",
       "",
       "Check the database connection and ensure the database is accessible. Review the error details for more information."),
+  READING_LEASE_FAILED(
+      StatusCode.DATABASE_ERROR,
+      "014",
+      "Reading the lease failed. Details: %s",
+      "",
+      "Check the database connection and ensure the database is accessible. Review the error details for more information."),
+  ACQUIRING_OR_RENEWING_LEASE_FAILED(
+      StatusCode.DATABASE_ERROR,
+      "015",
+      "Acquiring or renewing the lease failed. Details: %s",
+      "",
+      "Check the database connection and ensure the database is accessible. Review the error details for more information."),
+  CREATING_LEASE_TABLE_FAILED(
+      StatusCode.DATABASE_ERROR,
+      "016",
+      "Creating the lease table failed. Details: %s",
+      "",
+      "Check the database connection and ensure the database is accessible. Review the error details for more information."),
+  LEASE_TABLE_NOT_FOUND(
+      StatusCode.DATABASE_ERROR,
+      "017",
+      "The lease table does not exist.",
+      "",
+      "Create the lease table by running the schema loader. It is also created automatically on the next coordination round if the database user has permission to create tables."),
 
   //
   // Errors for RUNTIME_ERROR(502)

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseIntegrationTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseIntegrationTest.java
@@ -108,8 +108,7 @@ public class ScalarLeaseIntegrationTest {
   @Test
   public void tryAcquireOrRenew_WhenAbsent_ShouldLetExactlyOneHolderAcquire() {
     // The first holder acquires the absent lease; a second holder's PutIfNotExists must fail
-    // because
-    // the record now exists. This proves the acquire is a real compare-and-swap.
+    // because the record now exists. This proves the acquire is a real compare-and-swap.
     assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_A, 1000L)).isTrue();
     assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_B, 1000L)).isFalse();
 

--- a/ledger/src/integration-test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseIntegrationTest.java
+++ b/ledger/src/integration-test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseIntegrationTest.java
@@ -1,0 +1,189 @@
+package com.scalar.dl.ledger.lease.scalardb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.dl.ledger.config.LedgerConfig;
+import com.scalar.dl.ledger.database.scalardb.ScalarNamespaceResolver;
+import com.scalar.dl.ledger.lease.LeaseEntry;
+import com.scalar.dl.ledger.lease.LeaseTableNotFoundException;
+import com.scalar.dl.ledger.namespace.Namespaces;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Integration test for {@link ScalarLease} against a real storage backend. Unit tests exercise the
+ * conditional-mutation logic with a mocked storage; this test proves the compare-and-swap semantics
+ * that only a real linearizable backend can validate:
+ *
+ * <ul>
+ *   <li>an absent lease can be acquired by exactly one holder ({@code PutIfNotExists});
+ *   <li>a renew/takeover succeeds only when the observed holder AND expiry still match ({@code
+ *       PutIf}), so a stale observation cannot resurrect a lease that was already taken over.
+ * </ul>
+ *
+ * <p>Storage connection settings come from {@code scalardb.*} system properties (default: Cassandra
+ * on localhost), matching the other ledger integration tests.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ScalarLeaseIntegrationTest {
+  private static final String PROP_STORAGE = "scalardb.storage";
+  private static final String PROP_CONTACT_POINTS = "scalardb.contact_points";
+  private static final String PROP_USERNAME = "scalardb.username";
+  private static final String PROP_PASSWORD = "scalardb.password";
+  private static final String DEFAULT_STORAGE = "cassandra";
+  private static final String DEFAULT_CONTACT_POINTS = "localhost";
+  private static final String DEFAULT_USERNAME = "cassandra";
+  private static final String DEFAULT_PASSWORD = "cassandra";
+
+  private static final String NAMESPACE = "lease_it";
+  private static final String LEASE = "test_lease";
+  private static final String HOLDER_A = "auditor/A";
+  private static final String HOLDER_B = "auditor/B";
+
+  private Properties props;
+  private DistributedStorage storage;
+  private DistributedStorageAdmin storageAdmin;
+  private ScalarNamespaceResolver resolver;
+  private ScalarLease lease;
+  private String physicalNamespace;
+
+  @BeforeAll
+  public void setUpBeforeClass() throws Exception {
+    props = createProperties();
+    StorageFactory factory = StorageFactory.create(props);
+    storage = factory.getStorage();
+    storageAdmin = factory.getStorageAdmin();
+    resolver = new ScalarNamespaceResolver(new LedgerConfig(props));
+    physicalNamespace = resolver.resolve(Namespaces.DEFAULT);
+    lease = new ScalarLease(storage, storageAdmin, resolver);
+
+    storageAdmin.createNamespace(physicalNamespace, true);
+    lease.createTable();
+  }
+
+  @AfterAll
+  public void tearDownAfterClass() throws Exception {
+    if (storageAdmin != null) {
+      storageAdmin.dropTable(physicalNamespace, ScalarLease.TABLE, true);
+      storageAdmin.dropNamespace(physicalNamespace, true);
+      storageAdmin.close();
+    }
+    if (storage != null) {
+      storage.close();
+    }
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    // Reset the single lease record between tests.
+    storageAdmin.truncateTable(physicalNamespace, ScalarLease.TABLE);
+  }
+
+  private Properties createProperties() {
+    Properties props = new Properties();
+    props.put(LedgerConfig.NAMESPACE, NAMESPACE);
+    props.put(DatabaseConfig.STORAGE, System.getProperty(PROP_STORAGE, DEFAULT_STORAGE));
+    props.put(
+        DatabaseConfig.CONTACT_POINTS,
+        System.getProperty(PROP_CONTACT_POINTS, DEFAULT_CONTACT_POINTS));
+    props.put(DatabaseConfig.USERNAME, System.getProperty(PROP_USERNAME, DEFAULT_USERNAME));
+    props.put(DatabaseConfig.PASSWORD, System.getProperty(PROP_PASSWORD, DEFAULT_PASSWORD));
+    return props;
+  }
+
+  @Test
+  public void get_WhenLeaseNeverAcquired_ShouldReturnEmpty() {
+    assertThat(lease.get(LEASE)).isEmpty();
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenAbsent_ShouldLetExactlyOneHolderAcquire() {
+    // The first holder acquires the absent lease; a second holder's PutIfNotExists must fail
+    // because
+    // the record now exists. This proves the acquire is a real compare-and-swap.
+    assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_A, 1000L)).isTrue();
+    assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_B, 1000L)).isFalse();
+
+    LeaseEntry entry = lease.get(LEASE).orElseThrow(AssertionError::new);
+    assertThat(entry.getHolder()).isEqualTo(HOLDER_A);
+    assertThat(entry.getExpiry()).isEqualTo(1000L);
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenHolderRenewsWithMatchingObserved_ShouldSucceed() {
+    assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_A, 1000L)).isTrue();
+    LeaseEntry observed = lease.get(LEASE).orElseThrow(AssertionError::new);
+
+    assertThat(lease.tryAcquireOrRenew(LEASE, observed, HOLDER_A, 2000L)).isTrue();
+
+    assertThat(lease.get(LEASE).orElseThrow(AssertionError::new).getExpiry()).isEqualTo(2000L);
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenRenewingWithStaleObserved_ShouldFail() {
+    assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_A, 1000L)).isTrue();
+    LeaseEntry stale = lease.get(LEASE).orElseThrow(AssertionError::new);
+
+    // Renew once so the stored expiry moves from 1000 to 2000.
+    assertThat(lease.tryAcquireOrRenew(LEASE, stale, HOLDER_A, 2000L)).isTrue();
+
+    // A second attempt conditioned on the now-stale observation (expiry 1000) must fail: the
+    // compare-and-swap on expiry prevents resurrecting a superseded lease.
+    assertThat(lease.tryAcquireOrRenew(LEASE, stale, HOLDER_A, 3000L)).isFalse();
+    assertThat(lease.get(LEASE).orElseThrow(AssertionError::new).getExpiry()).isEqualTo(2000L);
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenTakingOverExpiredLease_ShouldSucceedAndBlockStaleOwner() {
+    assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_A, 1000L)).isTrue();
+    LeaseEntry observedByBoth = lease.get(LEASE).orElseThrow(AssertionError::new);
+
+    // Failover: B observes the (expired) lease and takes it over.
+    assertThat(lease.tryAcquireOrRenew(LEASE, observedByBoth, HOLDER_B, 5000L)).isTrue();
+    assertThat(lease.get(LEASE).orElseThrow(AssertionError::new).getHolder()).isEqualTo(HOLDER_B);
+
+    // The old holder, still holding its stale observation, cannot reclaim the lease.
+    assertThat(lease.tryAcquireOrRenew(LEASE, observedByBoth, HOLDER_A, 6000L)).isFalse();
+  }
+
+  @Test
+  public void createTable_WhenAlreadyExists_ShouldBeIdempotent() {
+    assertThat(lease.get(LEASE)).isEmpty();
+    // The table was created in setUp; calling again must be a no-op (ifNotExists), and the lease is
+    // still usable afterwards.
+    lease.createTable();
+    assertThat(lease.tryAcquireOrRenew(LEASE, null, HOLDER_A, 1000L)).isTrue();
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  public void get_WhenTableDropped_ShouldThrowLeaseTableNotFoundException() throws Exception {
+    storageAdmin.dropTable(physicalNamespace, ScalarLease.TABLE, true);
+
+    // Read through a fresh storage instance with no cached table metadata, so the drop is observed
+    // as a genuinely missing table (a warm storage cache would instead surface a lower-level
+    // error).
+    StorageFactory freshFactory = StorageFactory.create(props);
+    DistributedStorage freshStorage = freshFactory.getStorage();
+    DistributedStorageAdmin freshStorageAdmin = freshFactory.getStorageAdmin();
+    try {
+      ScalarLease freshLease = new ScalarLease(freshStorage, freshStorageAdmin, resolver);
+      assertThatThrownBy(() -> freshLease.get(LEASE))
+          .isInstanceOf(LeaseTableNotFoundException.class);
+    } finally {
+      // Restore the table for the remaining tests / teardown.
+      lease.createTable();
+      freshStorage.close();
+      freshStorageAdmin.close();
+    }
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/Lease.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/Lease.java
@@ -1,0 +1,67 @@
+package com.scalar.dl.ledger.lease;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * A generic, storage-agnostic lease for leader election and best-effort coordination among multiple
+ * nodes. A lease is a single named record holding the current holder and an expiration time;
+ * acquiring, renewing, and failing over are all expressed as a conditional compare-and-swap on that
+ * record ({@link #tryAcquireOrRenew}). Independent {@code leaseName}s are independent leases that
+ * live in one shared lease table.
+ *
+ * <p><b>This lease does NOT provide mutual exclusion.</b> Under a holder's GC pause or clock skew,
+ * more than one node may briefly believe it is the holder (this is inherent to a fencing-token-free
+ * lease). Therefore any work performed while holding the lease MUST be idempotent and crash-safe.
+ * Using a lease to guard non-idempotent work can cause silent data corruption; such use cases need
+ * a fencing token (a monotonic version enforced by the downstream resource) in addition to this
+ * lease.
+ *
+ * <p>Implementations back this with concrete storage (e.g. ScalarDB); the interface itself is free
+ * of any storage-specific type so that callers stay decoupled from the backend.
+ */
+public interface Lease {
+
+  /**
+   * Reads the current state of the named lease.
+   *
+   * @param leaseName the lease name; different names are independent leases
+   * @return the current lease record, or empty if it has never been acquired
+   * @throws LeaseTableNotFoundException if the backing lease table does not exist
+   * @throws LeaseException if the read fails due to an infrastructure error
+   */
+  Optional<LeaseEntry> get(String leaseName);
+
+  /**
+   * Atomically acquires or renews the named lease via a conditional compare-and-swap.
+   *
+   * <ul>
+   *   <li>When {@code observed} is null, this attempts to acquire an absent lease (succeeds only if
+   *       the record still does not exist).
+   *   <li>When {@code observed} is non-null, this attempts to renew or take over the lease
+   *       (succeeds only if the record still matches {@code observed}'s holder and expiry).
+   *       Comparing on the observed expiry, not just the holder, prevents a node from resurrecting
+   *       a lease it already lost during a pause.
+   * </ul>
+   *
+   * @param leaseName the lease name
+   * @param observed the lease state this attempt is conditioned on, or null to acquire an absent
+   *     lease
+   * @param holder the identifier of this node
+   * @param expiry the new expiration time in epoch milliseconds
+   * @return true if this node now holds the lease; false if the compare-and-swap lost (another node
+   *     holds or changed it)
+   * @throws LeaseException if the write fails due to an infrastructure error
+   */
+  boolean tryAcquireOrRenew(
+      String leaseName, @Nullable LeaseEntry observed, String holder, long expiry);
+
+  /**
+   * Ensures the backing lease table exists, creating it if absent (idempotent). Intended to be
+   * called lazily on a {@link LeaseTableNotFoundException} so that an upgraded deployment
+   * provisions the table without a separate schema-loader run.
+   *
+   * @throws LeaseException if the creation fails due to an infrastructure error
+   */
+  void createTable();
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/Lease.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/Lease.java
@@ -51,6 +51,8 @@ public interface Lease {
    * @param expiry the new expiration time in epoch milliseconds
    * @return true if this node now holds the lease; false if the compare-and-swap lost (another node
    *     holds or changed it)
+   * @throws LeaseTableNotFoundException if the backing lease table does not exist (e.g. when a
+   *     caller acquires without a preceding {@link #get})
    * @throws LeaseException if the write fails due to an infrastructure error
    */
   boolean tryAcquireOrRenew(

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/LeaseEntry.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/LeaseEntry.java
@@ -1,0 +1,57 @@
+package com.scalar.dl.ledger.lease;
+
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A snapshot of a lease record: which node currently holds it and when it expires. Storage
+ * agnostic; it carries no ScalarDB types so that {@link Lease} stays decoupled from the underlying
+ * storage.
+ */
+@Immutable
+public class LeaseEntry {
+  private final String holder;
+  private final long expiry;
+
+  /**
+   * Constructs a lease snapshot.
+   *
+   * @param holder the identifier of the node holding the lease
+   * @param expiry the expiration time in epoch milliseconds
+   */
+  public LeaseEntry(String holder, long expiry) {
+    this.holder = holder;
+    this.expiry = expiry;
+  }
+
+  public String getHolder() {
+    return holder;
+  }
+
+  /** Returns the expiration time in epoch milliseconds. */
+  public long getExpiry() {
+    return expiry;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LeaseEntry)) {
+      return false;
+    }
+    LeaseEntry that = (LeaseEntry) o;
+    return expiry == that.expiry && Objects.equals(holder, that.holder);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(holder, expiry);
+  }
+
+  @Override
+  public String toString() {
+    return "LeaseEntry{holder=" + holder + ", expiry=" + expiry + '}';
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/LeaseException.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/LeaseException.java
@@ -1,0 +1,24 @@
+package com.scalar.dl.ledger.lease;
+
+import com.scalar.dl.ledger.error.ScalarDlError;
+import com.scalar.dl.ledger.exception.LedgerException;
+
+/**
+ * Thrown when a lease operation fails due to an infrastructure error (e.g. the underlying storage
+ * is unreachable). Callers that use a lease for best-effort coordination typically log this and
+ * skip the current round rather than failing hard. This is distinct from a lost compare-and-swap,
+ * which {@link Lease#tryAcquireOrRenew} reports by returning {@code false} rather than throwing.
+ *
+ * <p>It extends {@link LedgerException} so that, like the other ScalarDL exceptions, it carries a
+ * {@link com.scalar.dl.ledger.service.StatusCode} that identifies the failure in logs.
+ */
+public class LeaseException extends LedgerException {
+
+  public LeaseException(ScalarDlError error, Object... args) {
+    super(error, args);
+  }
+
+  public LeaseException(ScalarDlError error, Throwable cause, Object... args) {
+    super(error, cause, args);
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/LeaseTableNotFoundException.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/LeaseTableNotFoundException.java
@@ -1,0 +1,15 @@
+package com.scalar.dl.ledger.lease;
+
+import com.scalar.dl.ledger.error.ScalarDlError;
+
+/**
+ * Thrown by {@link Lease#get} when the backing lease table does not exist. Callers may react by
+ * calling {@link Lease#createTable} once and retrying (reactive lazy provisioning), so that an
+ * upgraded deployment does not have to re-run the schema loader before the lease can be used.
+ */
+public class LeaseTableNotFoundException extends LeaseException {
+
+  public LeaseTableNotFoundException(ScalarDlError error, Throwable cause, Object... args) {
+    super(error, cause, args);
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/scalardb/ScalarLease.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/scalardb/ScalarLease.java
@@ -71,7 +71,7 @@ public class ScalarLease implements Lease {
     this.storage = checkNotNull(storage);
     this.storageAdmin = checkNotNull(storageAdmin);
     // The lease is a single global table in the default (base) namespace.
-    this.namespace = namespaceResolver.resolve(Namespaces.DEFAULT);
+    this.namespace = checkNotNull(namespaceResolver).resolve(Namespaces.DEFAULT);
   }
 
   @Override
@@ -134,6 +134,14 @@ public class ScalarLease implements Lease {
       // The compare-and-swap lost: another node holds or changed the lease. Expected during
       // failover contention; not an error.
       return false;
+    } catch (IllegalArgumentException e) {
+      // Mirror get(): surface a missing table as LeaseTableNotFoundException so an acquire-first
+      // caller can provision the table and retry, rather than leaking a raw storage exception.
+      if (e.getMessage() != null
+          && e.getMessage().startsWith(CoreError.TABLE_NOT_FOUND.buildCode())) {
+        throw new LeaseTableNotFoundException(CommonError.LEASE_TABLE_NOT_FOUND, e);
+      }
+      throw e;
     } catch (ExecutionException e) {
       throw new LeaseException(CommonError.ACQUIRING_OR_RENEWING_LEASE_FAILED, e, e.getMessage());
     }

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/scalardb/ScalarLease.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/scalardb/ScalarLease.java
@@ -1,0 +1,154 @@
+package com.scalar.dl.ledger.lease.scalardb;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.inject.Inject;
+import com.scalar.db.api.ConditionBuilder;
+import com.scalar.db.api.Consistency;
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.MutationCondition;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.TableMetadata;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.db.io.DataType;
+import com.scalar.db.io.Key;
+import com.scalar.dl.ledger.database.scalardb.ScalarNamespaceResolver;
+import com.scalar.dl.ledger.error.CommonError;
+import com.scalar.dl.ledger.lease.Lease;
+import com.scalar.dl.ledger.lease.LeaseEntry;
+import com.scalar.dl.ledger.lease.LeaseException;
+import com.scalar.dl.ledger.lease.LeaseTableNotFoundException;
+import com.scalar.dl.ledger.namespace.Namespaces;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link Lease} backed by ScalarDB's Storage API. Acquire/renew/failover are a single conditional
+ * mutation ({@code PutIfNotExists} for an absent lease, {@code PutIf} on the observed holder and
+ * expiry otherwise), which the storage layer evaluates as a linearizable compare-and-swap. The
+ * Storage API is used deliberately instead of Consensus Commit: it is lighter for a single-record
+ * CAS, and the Auditor does not use Consensus Commit at all.
+ *
+ * <p>The lease is a single global table living in the default (base) namespace, so no namespace is
+ * taken per call; different {@code leaseName}s share that one table.
+ */
+@ThreadSafe
+public class ScalarLease implements Lease {
+  static final String TABLE = "lease";
+  static final String LEASE_NAME = "lease_name";
+  static final String HOLDER = "holder";
+  static final String EXPIRY = "expiry";
+
+  // This schema is mirrored in schema-loader/auditor-schema.json (the "auditor.lease" entry), which
+  // provisions the table for new installs. Keep the two in sync: the reactive createTable() below
+  // uses this definition, so a drift would create a different table depending on the provisioning
+  // path.
+  private static final TableMetadata TABLE_METADATA =
+      TableMetadata.newBuilder()
+          .addColumn(LEASE_NAME, DataType.TEXT)
+          .addColumn(HOLDER, DataType.TEXT)
+          .addColumn(EXPIRY, DataType.BIGINT)
+          .addPartitionKey(LEASE_NAME)
+          .build();
+
+  private final DistributedStorage storage;
+  private final DistributedStorageAdmin storageAdmin;
+  private final String namespace;
+
+  @Inject
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public ScalarLease(
+      DistributedStorage storage,
+      DistributedStorageAdmin storageAdmin,
+      ScalarNamespaceResolver namespaceResolver) {
+    this.storage = checkNotNull(storage);
+    this.storageAdmin = checkNotNull(storageAdmin);
+    // The lease is a single global table in the default (base) namespace.
+    this.namespace = namespaceResolver.resolve(Namespaces.DEFAULT);
+  }
+
+  @Override
+  public Optional<LeaseEntry> get(String leaseName) {
+    Get get =
+        Get.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(LEASE_NAME, leaseName))
+            .consistency(Consistency.SEQUENTIAL)
+            .build();
+
+    try {
+      return storage.get(get).map(this::toLeaseEntry);
+    } catch (IllegalArgumentException e) {
+      if (e.getMessage() != null
+          && e.getMessage().startsWith(CoreError.TABLE_NOT_FOUND.buildCode())) {
+        throw new LeaseTableNotFoundException(CommonError.LEASE_TABLE_NOT_FOUND, e);
+      }
+      throw e;
+    } catch (ExecutionException e) {
+      throw new LeaseException(CommonError.READING_LEASE_FAILED, e, e.getMessage());
+    }
+  }
+
+  @Override
+  public boolean tryAcquireOrRenew(
+      String leaseName, @Nullable LeaseEntry observed, String holder, long expiry) {
+    MutationCondition condition;
+    if (observed == null) {
+      // Acquire an absent lease: succeeds only if no node has created it yet.
+      condition = ConditionBuilder.putIfNotExists();
+    } else {
+      // Renew or take over: succeeds only if the record still matches what we observed. Comparing
+      // on
+      // the observed expiry (not just the holder) prevents resurrecting a lease we already lost
+      // during a pause -- a blind holder-only update would silently overwrite a new holder.
+      condition =
+          ConditionBuilder.putIf(
+                  ConditionBuilder.column(HOLDER).isEqualToText(observed.getHolder()))
+              .and(ConditionBuilder.column(EXPIRY).isEqualToBigInt(observed.getExpiry()))
+              .build();
+    }
+
+    Put put =
+        Put.newBuilder()
+            .namespace(namespace)
+            .table(TABLE)
+            .partitionKey(Key.ofText(LEASE_NAME, leaseName))
+            .textValue(HOLDER, holder)
+            .bigIntValue(EXPIRY, expiry)
+            .consistency(Consistency.LINEARIZABLE)
+            .condition(condition)
+            .build();
+
+    try {
+      storage.put(put);
+      return true;
+    } catch (NoMutationException e) {
+      // The compare-and-swap lost: another node holds or changed the lease. Expected during
+      // failover contention; not an error.
+      return false;
+    } catch (ExecutionException e) {
+      throw new LeaseException(CommonError.ACQUIRING_OR_RENEWING_LEASE_FAILED, e, e.getMessage());
+    }
+  }
+
+  @Override
+  public void createTable() {
+    try {
+      storageAdmin.createTable(namespace, TABLE, TABLE_METADATA, true);
+    } catch (ExecutionException e) {
+      throw new LeaseException(CommonError.CREATING_LEASE_TABLE_FAILED, e, e.getMessage());
+    }
+  }
+
+  private LeaseEntry toLeaseEntry(Result result) {
+    return new LeaseEntry(result.getText(HOLDER), result.getBigInt(EXPIRY));
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/lease/scalardb/ScalarLease.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/lease/scalardb/ScalarLease.java
@@ -105,10 +105,10 @@ public class ScalarLease implements Lease {
       // Acquire an absent lease: succeeds only if no node has created it yet.
       condition = ConditionBuilder.putIfNotExists();
     } else {
-      // Renew or take over: succeeds only if the record still matches what we observed. Comparing
-      // on
-      // the observed expiry (not just the holder) prevents resurrecting a lease we already lost
-      // during a pause -- a blind holder-only update would silently overwrite a new holder.
+      // Renew or take over: the CAS succeeds only if the record still matches the holder and the
+      // expiry we observed. Conditioning on the expiry (not just the holder) prevents resurrecting
+      // a lease we already lost during a pause, where a holder-only check would silently overwrite
+      // the new holder.
       condition =
           ConditionBuilder.putIf(
                   ConditionBuilder.column(HOLDER).isEqualToText(observed.getHolder()))

--- a/ledger/src/test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseTest.java
@@ -1,0 +1,173 @@
+package com.scalar.dl.ledger.lease.scalardb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedStorageAdmin;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.PutIf;
+import com.scalar.db.api.PutIfNotExists;
+import com.scalar.db.api.Result;
+import com.scalar.db.common.CoreError;
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.storage.NoMutationException;
+import com.scalar.dl.ledger.database.scalardb.ScalarNamespaceResolver;
+import com.scalar.dl.ledger.lease.LeaseEntry;
+import com.scalar.dl.ledger.lease.LeaseException;
+import com.scalar.dl.ledger.lease.LeaseTableNotFoundException;
+import com.scalar.dl.ledger.namespace.Namespaces;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ScalarLeaseTest {
+  private static final String RESOLVED_NAMESPACE = "resolved_namespace";
+  private static final String ANY_LEASE_NAME = "transaction_state_purge";
+  private static final String ANY_HOLDER = "auditor/uuid-A";
+  private static final long ANY_EXPIRY = 1000L;
+
+  @Mock private DistributedStorage storage;
+  @Mock private DistributedStorageAdmin storageAdmin;
+  @Mock private ScalarNamespaceResolver namespaceResolver;
+  private ScalarLease lease;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    // The lease lives in the default (base) namespace; ScalarLease resolves it once at
+    // construction.
+    when(namespaceResolver.resolve(Namespaces.DEFAULT)).thenReturn(RESOLVED_NAMESPACE);
+    lease = new ScalarLease(storage, storageAdmin, namespaceResolver);
+  }
+
+  private Result mockResult(String holder, long expiry) {
+    Result result = mock(Result.class);
+    when(result.getText(ScalarLease.HOLDER)).thenReturn(holder);
+    when(result.getBigInt(ScalarLease.EXPIRY)).thenReturn(expiry);
+    return result;
+  }
+
+  @Test
+  public void get_WhenRecordDoesNotExist_ShouldReturnEmpty() throws Exception {
+    when(storage.get(any())).thenReturn(Optional.empty());
+
+    assertThat(lease.get(ANY_LEASE_NAME)).isEmpty();
+  }
+
+  @Test
+  public void get_WhenRecordExists_ShouldReturnLeaseEntry() throws Exception {
+    // Build the Result mock before stubbing storage.get to avoid a nested when(...) call.
+    Result result = mockResult(ANY_HOLDER, ANY_EXPIRY);
+    when(storage.get(any())).thenReturn(Optional.of(result));
+
+    Optional<LeaseEntry> entry = lease.get(ANY_LEASE_NAME);
+
+    assertThat(entry).isPresent();
+    assertThat(entry.get().getHolder()).isEqualTo(ANY_HOLDER);
+    assertThat(entry.get().getExpiry()).isEqualTo(ANY_EXPIRY);
+  }
+
+  @Test
+  public void get_WhenTableDoesNotExist_ShouldThrowLeaseTableNotFoundException() throws Exception {
+    when(storage.get(any()))
+        .thenThrow(
+            new IllegalArgumentException(
+                CoreError.TABLE_NOT_FOUND.buildCode() + " the table is missing"));
+
+    assertThatThrownBy(() -> lease.get(ANY_LEASE_NAME))
+        .isInstanceOf(LeaseTableNotFoundException.class);
+  }
+
+  @Test
+  public void get_WhenExecutionExceptionThrown_ShouldThrowLeaseException() throws Exception {
+    when(storage.get(any())).thenThrow(new ExecutionException("storage down"));
+
+    assertThatThrownBy(() -> lease.get(ANY_LEASE_NAME)).isInstanceOf(LeaseException.class);
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenObservedIsNull_ShouldUsePutIfNotExistsAndReturnTrue()
+      throws Exception {
+    boolean result = lease.tryAcquireOrRenew(ANY_LEASE_NAME, null, ANY_HOLDER, ANY_EXPIRY);
+
+    assertThat(result).isTrue();
+    ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+    verify(storage).put(captor.capture());
+    assertThat(captor.getValue().getCondition()).get().isInstanceOf(PutIfNotExists.class);
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenObservedIsPresent_ShouldUsePutIfOnHolderAndExpiry()
+      throws Exception {
+    LeaseEntry observed = new LeaseEntry(ANY_HOLDER, ANY_EXPIRY);
+
+    boolean result =
+        lease.tryAcquireOrRenew(ANY_LEASE_NAME, observed, ANY_HOLDER, ANY_EXPIRY + 3000L);
+
+    assertThat(result).isTrue();
+    ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+    verify(storage).put(captor.capture());
+    assertThat(captor.getValue().getCondition()).get().isInstanceOf(PutIf.class);
+    PutIf condition = (PutIf) captor.getValue().getCondition().get();
+    // Conditioned on both the observed holder and the observed expiry (compare-and-swap on expiry
+    // prevents resurrecting a lost lease).
+    assertThat(condition.getExpressions()).hasSize(2);
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenNoMutationExceptionThrown_ShouldReturnFalse() throws Exception {
+    doThrow(new NoMutationException("cas lost", Collections.emptyList()))
+        .when(storage)
+        .put(any(Put.class));
+
+    boolean result = lease.tryAcquireOrRenew(ANY_LEASE_NAME, null, ANY_HOLDER, ANY_EXPIRY);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void tryAcquireOrRenew_WhenExecutionExceptionThrown_ShouldThrowLeaseException()
+      throws Exception {
+    doThrow(new ExecutionException("storage down")).when(storage).put(any(Put.class));
+
+    assertThatThrownBy(() -> lease.tryAcquireOrRenew(ANY_LEASE_NAME, null, ANY_HOLDER, ANY_EXPIRY))
+        .isInstanceOf(LeaseException.class);
+  }
+
+  @Test
+  public void createTable_ShouldCreateLeaseTableWithIfNotExists() throws Exception {
+    lease.createTable();
+
+    verify(storageAdmin)
+        .createTable(eq(RESOLVED_NAMESPACE), eq(ScalarLease.TABLE), any(), eq(true));
+  }
+
+  @Test
+  public void createTable_WhenExecutionExceptionThrown_ShouldThrowLeaseException()
+      throws Exception {
+    doThrow(new ExecutionException("cannot create"))
+        .when(storageAdmin)
+        .createTable(any(), any(), any(), eq(true));
+
+    assertThatThrownBy(() -> lease.createTable()).isInstanceOf(LeaseException.class);
+  }
+
+  @Test
+  public void get_WhenNonTableNotFoundIllegalArgument_ShouldPropagate() throws Exception {
+    when(storage.get(any())).thenThrow(new IllegalArgumentException("some other problem"));
+
+    assertThatThrownBy(() -> lease.get(ANY_LEASE_NAME))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/ledger/src/test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/lease/scalardb/ScalarLeaseTest.java
@@ -146,6 +146,19 @@ public class ScalarLeaseTest {
   }
 
   @Test
+  public void tryAcquireOrRenew_WhenTableDoesNotExist_ShouldThrowLeaseTableNotFoundException()
+      throws Exception {
+    doThrow(
+            new IllegalArgumentException(
+                CoreError.TABLE_NOT_FOUND.buildCode() + " the table is missing"))
+        .when(storage)
+        .put(any(Put.class));
+
+    assertThatThrownBy(() -> lease.tryAcquireOrRenew(ANY_LEASE_NAME, null, ANY_HOLDER, ANY_EXPIRY))
+        .isInstanceOf(LeaseTableNotFoundException.class);
+  }
+
+  @Test
   public void createTable_ShouldCreateLeaseTableWithIfNotExists() throws Exception {
     lease.createTable();
 

--- a/schema-loader/auditor-schema.json
+++ b/schema-loader/auditor-schema.json
@@ -108,6 +108,20 @@
     },
     "compaction-strategy": "LCS"
   },
+  "auditor.lease": {
+    "transaction": false,
+    "partition-key": [
+      "lease_name"
+    ],
+    "clustering-key": [
+    ],
+    "columns": {
+      "lease_name": "TEXT",
+      "holder": "TEXT",
+      "expiry": "BIGINT"
+    },
+    "compaction-strategy": "LCS"
+  },
   "auditor.secret": {
     "transaction": false,
     "partition-key": [


### PR DESCRIPTION
## Description

In a multi-node Auditor deployment, the scheduled transaction state purge runs redundantly on every node. To coordinate it so that only one node runs it per round, we need a lease (leader-election) primitive. This PR adds that primitive to Core. The Auditor that consumes this primitive is in the corresponding `scalardl-enterprise` PR.

## Related issues and/or PRs

- Consumed by: `scalardl-enterprise` PR (scalar-labs/scalardl-enterprise#1743)
- Stacks on the `add-ledger-purge-finish-transaction` branch as its base (#579).

## Changes made

- Add a storage-agnostic `Lease` interface (`com.scalar.dl.ledger.lease`) with `LeaseEntry` and typed exceptions that carry a ScalarDL `StatusCode` via `CommonError`.
- Add `ScalarLease`, a ScalarDB Storage-API implementation that acquires, renews, and fails over a lease with a single-record linearizable compare-and-swap (`PutIfNotExists` / `PutIf` on the observed holder and expiry).
- Provision the lease table via `schema-loader/auditor-schema.json`, with reactive lazy creation as a fallback for installs upgraded without re-running the schema loader.
- Add an integration test exercising the compare-and-swap semantics (acquire / renew / stale-renew / failover / idempotent create) on real storage.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- The lease is **best-effort coordination, not mutual exclusion** (fencing-free); consumers must keep the guarded work idempotent. This contract is documented in the `Lease` Javadoc.
- The Storage API compare-and-swap is used rather than Consensus Commit: it is lighter for a single-record CAS, and the Auditor does not use Consensus Commit.
- Comparing on the observed *expiry* (not just the holder) on renew/takeover prevents a paused node from resurrecting a lease it already lost.

## Release notes

Added a generic lease (leader-election) primitive backed by the ScalarDB Storage API.
