### PR TITLE
Suppress grpc-java JUL logs in client CLI commands

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -165,7 +165,7 @@ task SmallbankLoader(type: CreateStartScripts) {
 // routed to Log4j2 (see the log4j-jul dependency above). This must be set at JVM startup, so it
 // is applied to every generated start script.
 tasks.withType(CreateStartScripts).configureEach {
-    defaultJvmOpts = ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
+    defaultJvmOpts += ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
 }
 
 distributions {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     api group: 'org.glassfish', name: 'javax.json', version: "${jsonpVersion}"
     api group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jacksonVersion}"
 
+    // Routes grpc-java's java.util.logging (JUL) output (e.g. io.grpc.netty.TcpMetrics) to Log4j2
+    // so that it is controlled by our log4j2.properties. This requires the java.util.logging.manager
+    // system property to be set at JVM startup (see the CreateStartScripts configuration below).
+    runtimeOnly group: 'org.apache.logging.log4j', name: 'log4j-jul', version: "${log4jVersion}"
+
     // for tests
     testImplementation project(':common-test')
     integrationTestImplementation sourceSets.main.output
@@ -154,6 +159,13 @@ task SmallbankLoader(type: CreateStartScripts) {
     applicationName = 'smallbank-loader'
     outputDir = new File(project.buildDir, 'scriptsTmp')
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
+}
+
+// Replace the JUL LogManager with Log4j2's implementation so that grpc-java's JUL logging is
+// routed to Log4j2 (see the log4j-jul dependency above). This must be set at JVM startup, so it
+// is applied to every generated start script.
+tasks.withType(CreateStartScripts).configureEach {
+    defaultJvmOpts = ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
 }
 
 distributions {

--- a/client/conf/log4j2.properties
+++ b/client/conf/log4j2.properties
@@ -5,7 +5,9 @@ appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d [%-5p %c] %m%n
 
-# Suppress grpc-java's benign transport-layer INFO logs routed through JUL
-# (e.g. io.grpc.netty.TcpMetrics "Epoll available during static init ...").
-logger.grpcNetty.name=io.grpc.netty
-logger.grpcNetty.level=WARN
+# Suppress grpc-java's benign TcpMetrics INFO log routed through JUL
+# ("Epoll available during static init of TcpMetrics ..."). This can be removed once grpc-java
+# is bumped to a version that logs it at FINE instead of INFO:
+# https://github.com/grpc/grpc-java/blob/master/netty/src/main/java/io/grpc/netty/TcpMetrics.java
+logger.grpcTcpMetrics.name=io.grpc.netty.TcpMetrics
+logger.grpcTcpMetrics.level=WARN

--- a/client/conf/log4j2.properties
+++ b/client/conf/log4j2.properties
@@ -4,3 +4,8 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d [%-5p %c] %m%n
+
+# Suppress grpc-java's benign transport-layer INFO logs routed through JUL
+# (e.g. io.grpc.netty.TcpMetrics "Epoll available during static init ...").
+logger.grpcNetty.name=io.grpc.netty
+logger.grpcNetty.level=WARN

--- a/client/src/main/resources/log4j2.properties
+++ b/client/src/main/resources/log4j2.properties
@@ -5,7 +5,9 @@ appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d [%-5p %c] %m%n
 
-# Suppress grpc-java's benign transport-layer INFO logs routed through JUL
-# (e.g. io.grpc.netty.TcpMetrics "Epoll available during static init ...").
-logger.grpcNetty.name=io.grpc.netty
-logger.grpcNetty.level=WARN
+# Suppress grpc-java's benign TcpMetrics INFO log routed through JUL
+# ("Epoll available during static init of TcpMetrics ..."). This can be removed once grpc-java
+# is bumped to a version that logs it at FINE instead of INFO:
+# https://github.com/grpc/grpc-java/blob/master/netty/src/main/java/io/grpc/netty/TcpMetrics.java
+logger.grpcTcpMetrics.name=io.grpc.netty.TcpMetrics
+logger.grpcTcpMetrics.level=WARN

--- a/client/src/main/resources/log4j2.properties
+++ b/client/src/main/resources/log4j2.properties
@@ -4,3 +4,8 @@ appender.console.type=Console
 appender.console.name=STDOUT
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d [%-5p %c] %m%n
+
+# Suppress grpc-java's benign transport-layer INFO logs routed through JUL
+# (e.g. io.grpc.netty.TcpMetrics "Epoll available during static init ...").
+logger.grpcNetty.name=io.grpc.netty
+logger.grpcNetty.level=WARN

--- a/hash-store/build.gradle
+++ b/hash-store/build.gradle
@@ -55,7 +55,7 @@ task HashStore(type: CreateStartScripts) {
 // routed to Log4j2. The log4j-jul dependency and the io.grpc.netty log level come transitively
 // from the :client module. This must be set at JVM startup, so it is applied to the start script.
 tasks.withType(CreateStartScripts).configureEach {
-    defaultJvmOpts = ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
+    defaultJvmOpts += ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
 }
 
 distributions {

--- a/hash-store/build.gradle
+++ b/hash-store/build.gradle
@@ -51,6 +51,13 @@ task HashStore(type: CreateStartScripts) {
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
 
+// Replace the JUL LogManager with Log4j2's implementation so that grpc-java's JUL logging is
+// routed to Log4j2. The log4j-jul dependency and the io.grpc.netty log level come transitively
+// from the :client module. This must be set at JVM startup, so it is applied to the start script.
+tasks.withType(CreateStartScripts).configureEach {
+    defaultJvmOpts = ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
+}
+
 distributions {
     main {
         contents {

--- a/table-store/build.gradle
+++ b/table-store/build.gradle
@@ -50,6 +50,13 @@ task TableStore(type: CreateStartScripts) {
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
 
+// Replace the JUL LogManager with Log4j2's implementation so that grpc-java's JUL logging is
+// routed to Log4j2. The log4j-jul dependency and the io.grpc.netty log level come transitively
+// from the :client module. This must be set at JVM startup, so it is applied to the start script.
+tasks.withType(CreateStartScripts).configureEach {
+    defaultJvmOpts = ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
+}
+
 distributions {
     main {
         contents {

--- a/table-store/build.gradle
+++ b/table-store/build.gradle
@@ -54,7 +54,7 @@ task TableStore(type: CreateStartScripts) {
 // routed to Log4j2. The log4j-jul dependency and the io.grpc.netty log level come transitively
 // from the :client module. This must be set at JVM startup, so it is applied to the start script.
 tasks.withType(CreateStartScripts).configureEach {
-    defaultJvmOpts = ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
+    defaultJvmOpts += ['-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager']
 }
 
 distributions {


### PR DESCRIPTION
## Description

Since the recent grpc-java bump, running a ScalarDL client CLI command prints a benign grpc-java message to the console, for example:

```
Jul 06, 2026 11:42:04 AM io.grpc.netty.TcpMetrics loadEpollInfo
INFO: Epoll available during static init of TcpMetrics:false
```

grpc-java emits this message through `java.util.logging` (JUL). ScalarDL configures logging with Log4j2 but does not bridge JUL to Log4j2, so the message bypasses our configuration and is written straight to the console by the default JUL handler. This PR routes JUL through Log4j2 and suppresses these transport-layer INFO logs for the client CLI commands.

## Related issues and/or PRs

None

## Changes made

- Add the `log4j-jul` adapter to the client module and set `-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager` in the generated start scripts so that grpc-java's JUL logs go through Log4j2.
- Raise the `io.grpc.netty` log level to `WARN` in the client `log4j2.properties` (both `conf/` and `src/main/resources/`).
- Add the same JVM option to the hash-store and table-store start scripts; these modules inherit the `log4j-jul` dependency and the log level from the client module.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Verified manually by building the install distributions: the message no longer appears when running the commands, while it still appears when the `java.util.logging.manager` system property is not set. Suppression requires both routing JUL to Log4j2 and the `io.grpc.netty=WARN` level; either alone is not sufficient.
- `log4j-jul` (JUL → Log4j2) is used rather than `jul-to-slf4j` because ScalarDL's logging backend is Log4j2, so `log4j-jul` routes JUL directly to Log4j2 with no extra hop, which is the approach recommended by Log4j2.
- **The Ledger server also emits this message at startup, but it is intentionally out of scope here.** Ledger runs under a SecurityManager with a restricted contract `ProtectionDomain`, and replacing the JUL `LogManager` JVM-wide would route contract-path logging through Log4j2 and likely require additional permissions in that domain. It can be addressed separately with a lower-risk approach (e.g., raising the JUL level for `io.grpc.netty` at server startup without replacing the `LogManager`).

## Release notes

Suppressed a benign grpc-java log message (for example, `io.grpc.netty.TcpMetrics` "Epoll available during static init ...") that was printed to the console when running ScalarDL client CLI commands.
