### PR TITLE
Backport to branch(3.13) : Reject unsupported ScalarDB transaction managers in LedgerConfig

### DIFF
--- a/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/config/LedgerConfig.java
@@ -7,6 +7,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.moandjiezana.toml.Toml;
 import com.scalar.db.config.DatabaseConfig;
+import com.scalar.db.storage.jdbc.JdbcConfig;
 import com.scalar.db.transaction.consensuscommit.ConsensusCommitConfig;
 import com.scalar.dl.ledger.error.LedgerError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -15,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -562,17 +562,25 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
             .collect(Collectors.toSet());
   }
 
+  // The ScalarDB transaction managers that ScalarDL supports. Any other value (e.g.,
+  // "single-crud-operation") is rejected because ScalarDL relies on multi-operation transactions.
+  private static final ImmutableSet<String> SUPPORTED_TRANSACTION_MANAGERS =
+      ImmutableSet.of(
+          ConsensusCommitConfig.TRANSACTION_MANAGER_NAME, // "consensus-commit"
+          JdbcConfig.TRANSACTION_MANAGER_NAME); // "jdbc"
+
   private void validateTransactionManager() {
     DatabaseConfig databaseConfig = new DatabaseConfig(props);
-    String transactionManager = databaseConfig.getTransactionManager().toLowerCase(Locale.ROOT);
+    String transactionManager = databaseConfig.getTransactionManager();
 
-    if (transactionManager.equals("jdbc")) {
+    if (JdbcConfig.TRANSACTION_MANAGER_NAME.equalsIgnoreCase(transactionManager)) {
       if (isAuditorEnabled && !isTxStateManagementEnabled) {
         throw new IllegalArgumentException(
             LedgerError.CONFIG_TX_STATE_MANAGEMENT_MUST_BE_ENABLED_FOR_JDBC_TRANSACTION
                 .buildMessage(TX_STATE_MANAGEMENT_ENABLED));
       }
-    } else if (transactionManager.equals("consensus-commit")) {
+    } else if (ConsensusCommitConfig.TRANSACTION_MANAGER_NAME.equalsIgnoreCase(
+        transactionManager)) {
       if (isTxStateManagementEnabled) {
         throw new IllegalArgumentException(
             LedgerError.CONFIG_TX_STATE_MANAGEMENT_MUST_BE_DISABLED_FOR_CONSENSUS_COMMIT
@@ -593,6 +601,10 @@ public class LedgerConfig implements ServerConfig, ServersHmacAuthenticatable {
             ConsensusCommitConfig.COORDINATOR_WRITE_OMISSION_ON_READ_ONLY_ENABLED,
             Boolean.toString(false));
       }
+    } else {
+      throw new IllegalArgumentException(
+          LedgerError.CONFIG_TRANSACTION_MANAGER_NOT_SUPPORTED.buildMessage(
+              transactionManager, String.join(", ", SUPPORTED_TRANSACTION_MANAGERS)));
     }
   }
 

--- a/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
@@ -187,6 +187,12 @@ public enum LedgerError implements ScalarDlError {
       "%s must be disabled because group commit is not supported.",
       "",
       "Set the group commit configuration property to false as it is not supported."),
+  CONFIG_TRANSACTION_MANAGER_NOT_SUPPORTED(
+      StatusCode.INVALID_ARGUMENT,
+      "009",
+      "The transaction manager '%s' is not supported. The supported transaction managers are: %s.",
+      "",
+      "Set the transaction manager configuration property to one of the supported values."),
 
   //
   // Errors for DATABASE_ERROR(500)

--- a/ledger/src/test/java/com/scalar/dl/ledger/config/LedgerConfigTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/config/LedgerConfigTest.java
@@ -465,6 +465,21 @@ public class LedgerConfigTest {
   }
 
   @Test
+  public void
+      constructor_UnsupportedTransactionManagerSpecified_ShouldThrowIllegalArgumentException() {
+    // Arrange
+    props.setProperty(DatabaseConfig.TRANSACTION_MANAGER, "single-crud-operation");
+
+    // Act
+    Throwable thrown = catchThrowable(() -> new LedgerConfig(props));
+
+    // Assert
+    assertThat(thrown)
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("single-crud-operation");
+  }
+
+  @Test
   public void constructor_AuditorAndProofEnabledAndPrivateKeyGiven_ShouldConstructProperly() {
     // Arrange
     props.setProperty(LedgerConfig.AUDITOR_ENABLED, "true");


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/585
- **Commit to backport:** 1212b93615cfa3d492161d9734de2860ea6fbb24

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-585 &&
git cherry-pick --no-rerere-autoupdate -m1 1212b93615cfa3d492161d9734de2860ea6fbb24
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!