### PR TITLE
Fix several vulnerabilities in grpc-health-probe

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.47
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.53
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/


### PR DESCRIPTION
## Description

This PR fixes the following vulnerabilities in grpc-health-probe.

- CVE-2026-25681
- CVE-2026-27136
- CVE-2026-27145
- CVE-2026-32280
- CVE-2026-32281
- CVE-2026-32283
- CVE-2026-33811
- CVE-2026-33814
- CVE-2026-34986
- CVE-2026-39820
- CVE-2026-39821
- CVE-2026-39836
- CVE-2026-42499
- CVE-2026-42504

## Related issues and/or PRs

- scalar-labs/scalardl-enterprise#1748

## Changes made

- Bump grpc-health-probe

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed several vulnerabilities in grpc-health-probe.