### PR TITLE
Reject unsupported ScalarDB transaction managers in LedgerConfig

### DIFF
--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -7,6 +7,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.moandjiezana.toml.Toml;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.dl.ledger.error.LedgerError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -562,17 +563,24 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
             .collect(Collectors.toSet());
   }
 
+  // The ScalarDB transaction managers that ScalarDL supports. Any other value (e.g.,
+  // "single-crud-operation") is rejected because ScalarDL relies on multi-operation transactions.
+  private static final Set<String> SUPPORTED_TRANSACTION_MANAGERS =
+      ImmutableSet.of(
+          ConsensusCommitConfig.TRANSACTION_MANAGER_NAME, // "consensus-commit"
+          JdbcConfig.TRANSACTION_MANAGER_NAME); // "jdbc"
+
   private void validateTransactionManager() {
     DatabaseConfig databaseConfig = new DatabaseConfig(props);
     String transactionManager = databaseConfig.getTransactionManager().toLowerCase(Locale.ROOT);
 
-    if (transactionManager.equals("jdbc")) {
+    if (transactionManager.equals(JdbcConfig.TRANSACTION_MANAGER_NAME)) {
       if (isAuditorEnabled && !isTxStateManagementEnabled) {
         throw new IllegalArgumentException(
             LedgerError.CONFIG_TX_STATE_MANAGEMENT_MUST_BE_ENABLED_FOR_JDBC_TRANSACTION
                 .buildMessage(TX_STATE_MANAGEMENT_ENABLED));
       }
-    } else if (transactionManager.equals("consensus-commit")) {
+    } else if (transactionManager.equals(ConsensusCommitConfig.TRANSACTION_MANAGER_NAME)) {
       if (isTxStateManagementEnabled) {
         throw new IllegalArgumentException(
             LedgerError.CONFIG_TX_STATE_MANAGEMENT_MUST_BE_DISABLED_FOR_CONSENSUS_COMMIT
@@ -593,6 +601,10 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
             ConsensusCommitConfig.COORDINATOR_WRITE_OMISSION_ON_READ_ONLY_ENABLED,
             Boolean.toString(false));
       }
+    } else {
+      throw new IllegalArgumentException(
+          LedgerError.CONFIG_TRANSACTION_MANAGER_NOT_SUPPORTED.buildMessage(
+              transactionManager, String.join(", ", SUPPORTED_TRANSACTION_MANAGERS)));
     }
   }
 

--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -564,7 +564,7 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
 
   // The ScalarDB transaction managers that ScalarDL supports. Any other value (e.g.,
   // "single-crud-operation") is rejected because ScalarDL relies on multi-operation transactions.
-  private static final Set<String> SUPPORTED_TRANSACTION_MANAGERS =
+  private static final ImmutableSet<String> SUPPORTED_TRANSACTION_MANAGERS =
       ImmutableSet.of(
           ConsensusCommitConfig.TRANSACTION_MANAGER_NAME, // "consensus-commit"
           JdbcConfig.TRANSACTION_MANAGER_NAME); // "jdbc"

--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -16,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -572,15 +571,16 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
 
   private void validateTransactionManager() {
     DatabaseConfig databaseConfig = new DatabaseConfig(props);
-    String transactionManager = databaseConfig.getTransactionManager().toLowerCase(Locale.ROOT);
+    String transactionManager = databaseConfig.getTransactionManager();
 
-    if (transactionManager.equals(JdbcConfig.TRANSACTION_MANAGER_NAME)) {
+    if (JdbcConfig.TRANSACTION_MANAGER_NAME.equalsIgnoreCase(transactionManager)) {
       if (isAuditorEnabled && !isTxStateManagementEnabled) {
         throw new IllegalArgumentException(
             LedgerError.CONFIG_TX_STATE_MANAGEMENT_MUST_BE_ENABLED_FOR_JDBC_TRANSACTION
                 .buildMessage(TX_STATE_MANAGEMENT_ENABLED));
       }
-    } else if (transactionManager.equals(ConsensusCommitConfig.TRANSACTION_MANAGER_NAME)) {
+    } else if (ConsensusCommitConfig.TRANSACTION_MANAGER_NAME.equalsIgnoreCase(
+        transactionManager)) {
       if (isTxStateManagementEnabled) {
         throw new IllegalArgumentException(
             LedgerError.CONFIG_TX_STATE_MANAGEMENT_MUST_BE_DISABLED_FOR_CONSENSUS_COMMIT

--- a/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
@@ -187,6 +187,12 @@ public enum LedgerError implements ScalarDlError {
       "%s must be disabled because group commit is not supported.",
       "",
       "Set the group commit configuration property to false as it is not supported."),
+  CONFIG_TRANSACTION_MANAGER_NOT_SUPPORTED(
+      StatusCode.INVALID_ARGUMENT,
+      "009",
+      "The transaction manager '%s' is not supported. The supported transaction managers are: %s.",
+      "",
+      "Set the transaction manager configuration property to one of the supported values."),
 
   //
   // Errors for DATABASE_ERROR(500)

--- a/ledger/src/test/java/com/scalar/dl/ledger/config/LedgerConfigTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/config/LedgerConfigTest.java
@@ -465,6 +465,21 @@ public class LedgerConfigTest {
   }
 
   @Test
+  public void
+      constructor_UnsupportedTransactionManagerSpecified_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "single-crud-operation");
+
+    // Act
+    Throwable thrown = catchThrowable(() -> new LedgerConfig(props));
+
+    // Assert
+    assertThat(thrown)
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("single-crud-operation");
+  }
+
+  @Test
   public void constructor_AuditorAndProofEnabledAndPrivateKeyGiven_ShouldConstructProperly() {
     // Arrange
     props.setProperty(LedgerConfig.AUDITOR_ENABLED, "true");


### PR DESCRIPTION
## Description

`LedgerConfig.validateTransactionManager()` only handled the `jdbc` and `consensus-commit` transaction managers and silently accepted any other value for `scalar.db.transaction_manager`. ScalarDB has since gained additional transaction managers (e.g. `single-crud-operation`, added in ScalarDB 3.13.0), which cannot support ScalarDL's multi-operation transactions. Because such values slipped through configuration validation, a misconfiguration surfaced only later as an obscure runtime failure instead of a clear startup error.

This PR makes the Ledger reject any unsupported transaction manager at startup. The supported set is a whitelist built from ScalarDB's public constants (`ConsensusCommitConfig.TRANSACTION_MANAGER_NAME` and `JdbcConfig.TRANSACTION_MANAGER_NAME`), so the branch conditions and the error message stay in sync with ScalarDB and avoid hardcoded strings.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl-tools/pull/48#discussion_r3533714064

## Changes made

- Add a whitelist of supported transaction managers built from ScalarDB's public constants and reject any other value in `LedgerConfig.validateTransactionManager()`
- Add the `CONFIG_TRANSACTION_MANAGER_NOT_SUPPORTED` error whose message lists the supported values
- Add a unit test covering an unsupported transaction manager (`single-crud-operation`)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The Auditor uses ScalarDB only through the storage layer and does not use a transaction manager, so no Auditor-side change is needed.

## Release notes

Fixed the Ledger to reject unsupported ScalarDB transaction managers at startup instead of silently accepting them.
