### PR TITLE
Fix compile warnings

### DIFF
--- a/common-test/src/main/java/com/scalar/dl/ledger/service/function/CreateFunction.java
+++ b/common-test/src/main/java/com/scalar/dl/ledger/service/function/CreateFunction.java
@@ -12,6 +12,7 @@ import javax.json.JsonObject;
 public class CreateFunction extends Function {
 
   @Override
+  @SuppressWarnings("unchecked")
   public void invoke(
       Database database,
       Optional<JsonObject> functionArgument,

--- a/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
+++ b/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
@@ -153,6 +153,7 @@ public class Argument {
    *     testing purposes only.
    */
   @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public static String format(Object argument, String nonce, List<String> functionIds) {
     return format(argument, nonce, null, functionIds);
   }

--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -455,7 +455,7 @@ public final class LedgerConfig implements ServerConfig, ServersHmacAuthenticata
             Objects.requireNonNull(
                     ConfigUtils.getString(
                         props, AUTHENTICATION_METHOD, DEFAULT_AUTHENTICATION_METHOD.getMethod()))
-                .toLowerCase());
+                .toLowerCase(Locale.ROOT));
     if (authenticationMethod == AuthenticationMethod.HMAC) {
       hmacCipherKey = ConfigUtils.getString(props, AUTHENTICATION_HMAC_CIPHER_KEY, null);
       if (hmacCipherKey == null) {

--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 @Immutable
 @SuppressFBWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
-public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
+public final class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
   private static final Logger LOGGER = LoggerFactory.getLogger(LedgerConfig.class);
   @VisibleForTesting static final String PRODUCT_NAME = "scalardl";
   @VisibleForTesting static final String SERVICE_NAME = "ledger";
@@ -316,13 +316,6 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
     props.putAll(properties);
     load();
   }
-
-  /**
-   * SpotBugs detects Bug Type "CT_CONSTRUCTOR_THROW" saying that "The object under construction
-   * remains partially initialized and may be vulnerable to Finalizer attacks."
-   */
-  @Override
-  protected final void finalize() {}
 
   public DatabaseConfig getDatabaseConfig() {
     return new DatabaseConfig(props);

--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
@@ -414,7 +414,7 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
     }
   }
 
-  static class AssetMetadata {
+  static final class AssetMetadata {
     public static final String ID = "asset_id";
     public static final String AGE = "latest_age";
     private final String id;
@@ -434,13 +434,6 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
             CommonError.UNEXPECTED_RECORD_VALUE_OBSERVED, e, e.getMessage());
       }
     }
-
-    /**
-     * SpotBugs detects Bug Type "CT_CONSTRUCTOR_THROW" saying that "The object under construction
-     * remains partially initialized and may be vulnerable to Finalizer attacks."
-     */
-    @Override
-    protected final void finalize() {}
 
     /**
      * Returns the id of the asset.

--- a/ledger/src/permission-test/java/com/scalar/dl/ledger/service/LedgerServicePermissionTest.java
+++ b/ledger/src/permission-test/java/com/scalar/dl/ledger/service/LedgerServicePermissionTest.java
@@ -72,7 +72,6 @@ public class LedgerServicePermissionTest {
   private static final String NONCE_ATTRIBUTE_NAME = "nonce";
   private static final String ENTITY_ID = "entity_id";
   private static final int KEY_VERSION = 1;
-  private static final String ANY_NAMESPACE = "test_namespace";
   @Mock private TransactionManager transactionManager;
   @Mock private Transaction transaction;
   @Mock private Ledger ledger;

--- a/testing/src/main/java/com/scalar/dl/testing/function/CreateFunction.java
+++ b/testing/src/main/java/com/scalar/dl/testing/function/CreateFunction.java
@@ -13,6 +13,7 @@ import javax.json.JsonObject;
 public class CreateFunction extends Function {
 
   @Override
+  @SuppressWarnings("unchecked")
   public void invoke(
       Database database,
       Optional<JsonObject> functionArgument,


### PR DESCRIPTION
## Description

Building the project with `./gradlew compileJava` (and the test/permission-test source sets) emitted several compiler warnings in the `common` and `ledger` modules. This PR cleans them up so the build output is quiet and future real warnings are easier to spot. As part of removing the empty `finalize()` methods, the affected classes are now `final`, which blocks finalizer attacks (the original `CT_CONSTRUCTOR_THROW` concern) more strongly than the previous empty-`finalize()` workaround while no longer depending on the deprecated-for-removal `finalize()` API.

The only behavioral change is making `LedgerConfig`'s authentication-method parsing locale-independent (`Locale.ROOT`); it mirrors the same fix in scalardl-enterprise's `AuditorConfig`. This spot is not flagged by scalardl's older Error Prone but carries the same latent default-locale dependency.

## Related issues and/or PRs

- scalar-labs/scalardl-enterprise#1753

## Changes made

- Make `LedgerConfig` and the inner `AssetMetadata` `final` and remove their empty `finalize()`, resolving the `[removal]` warnings and strengthening the finalizer-attack mitigation.
- Specify `Locale.ROOT` for the authentication-method parsing in `LedgerConfig` (mirrors the same fix in scalardl-enterprise's `AuditorConfig`).
- Suppress the intentional `InlineMeSuggester` and `unchecked` warnings (the deprecated `Argument.format` overload and the `CreateFunction.invoke` test helpers).
- Remove the unused `ANY_NAMESPACE` field in `LedgerServicePermissionTest`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

All source sets (`main`, `test`, `integration-test`, `permission-test`) were compiled to verify the fixes. Remaining `[removal]` warnings in `LedgerServicePermissionTest` come from the `SecurityManager`/`AccessController` APIs that the test exercises by design and are intentionally left as-is.

## Release notes

N/A
