### PR TITLE
Grant contract sandbox permissions regardless of storage type

### DIFF
--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerModule.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerModule.java
@@ -53,7 +53,6 @@ import java.security.Permissions;
 import java.security.ProtectionDomain;
 import java.sql.SQLPermission;
 import java.util.Base64;
-import java.util.Locale;
 import java.util.PropertyPermission;
 import javax.annotation.Nullable;
 
@@ -181,7 +180,7 @@ public class LedgerModule extends AbstractModule {
   @Provides
   @Singleton
   ProtectionDomain provideProtectionDomain() {
-    return getProtectionDomain(databaseConfig);
+    return getProtectionDomain();
   }
 
   @Provides
@@ -197,19 +196,10 @@ public class LedgerModule extends AbstractModule {
     }
   }
 
-  public static ProtectionDomain getProtectionDomain(DatabaseConfig databaseConfig) {
+  public static ProtectionDomain getProtectionDomain() {
     // (null, null) means that it denies all if java.security.manager is enabled
     PermissionCollection permissionCollection = new Permissions();
     permissionCollection.add(new RuntimePermission("createClassLoader"));
-    // For ScalarDB on JDBC databases
-    if (databaseConfig.getStorage().toLowerCase(Locale.ROOT).equals("jdbc")) {
-      permissionCollection.add(new SocketPermission("*", "connect,resolve"));
-      // The PostgreSQL JDBC driver reads this property to decide SOCKS proxy resolution.
-      permissionCollection.add(new PropertyPermission("socksProxyHost", "read"));
-      // HikariCP calls these methods when validating/closing connections.
-      permissionCollection.add(new SQLPermission("setNetworkTimeout"));
-      permissionCollection.add(new SQLPermission("callAbort"));
-    }
     // For ScalarDB on Cosmos DB
     permissionCollection.add(new RuntimePermission("getenv.*"));
     permissionCollection.add(new PropertyPermission("log4j2.flowMessageFactory", "read"));
@@ -220,13 +210,15 @@ public class LedgerModule extends AbstractModule {
     // For ScalarDB on DynamoDB
     permissionCollection.add(new PropertyPermission("aws.executionEnvironment", "read"));
     permissionCollection.add(new PropertyPermission("com.amazonaws.xray.traceHeader", "read"));
-    if (databaseConfig.getStorage().toLowerCase(Locale.ROOT).equals("dynamo")) {
-      permissionCollection.add(new SocketPermission("*", "connect,resolve"));
-    }
-    // For ScalarDB on Cloud Storage
-    if (databaseConfig.getStorage().toLowerCase(Locale.ROOT).equals("cloud-storage")) {
-      permissionCollection.add(new SocketPermission("*", "connect,resolve"));
-    }
+    // These permissions are required by ScalarDB on DynamoDB, Cloud Storage, and JDBC databases.
+    // They are set regardless of the storage type so that multi-storage configurations and storages
+    // added in the future are handled without changes here.
+    permissionCollection.add(new SocketPermission("*", "connect,resolve"));
+    // The PostgreSQL JDBC driver reads this property to decide SOCKS proxy resolution.
+    permissionCollection.add(new PropertyPermission("socksProxyHost", "read"));
+    // HikariCP calls these methods when validating/closing connections.
+    permissionCollection.add(new SQLPermission("setNetworkTimeout"));
+    permissionCollection.add(new SQLPermission("callAbort"));
     return new ProtectionDomain(null, permissionCollection);
   }
 }


### PR DESCRIPTION
## Description

`LedgerModule.getProtectionDomain()` builds the restricted `ProtectionDomain` (the sandbox) applied to contract code when a `SecurityManager` is enabled. It granted the permissions needed to open database connections only when `databaseConfig.getStorage()` equaled `"jdbc"`, `"dynamo"`, or `"cloud-storage"`.

ScalarDB `multi-storage` makes `getStorage()` return `"multi-storage"`, so none of those branches fired even when an underlying storage was JDBC/DynamoDB/Cloud Storage. As a result, contract execution on a multi-storage-backed deployment fails at runtime with an `AccessControlException` when a connection is opened in the contract context.

This PR grants those permissions unconditionally, regardless of the configured storage type, so multi-storage configurations (and any storage added in the future) are covered without further changes. The permission is the same broad grant (`SocketPermission("*", "connect,resolve")`) whatever the storage is, so the only practical effect of removing the branching is that contracts on the Cassandra / Cosmos DB backends — which previously triggered no such check and so had no outbound-socket permission — gain the same capability the JDBC/DynamoDB/Cloud Storage backends already had. This is an acceptable trade-off because the sandbox is defense-in-depth rather than the trust boundary (see Additional notes).

## Related issues and/or PRs

- Follow-up to #558, which introduced the per-storage `jdbc` branch that this PR generalizes.
- Paired with the corresponding Enterprise PR that updates the `AuditorModule` caller for the signature change (scalar-labs/scalardl-enterprise#1747).

## Changes made

- Grant the DynamoDB / Cloud Storage / JDBC sandbox permissions unconditionally instead of gating them on the ScalarDB storage type, so multi-storage (and future storages) are covered
- Remove the now-unused `DatabaseConfig` parameter from the public static `getProtectionDomain()` (the permission set is storage-independent)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- Security posture: this sandbox is defense-in-depth, not a containment boundary against a malicious contract. Contracts are registered only by authenticated clients and are signature-verified for integrity/provenance, but the signature does not attest that a contract is benign — the trust boundary is authenticated, signed registration (i.e. access control). Granting outbound sockets unconditionally means contracts on Cassandra/Cosmos DB backends (which previously had no `SocketPermission`) gain the same egress the common remote backends already had; this is an accepted, minor reduction of a defense-in-depth layer, not a change to the trust boundary.
- The removed parameter is a public static API also called by the Enterprise Auditor. The paired Enterprise PR updates that caller, and this change must be published (snapshot/version bump) before Enterprise builds against it.
- There is no existing test that asserts the contents of the permission set (`getProtectionDomain` is not covered by a unit test), so none was added.
- This is a continuation of the same investigation as #558 and the transaction-manager whitelist change, which explicitly foreshadowed generalizing this storage-gated branch.

## Release notes

Fixed contract execution failing with an `AccessControlException` when ScalarDL runs on a ScalarDB multi-storage configuration backed by JDBC (or DynamoDB / Cloud Storage), by granting the required sandbox permissions regardless of the configured storage type.
