### PR TITLE
Backport to branch(3.12) : Fix several vulnerabilities in grpc-health-probe

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/busybox:1.36 AS tools
 
 ENV DOCKERIZE_VERSION v0.6.1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.47
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.53
 
 # Install dockerize
 RUN set -x && \


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/589
- **Commit to backport:** 17f04982fb5ccd93c95b5f146b9c33ad911eec90

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.12-pull-589 &&
git cherry-pick --no-rerere-autoupdate -m1 17f04982fb5ccd93c95b5f146b9c33ad911eec90
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!