### PR TITLE
Backport to branch(3.13) : Restrict function execution to its own namespace

### DIFF
--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/NamespaceRestrictedMutableDatabase.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/NamespaceRestrictedMutableDatabase.java
@@ -1,0 +1,149 @@
+package com.scalar.dl.ledger.database.scalardb;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Operation;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.dl.ledger.database.MutableDatabase;
+import com.scalar.dl.ledger.error.LedgerError;
+import com.scalar.dl.ledger.exception.InvalidFunctionException;
+import com.scalar.dl.ledger.namespace.Namespaces;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A decorator for {@link MutableDatabase} that enforces namespace-based access control on the
+ * ScalarDB operations issued by functions.
+ *
+ * <p>This is the single place that governs which ScalarDB namespaces a function may access. System
+ * namespaces and namespaces with reserved prefixes are always rejected, regardless of the context
+ * namespace (this still applies even if the context namespace itself happens to be a reserved
+ * name). In addition:
+ *
+ * <ul>
+ *   <li>When the context namespace is the default namespace, only that deny list applies (the
+ *       historical behavior, kept for backward compatibility), and operations without a namespace
+ *       are allowed.
+ *   <li>When the context namespace is a non-default namespace, the function may access the ScalarDB
+ *       namespace with the same name as its context namespace, or any namespace whose name is
+ *       prefixed by the context namespace followed by a separator ("_"). For example, a context
+ *       namespace of "tenant_a" allows access to "tenant_a", "tenant_a_logs", and "tenant_a_2024",
+ *       but not "tenant_ax". Any operation targeting a namespace outside this set, or an operation
+ *       without an explicit namespace, is rejected.
+ * </ul>
+ *
+ * <p>This mirrors {@link com.scalar.dl.ledger.database.NamespaceRestrictedAssetLedger}, which
+ * applies the equivalent restriction to the Asset Ledger accessed by contracts. Two differences are
+ * intentional:
+ *
+ * <ul>
+ *   <li>This decorator is always applied (even for the default context namespace) because it must
+ *       also enforce the system-namespace deny list, which the Asset Ledger does not need. The
+ *       Asset Ledger decorator is only applied for non-default context namespaces.
+ *   <li>In a non-default context, this decorator rejects operations without an explicit namespace,
+ *       whereas the Asset Ledger decorator delegates them. An unspecified namespace here would
+ *       otherwise fall back to ScalarDB's configured default namespace and allow implicit
+ *       cross-namespace access.
+ * </ul>
+ */
+@ThreadSafe
+public class NamespaceRestrictedMutableDatabase
+    implements MutableDatabase<Get, Scan, Put, Delete, Result> {
+  private static final List<String> DISALLOWED_NAMESPACES =
+      Arrays.asList(
+          "system",
+          "system_schema",
+          "system_auth",
+          "system_distributed",
+          "system_traces",
+          "coordinator");
+  // Note: "auditor" is included as a safeguard for development and PoC environments. In
+  // production, the Auditor namespace is not accessible from Ledger's transaction manager because
+  // Ledger and Auditor belong to different administrative domains.
+  private static final List<String> DISALLOWED_NAMESPACE_PREFIXES =
+      Arrays.asList("scalar", "auditor");
+  // A function's context namespace grants access to namespaces prefixed by it and this separator,
+  // matching the separator used to compose physical namespace names in ScalarNamespaceResolver.
+  private static final String NAMESPACE_SEPARATOR = "_";
+
+  private final MutableDatabase<Get, Scan, Put, Delete, Result> delegate;
+  private final String contextNamespace;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public NamespaceRestrictedMutableDatabase(
+      MutableDatabase<Get, Scan, Put, Delete, Result> delegate, String contextNamespace) {
+    this.delegate = delegate;
+    this.contextNamespace = contextNamespace;
+  }
+
+  @Override
+  public Optional<Result> get(Get get) {
+    validateNamespaceAccess(get);
+    return delegate.get(get);
+  }
+
+  @Override
+  public List<Result> scan(Scan scan) {
+    validateNamespaceAccess(scan);
+    return delegate.scan(scan);
+  }
+
+  @Override
+  public void put(Put put) {
+    validateNamespaceAccess(put);
+    delegate.put(put);
+  }
+
+  @Override
+  public void delete(Delete delete) {
+    validateNamespaceAccess(delete);
+    delegate.delete(delete);
+  }
+
+  private void validateNamespaceAccess(Operation operation) {
+    // Always reject system namespaces and namespaces with reserved prefixes, regardless of the
+    // context namespace. This is required even for a non-default context namespace because the
+    // context namespace itself can be a reserved name (only "default" is reserved at namespace
+    // creation), in which case the equality check below would otherwise allow access to it.
+    validateAgainstDisallowedNamespaces(operation);
+
+    if (Namespaces.DEFAULT.equals(contextNamespace)) {
+      return;
+    }
+
+    // For a non-default context namespace, a function may access the ScalarDB namespace with the
+    // same name as its context namespace, or any namespace prefixed by the context namespace
+    // followed by a separator. An operation without an explicit namespace is also rejected to
+    // prevent implicit access to the configured default namespace.
+    String namespace = operation.forNamespace().orElse(null);
+    if (namespace == null || !isAccessibleNamespace(namespace)) {
+      throw new InvalidFunctionException(
+          LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_DIFFERENT_NAMESPACE,
+          namespace,
+          contextNamespace);
+    }
+  }
+
+  private boolean isAccessibleNamespace(String namespace) {
+    return contextNamespace.equals(namespace)
+        || namespace.startsWith(contextNamespace + NAMESPACE_SEPARATOR);
+  }
+
+  private void validateAgainstDisallowedNamespaces(Operation operation) {
+    Optional<String> namespace = operation.forNamespace();
+    if (namespace.isEmpty()) {
+      return;
+    }
+    String lowercaseNamespace = namespace.get().toLowerCase();
+    if (DISALLOWED_NAMESPACES.contains(lowercaseNamespace)
+        || DISALLOWED_NAMESPACE_PREFIXES.stream().anyMatch(lowercaseNamespace::startsWith)) {
+      throw new InvalidFunctionException(
+          LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_SPECIFIED_NAMESPACE);
+    }
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarMutableDatabase.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarMutableDatabase.java
@@ -3,7 +3,6 @@ package com.scalar.dl.ledger.database.scalardb;
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Operation;
 import com.scalar.db.api.Put;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
@@ -14,33 +13,30 @@ import com.scalar.dl.ledger.error.LedgerError;
 import com.scalar.dl.ledger.exception.ConflictException;
 import com.scalar.dl.ledger.exception.DatabaseException;
 import com.scalar.dl.ledger.exception.InvalidFunctionException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * A {@link MutableDatabase} implementation backed by a ScalarDB {@link DistributedTransaction}.
+ *
+ * <p>Namespace-based access control is intentionally not handled here; it is enforced by {@link
+ * NamespaceRestrictedMutableDatabase}, which wraps this class. This class only delegates operations
+ * to the underlying transaction and translates ScalarDB exceptions.
+ *
+ * <p>Instances must always be wrapped by {@link NamespaceRestrictedMutableDatabase}, which enforces
+ * namespace access control. The constructor is intentionally package-private so that instances can
+ * only be created from within this package (in practice, by {@link ScalarTransactionManager}),
+ * keeping the wrapping requirement contained to this package.
+ */
 public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, Delete, Result> {
   private final DistributedTransaction transaction;
-  private static final List<String> DISALLOWED_NAMESPACES =
-      Arrays.asList(
-          "system",
-          "system_schema",
-          "system_auth",
-          "system_distributed",
-          "system_traces",
-          "coordinator");
-  // Note: "auditor" is included as a safeguard for development and PoC environments. In
-  // production, the Auditor namespace is not accessible from Ledger's transaction manager because
-  // Ledger and Auditor belong to different administrative domains.
-  private static final List<String> DISALLOWED_NAMESPACE_PREFIXES =
-      Arrays.asList("scalar", "auditor");
 
-  public ScalarMutableDatabase(DistributedTransaction transaction) {
+  ScalarMutableDatabase(DistributedTransaction transaction) {
     this.transaction = transaction;
   }
 
   @Override
   public Optional<Result> get(Get get) {
-    validateNamespace(get);
     try {
       return transaction.get(get);
     } catch (IllegalArgumentException e) {
@@ -56,7 +52,6 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
 
   @Override
   public List<Result> scan(Scan scan) {
-    validateNamespace(scan);
     try {
       return transaction.scan(scan);
     } catch (IllegalArgumentException e) {
@@ -72,7 +67,6 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
 
   @Override
   public void put(Put put) {
-    validateNamespace(put);
     try {
       // Make put() consistent with Ledger's put(), which always pre-read implicitly.
       transaction.put(Put.newBuilder(put).implicitPreReadEnabled(true).build());
@@ -89,7 +83,6 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
 
   @Override
   public void delete(Delete delete) {
-    validateNamespace(delete);
     try {
       transaction.delete(delete);
     } catch (IllegalArgumentException e) {
@@ -100,20 +93,6 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
     } catch (CrudException e) {
       throw new DatabaseException(
           LedgerError.OPERATION_FAILED_DUE_TO_DATABASE_ERROR, e, e.getMessage());
-    }
-  }
-
-  private void validateNamespace(Operation operation) {
-    if (operation.forNamespace().isEmpty()) {
-      return;
-    }
-    String namespace = operation.forNamespace().get();
-
-    String lowercaseNamespace = namespace.toLowerCase();
-    if (DISALLOWED_NAMESPACES.contains(lowercaseNamespace)
-        || DISALLOWED_NAMESPACE_PREFIXES.stream().anyMatch(lowercaseNamespace::startsWith)) {
-      throw new InvalidFunctionException(
-          LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_SPECIFIED_NAMESPACE);
     }
   }
 }

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTransactionManager.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTransactionManager.java
@@ -79,17 +79,25 @@ public class ScalarTransactionManager implements TransactionManager, TableMetada
       throw new DatabaseException(LedgerError.STARTING_TRANSACTION_FAILED, e, e.getMessage());
     }
 
+    String contextNamespace =
+        request == null ? Namespaces.DEFAULT : request.getContextNamespaceOrDefault();
+
     MutableDatabase<Get, Scan, Put, Delete, Result> database = null;
     if (config.isFunctionEnabled()) {
-      database = new ScalarMutableDatabase(transaction);
+      database =
+          new NamespaceRestrictedMutableDatabase(
+              new ScalarMutableDatabase(transaction), contextNamespace);
     }
 
-    TamperEvidentAssetLedger ledger = createTamperEvidentAssetLedger(request, transaction);
+    TamperEvidentAssetLedger ledger =
+        createTamperEvidentAssetLedger(request, transaction, contextNamespace);
     return new Transaction(ledger, database);
   }
 
   private TamperEvidentAssetLedger createTamperEvidentAssetLedger(
-      ContractExecutionRequest request, DistributedTransaction transaction) {
+      ContractExecutionRequest request,
+      DistributedTransaction transaction,
+      String contextNamespace) {
     TamperEvidentAssetLedger ledger =
         new ScalarTamperEvidentAssetLedger(
             transaction,
@@ -101,8 +109,6 @@ public class ScalarTransactionManager implements TransactionManager, TableMetada
             stateManager,
             namespaceResolver,
             config);
-    String contextNamespace =
-        request == null ? Namespaces.DEFAULT : request.getContextNamespaceOrDefault();
     if (!contextNamespace.equals(Namespaces.DEFAULT)) {
       ledger = new NamespaceRestrictedAssetLedger(ledger, contextNamespace);
     }

--- a/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
@@ -135,6 +135,12 @@ public enum LedgerError implements ScalarDlError {
       "The database operation in the function failed. Details: %s",
       "",
       "Verify that the arguments passed to the database operation are valid and correct."),
+  FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_DIFFERENT_NAMESPACE(
+      StatusCode.INVALID_FUNCTION,
+      "003",
+      "The function is not allowed to access a namespace that is neither its context namespace nor prefixed by it. Namespace: %s; Context namespace: %s",
+      "",
+      "A function registered in a non-default namespace can only access the ScalarDB namespace with the same name as its context namespace or a namespace whose name starts with the context namespace followed by an underscore. Specify such a namespace explicitly in the database operation, or register the function in the appropriate namespace."),
 
   //
   // Errors for INVALID_ARGUMENT(414)

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/NamespaceRestrictedMutableDatabaseTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/NamespaceRestrictedMutableDatabaseTest.java
@@ -1,0 +1,279 @@
+package com.scalar.dl.ledger.database.scalardb;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import com.scalar.db.api.Delete;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.api.Scan;
+import com.scalar.db.io.Key;
+import com.scalar.dl.ledger.database.MutableDatabase;
+import com.scalar.dl.ledger.error.LedgerError;
+import com.scalar.dl.ledger.exception.InvalidFunctionException;
+import com.scalar.dl.ledger.namespace.Namespaces;
+import com.scalar.dl.ledger.service.StatusCode;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class NamespaceRestrictedMutableDatabaseTest {
+  private static final String CONTEXT_NAMESPACE = "context_ns";
+  private static final String DIFFERENT_NAMESPACE = "different_ns";
+  private static final String TABLE = "table";
+  private static final Key PARTITION_KEY = Key.ofText("col", "val");
+
+  private enum Op {
+    GET,
+    SCAN,
+    PUT,
+    DELETE
+  }
+
+  @Mock private MutableDatabase<Get, Scan, Put, Delete, Result> delegate;
+
+  // contextNamespace == DEFAULT: only the disallowed (system) namespaces are blocked.
+  private NamespaceRestrictedMutableDatabase defaultDatabase;
+  // contextNamespace != DEFAULT: the same-named namespace and namespaces prefixed by it are
+  // accessible.
+  private NamespaceRestrictedMutableDatabase restrictedDatabase;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    defaultDatabase = new NamespaceRestrictedMutableDatabase(delegate, Namespaces.DEFAULT);
+    restrictedDatabase = new NamespaceRestrictedMutableDatabase(delegate, CONTEXT_NAMESPACE);
+  }
+
+  static Stream<String> disallowedNamespaces() {
+    return Stream.of(
+        "system",
+        "system_schema",
+        "system_auth",
+        "system_distributed",
+        "system_traces",
+        "coordinator",
+        "scalar",
+        "scalar_my_namespace",
+        "auditor",
+        "auditor_my_namespace",
+        // Case insensitive
+        "SYSTEM",
+        "Coordinator",
+        "SCALAR",
+        "Scalar_Namespace",
+        "AUDITOR",
+        "Auditor_Namespace");
+  }
+
+  static Stream<Arguments> operationsAndDisallowedNamespaces() {
+    return disallowedNamespaces()
+        .flatMap(ns -> Arrays.stream(Op.values()).map(op -> Arguments.of(op, ns)));
+  }
+
+  static Stream<Arguments> operationsAndReservedContextNamespaces() {
+    return Stream.of("coordinator", "system", "scalar_secret", "auditor_log")
+        .flatMap(ns -> Arrays.stream(Op.values()).map(op -> Arguments.of(op, ns)));
+  }
+
+  static Stream<Arguments> operationsAndPrefixedNamespaces() {
+    // Namespaces prefixed by the context namespace followed by the separator, which are accessible.
+    return Stream.of(CONTEXT_NAMESPACE + "_sub", CONTEXT_NAMESPACE + "_2024_archive")
+        .flatMap(ns -> Arrays.stream(Op.values()).map(op -> Arguments.of(op, ns)));
+  }
+
+  static Stream<Arguments> operationsAndSiblingNamespaces() {
+    // Namespaces that share the string prefix but are not bounded by the separator, so they must be
+    // rejected (for example, "context_nsx" must not match context namespace "context_ns").
+    return Stream.of(CONTEXT_NAMESPACE + "x", CONTEXT_NAMESPACE + "sibling")
+        .flatMap(ns -> Arrays.stream(Op.values()).map(op -> Arguments.of(op, ns)));
+  }
+
+  // ---- DEFAULT context: backward-compatible behavior (only system namespaces blocked) ----
+
+  @ParameterizedTest
+  @MethodSource("operationsAndDisallowedNamespaces")
+  public void operation_DefaultContextWithDisallowedNamespace_ShouldThrowInvalidFunctionException(
+      Op op, String namespace) {
+    assertThatThrownBy(() -> run(defaultDatabase, op, namespace))
+        .isInstanceOf(InvalidFunctionException.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_DefaultContextWithAllowedNamespace_ShouldDelegate(Op op) {
+    assertThatCode(() -> run(defaultDatabase, op, "my_namespace")).doesNotThrowAnyException();
+    verifyDelegated(op, "my_namespace");
+  }
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_DefaultContextWithoutNamespace_ShouldDelegate(Op op) {
+    assertThatCode(() -> run(defaultDatabase, op, null)).doesNotThrowAnyException();
+    verifyDelegated(op, null);
+  }
+
+  // ---- Non-default context: the same-named namespace and namespaces prefixed by it (with the
+  // separator) are accessible ----
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_NonDefaultContextWithSameNamespace_ShouldDelegate(Op op) {
+    assertThatCode(() -> run(restrictedDatabase, op, CONTEXT_NAMESPACE)).doesNotThrowAnyException();
+    verifyDelegated(op, CONTEXT_NAMESPACE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("operationsAndPrefixedNamespaces")
+  public void operation_NonDefaultContextWithPrefixedNamespace_ShouldDelegate(
+      Op op, String namespace) {
+    assertThatCode(() -> run(restrictedDatabase, op, namespace)).doesNotThrowAnyException();
+    verifyDelegated(op, namespace);
+  }
+
+  @ParameterizedTest
+  @MethodSource("operationsAndSiblingNamespaces")
+  public void operation_NonDefaultContextWithSiblingNamespace_ShouldThrow(Op op, String namespace) {
+    // A namespace that shares the string prefix but is not separated by the separator is rejected.
+    assertThatThrownBy(() -> run(restrictedDatabase, op, namespace))
+        .isInstanceOf(InvalidFunctionException.class)
+        .hasMessage(
+            LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_DIFFERENT_NAMESPACE.buildMessage(
+                namespace, CONTEXT_NAMESPACE))
+        .extracting("code")
+        .isEqualTo(StatusCode.INVALID_FUNCTION);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_NonDefaultContextWithDifferentNamespace_ShouldThrow(Op op) {
+    assertThatThrownBy(() -> run(restrictedDatabase, op, DIFFERENT_NAMESPACE))
+        .isInstanceOf(InvalidFunctionException.class)
+        .hasMessage(
+            LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_DIFFERENT_NAMESPACE.buildMessage(
+                DIFFERENT_NAMESPACE, CONTEXT_NAMESPACE))
+        .extracting("code")
+        .isEqualTo(StatusCode.INVALID_FUNCTION);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_NonDefaultContextWithoutNamespace_ShouldThrow(Op op) {
+    assertThatThrownBy(() -> run(restrictedDatabase, op, null))
+        .isInstanceOf(InvalidFunctionException.class)
+        .hasMessage(
+            LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_DIFFERENT_NAMESPACE.buildMessage(
+                (Object) null, CONTEXT_NAMESPACE))
+        .extracting("code")
+        .isEqualTo(StatusCode.INVALID_FUNCTION);
+  }
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_NonDefaultContextWithSystemNamespace_ShouldThrow(Op op) {
+    // A system namespace is always rejected by the deny list, which is applied regardless of the
+    // context namespace.
+    assertThatThrownBy(() -> run(restrictedDatabase, op, "coordinator"))
+        .isInstanceOf(InvalidFunctionException.class)
+        .hasMessage(
+            LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_SPECIFIED_NAMESPACE.buildMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("operationsAndReservedContextNamespaces")
+  public void operation_ReservedContextNamespaceTargetingItself_ShouldThrow(
+      Op op, String reservedNamespace) {
+    // Even when the context namespace itself is a reserved name, accessing that reserved ScalarDB
+    // namespace must be rejected; the deny list is always applied.
+    NamespaceRestrictedMutableDatabase database =
+        new NamespaceRestrictedMutableDatabase(delegate, reservedNamespace);
+    assertThatThrownBy(() -> run(database, op, reservedNamespace))
+        .isInstanceOf(InvalidFunctionException.class)
+        .hasMessage(
+            LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_SPECIFIED_NAMESPACE.buildMessage());
+  }
+
+  @ParameterizedTest
+  @EnumSource(Op.class)
+  public void operation_NonDefaultContextWithDifferentCase_ShouldThrow(Op op) {
+    // The same-name check is case-sensitive, mirroring NamespaceRestrictedAssetLedger.
+    String differentCase = CONTEXT_NAMESPACE.toUpperCase();
+    assertThatThrownBy(() -> run(restrictedDatabase, op, differentCase))
+        .isInstanceOf(InvalidFunctionException.class)
+        .hasMessage(
+            LedgerError.FUNCTION_IS_NOT_ALLOWED_TO_ACCESS_DIFFERENT_NAMESPACE.buildMessage(
+                differentCase, CONTEXT_NAMESPACE));
+  }
+
+  // ---- helpers ----
+
+  private void run(NamespaceRestrictedMutableDatabase database, Op op, String namespace) {
+    switch (op) {
+      case GET:
+        database.get(get(namespace));
+        return;
+      case SCAN:
+        database.scan(scan(namespace));
+        return;
+      case PUT:
+        database.put(put(namespace));
+        return;
+      case DELETE:
+        database.delete(delete(namespace));
+        return;
+      default:
+        throw new AssertionError("unexpected op: " + op);
+    }
+  }
+
+  private void verifyDelegated(Op op, String namespace) {
+    switch (op) {
+      case GET:
+        verify(delegate).get(get(namespace));
+        return;
+      case SCAN:
+        verify(delegate).scan(scan(namespace));
+        return;
+      case PUT:
+        verify(delegate).put(put(namespace));
+        return;
+      case DELETE:
+        verify(delegate).delete(delete(namespace));
+        return;
+      default:
+        throw new AssertionError("unexpected op: " + op);
+    }
+  }
+
+  private Get get(String namespace) {
+    return namespace == null
+        ? Get.newBuilder().table(TABLE).partitionKey(PARTITION_KEY).build()
+        : Get.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+  }
+
+  private Scan scan(String namespace) {
+    return namespace == null
+        ? Scan.newBuilder().table(TABLE).partitionKey(PARTITION_KEY).build()
+        : Scan.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+  }
+
+  private Put put(String namespace) {
+    return namespace == null
+        ? Put.newBuilder().table(TABLE).partitionKey(PARTITION_KEY).build()
+        : Put.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+  }
+
+  private Delete delete(String namespace) {
+    return namespace == null
+        ? Delete.newBuilder().table(TABLE).partitionKey(PARTITION_KEY).build()
+        : Delete.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+  }
+}

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarMutableDatabaseTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/ScalarMutableDatabaseTest.java
@@ -1,27 +1,28 @@
 package com.scalar.dl.ledger.database.scalardb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.db.api.Delete;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.Get;
 import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.io.Key;
-import com.scalar.dl.ledger.exception.InvalidFunctionException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class ScalarMutableDatabaseTest {
+  private static final String NAMESPACE = "my_namespace";
   private static final String TABLE = "table";
   private static final Key PARTITION_KEY = Key.ofText("col", "val");
 
@@ -34,134 +35,63 @@ public class ScalarMutableDatabaseTest {
     database = new ScalarMutableDatabase(transaction);
   }
 
-  static Stream<String> disallowedNamespaces() {
-    return Stream.of(
-        // Exact match namespaces
-        "system",
-        "system_schema",
-        "system_auth",
-        "system_distributed",
-        "system_traces",
-        "coordinator",
-        // Prefix match: scalar
-        "scalar",
-        "scalar_my_namespace",
-        // Prefix match: auditor
-        "auditor",
-        "auditor_my_namespace",
-        // Case insensitive
-        "SYSTEM",
-        "Coordinator",
-        "SCALAR",
-        "Scalar_Namespace",
-        "AUDITOR",
-        "Auditor_Namespace");
-  }
-
-  static Stream<String> allowedNamespaces() {
-    return Stream.of("my_namespace", "app_data", "user_table");
-  }
-
-  @ParameterizedTest
-  @MethodSource("disallowedNamespaces")
-  public void get_DisallowedNamespaceGiven_ShouldThrowInvalidFunctionException(String namespace) {
+  @Test
+  public void get_ShouldDelegateToTransaction() throws Exception {
     // Arrange
     Get get =
-        Get.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+        Get.newBuilder().namespace(NAMESPACE).table(TABLE).partitionKey(PARTITION_KEY).build();
+    Result result = mock(Result.class);
+    when(transaction.get(get)).thenReturn(Optional.of(result));
 
-    // Act Assert
-    assertThatThrownBy(() -> database.get(get)).isInstanceOf(InvalidFunctionException.class);
+    // Act
+    Optional<Result> actual = database.get(get);
+
+    // Assert
+    assertThat(actual).hasValue(result);
+    verify(transaction).get(get);
   }
 
-  @ParameterizedTest
-  @MethodSource("disallowedNamespaces")
-  public void scan_DisallowedNamespaceGiven_ShouldThrowInvalidFunctionException(String namespace) {
+  @Test
+  public void scan_ShouldDelegateToTransaction() throws Exception {
     // Arrange
     Scan scan =
-        Scan.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+        Scan.newBuilder().namespace(NAMESPACE).table(TABLE).partitionKey(PARTITION_KEY).build();
+    Result result = mock(Result.class);
+    when(transaction.scan(scan)).thenReturn(Collections.singletonList(result));
 
-    // Act Assert
-    assertThatThrownBy(() -> database.scan(scan)).isInstanceOf(InvalidFunctionException.class);
+    // Act
+    List<Result> actual = database.scan(scan);
+
+    // Assert
+    assertThat(actual).containsExactly(result);
+    verify(transaction).scan(scan);
   }
 
-  @ParameterizedTest
-  @MethodSource("disallowedNamespaces")
-  public void put_DisallowedNamespaceGiven_ShouldThrowInvalidFunctionException(String namespace) {
+  @Test
+  public void put_ShouldDelegateToTransactionWithImplicitPreReadEnabled() throws Exception {
     // Arrange
     Put put =
-        Put.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
+        Put.newBuilder().namespace(NAMESPACE).table(TABLE).partitionKey(PARTITION_KEY).build();
 
-    // Act Assert
-    assertThatThrownBy(() -> database.put(put)).isInstanceOf(InvalidFunctionException.class);
+    // Act
+    database.put(put);
+
+    // Assert
+    ArgumentCaptor<Put> captor = ArgumentCaptor.forClass(Put.class);
+    verify(transaction).put(captor.capture());
+    assertThat(captor.getValue().isImplicitPreReadEnabled()).isTrue();
   }
 
-  @ParameterizedTest
-  @MethodSource("disallowedNamespaces")
-  public void delete_DisallowedNamespaceGiven_ShouldThrowInvalidFunctionException(
-      String namespace) {
+  @Test
+  public void delete_ShouldDelegateToTransaction() throws Exception {
     // Arrange
     Delete delete =
-        Delete.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
-
-    // Act Assert
-    assertThatThrownBy(() -> database.delete(delete)).isInstanceOf(InvalidFunctionException.class);
-  }
-
-  @ParameterizedTest
-  @MethodSource("allowedNamespaces")
-  public void get_AllowedNamespaceGiven_ShouldNotThrow(String namespace) throws Exception {
-    // Arrange
-    Get get =
-        Get.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
-    when(transaction.get(get)).thenReturn(Optional.empty());
+        Delete.newBuilder().namespace(NAMESPACE).table(TABLE).partitionKey(PARTITION_KEY).build();
 
     // Act
-    Throwable thrown = catchThrowable(() -> database.get(get));
+    database.delete(delete);
 
     // Assert
-    assertThat(thrown).isNull();
-  }
-
-  @ParameterizedTest
-  @MethodSource("allowedNamespaces")
-  public void scan_AllowedNamespaceGiven_ShouldNotThrow(String namespace) throws Exception {
-    // Arrange
-    Scan scan =
-        Scan.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
-    when(transaction.scan(scan)).thenReturn(Collections.emptyList());
-
-    // Act
-    Throwable thrown = catchThrowable(() -> database.scan(scan));
-
-    // Assert
-    assertThat(thrown).isNull();
-  }
-
-  @ParameterizedTest
-  @MethodSource("allowedNamespaces")
-  public void put_AllowedNamespaceGiven_ShouldNotThrow(String namespace) throws Exception {
-    // Arrange
-    Put put =
-        Put.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
-
-    // Act
-    Throwable thrown = catchThrowable(() -> database.put(put));
-
-    // Assert
-    assertThat(thrown).isNull();
-  }
-
-  @ParameterizedTest
-  @MethodSource("allowedNamespaces")
-  public void delete_AllowedNamespaceGiven_ShouldNotThrow(String namespace) throws Exception {
-    // Arrange
-    Delete delete =
-        Delete.newBuilder().namespace(namespace).table(TABLE).partitionKey(PARTITION_KEY).build();
-
-    // Act
-    Throwable thrown = catchThrowable(() -> database.delete(delete));
-
-    // Assert
-    assertThat(thrown).isNull();
+    verify(transaction).delete(delete);
   }
 }

--- a/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerIntegrationTestBase.java
+++ b/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerIntegrationTestBase.java
@@ -278,7 +278,7 @@ public abstract class LedgerIntegrationTestBase {
   void truncateTables() throws Exception {
     storageAdmin.truncateTable(getPhysicalNamespace(), ASSET_TABLE);
     storageAdmin.truncateTable(getPhysicalNamespace(), ASSET_METADATA_TABLE);
-    transactionAdmin.truncateTable(FUNCTION_NAMESPACE, FUNCTION_TABLE);
+    transactionAdmin.truncateTable(getFunctionNamespace(), FUNCTION_TABLE);
   }
 
   @AfterAll
@@ -287,8 +287,8 @@ public abstract class LedgerIntegrationTestBase {
 
     if (transactionAdmin != null) {
       try {
-        transactionAdmin.dropTable(FUNCTION_NAMESPACE, FUNCTION_TABLE);
-        transactionAdmin.dropNamespace(FUNCTION_NAMESPACE);
+        transactionAdmin.dropTable(getFunctionNamespace(), FUNCTION_TABLE);
+        transactionAdmin.dropNamespace(getFunctionNamespace());
       } catch (Exception e) {
         logger.warn("Failed to drop function table", e);
       }
@@ -347,9 +347,22 @@ public abstract class LedgerIntegrationTestBase {
     SchemaLoader.load(props, TestSchemas.getLedgerSchema(), Collections.emptyMap(), true);
   }
 
+  /**
+   * Returns the ScalarDB namespace that functions access in these tests. Functions may only access
+   * the namespace with the same name as the context namespace, so this defaults to {@link
+   * com.scalar.dl.testing.schema.SchemaConstants#FUNCTION_NAMESPACE} for the default context and is
+   * overridden to the context namespace when running under a non-default context.
+   *
+   * @return the function namespace
+   */
+  protected String getFunctionNamespace() {
+    return FUNCTION_NAMESPACE;
+  }
+
   protected void createFunctionTableSchema() throws Exception {
-    transactionAdmin.createNamespace(FUNCTION_NAMESPACE, true);
-    transactionAdmin.createTable(FUNCTION_NAMESPACE, FUNCTION_TABLE, FUNCTION_TABLE_METADATA, true);
+    transactionAdmin.createNamespace(getFunctionNamespace(), true);
+    transactionAdmin.createTable(
+        getFunctionNamespace(), FUNCTION_TABLE, FUNCTION_TABLE_METADATA, true);
   }
 
   protected ClientConfig getDigitalSignatureClientConfig(
@@ -652,7 +665,7 @@ public abstract class LedgerIntegrationTestBase {
         Json.createObjectBuilder()
             .add(ID_ATTRIBUTE_NAME, SOME_ID_1)
             .add(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_1)
-            .add(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE)
+            .add(NAMESPACE_ATTRIBUTE_NAME, getFunctionNamespace())
             .build();
 
     // Act
@@ -662,7 +675,7 @@ public abstract class LedgerIntegrationTestBase {
     // Assert
     Get get =
         Get.newBuilder()
-            .namespace(FUNCTION_NAMESPACE)
+            .namespace(getFunctionNamespace())
             .table(FUNCTION_TABLE)
             .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, SOME_ID_1))
             .build();
@@ -684,7 +697,7 @@ public abstract class LedgerIntegrationTestBase {
         Json.createObjectBuilder()
             .add(ID_ATTRIBUTE_NAME, SOME_ID_1)
             .add(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_1)
-            .add(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE)
+            .add(NAMESPACE_ATTRIBUTE_NAME, getFunctionNamespace())
             .build();
 
     // Act
@@ -694,7 +707,7 @@ public abstract class LedgerIntegrationTestBase {
     // Assert
     Get get =
         Get.newBuilder()
-            .namespace(FUNCTION_NAMESPACE)
+            .namespace(getFunctionNamespace())
             .table(FUNCTION_TABLE)
             .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, SOME_ID_1))
             .build();
@@ -717,7 +730,7 @@ public abstract class LedgerIntegrationTestBase {
             .createObjectNode()
             .put(ID_ATTRIBUTE_NAME, SOME_ID_1)
             .put(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_1)
-            .put(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE);
+            .put(NAMESPACE_ATTRIBUTE_NAME, getFunctionNamespace());
 
     // Act
     clientServiceA.executeContract(
@@ -726,7 +739,7 @@ public abstract class LedgerIntegrationTestBase {
     // Assert
     Get get =
         Get.newBuilder()
-            .namespace(FUNCTION_NAMESPACE)
+            .namespace(getFunctionNamespace())
             .table(FUNCTION_TABLE)
             .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, SOME_ID_1))
             .build();
@@ -740,7 +753,7 @@ public abstract class LedgerIntegrationTestBase {
       throws Exception {
     // Arrange
     String contractArgument = SOME_ASSET_ID_1 + "," + SOME_AMOUNT_1;
-    String functionArgument = SOME_ID_1 + "," + SOME_AMOUNT_1 + "," + FUNCTION_NAMESPACE;
+    String functionArgument = SOME_ID_1 + "," + SOME_AMOUNT_1 + "," + getFunctionNamespace();
 
     // Act
     clientServiceA.executeContract(
@@ -749,7 +762,7 @@ public abstract class LedgerIntegrationTestBase {
     // Assert
     Get get =
         Get.newBuilder()
-            .namespace(FUNCTION_NAMESPACE)
+            .namespace(getFunctionNamespace())
             .table(FUNCTION_TABLE)
             .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, SOME_ID_1))
             .build();
@@ -797,13 +810,13 @@ public abstract class LedgerIntegrationTestBase {
             .createObjectNode()
             .put(ID_ATTRIBUTE_NAME, SOME_ID_1)
             .put(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_1)
-            .put(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE);
+            .put(NAMESPACE_ATTRIBUTE_NAME, getFunctionNamespace());
     JsonNode functionArgument2 =
         mapper
             .createObjectNode()
             .put(ID_ATTRIBUTE_NAME, SOME_ID_1)
             .put(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_2)
-            .put(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE);
+            .put(NAMESPACE_ATTRIBUTE_NAME, getFunctionNamespace());
 
     // Act
     clientServiceA.executeContract(
@@ -814,7 +827,7 @@ public abstract class LedgerIntegrationTestBase {
     // Assert
     Get get =
         Get.newBuilder()
-            .namespace(FUNCTION_NAMESPACE)
+            .namespace(getFunctionNamespace())
             .table(FUNCTION_TABLE)
             .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, SOME_ID_1))
             .build();

--- a/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerOnlyContextNamespaceIntegrationTestBase.java
+++ b/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerOnlyContextNamespaceIntegrationTestBase.java
@@ -1,16 +1,37 @@
 package com.scalar.dl.testing.testcase;
 
+import static com.scalar.dl.testing.contract.Constants.AMOUNT_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.ASSET_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.BALANCE_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.CREATE_CONTRACT_ID1;
+import static com.scalar.dl.testing.contract.Constants.CREATE_FUNCTION_ID1;
+import static com.scalar.dl.testing.contract.Constants.ID_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.NAMESPACE_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.schema.SchemaConstants.FUNCTION_NAMESPACE;
+import static com.scalar.dl.testing.schema.SchemaConstants.FUNCTION_TABLE;
+import static com.scalar.dl.testing.schema.SchemaConstants.FUNCTION_TABLE_METADATA;
 import static com.scalar.dl.testing.schema.SchemaConstants.SCALAR_NAMESPACE;
 import static com.scalar.dl.testing.schema.SchemaConstants.resolveNamespace;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Result;
+import com.scalar.db.io.Key;
+import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.ClientService;
 import com.scalar.dl.ledger.config.AuthenticationMethod;
 import com.scalar.dl.ledger.namespace.Namespaces;
+import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.testing.container.LedgerTestCluster;
 import com.scalar.dl.testing.util.TestCertificates;
 import java.io.IOException;
+import java.util.Optional;
+import javax.json.Json;
+import javax.json.JsonObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base class for running all {@link LedgerOnlyIntegrationTestBase} tests (including Function tests)
@@ -46,6 +67,9 @@ public abstract class LedgerOnlyContextNamespaceIntegrationTestBase
     extends LedgerOnlyIntegrationTestBase {
 
   protected static final String TEST_NAMESPACE = "context_test";
+  // A namespace prefixed by the context namespace (with the separator). Functions in the context
+  // namespace are allowed to access it under prefix-based access control.
+  protected static final String PREFIXED_FUNCTION_NAMESPACE = TEST_NAMESPACE + "_sub";
 
   // Admin ClientService (default namespace, for privileged operations)
   protected ClientService adminClientService;
@@ -58,6 +82,25 @@ public abstract class LedgerOnlyContextNamespaceIntegrationTestBase
   @Override
   protected String getContextNamespace() {
     return TEST_NAMESPACE;
+  }
+
+  /**
+   * In a non-default context, functions may only access the ScalarDB namespace with the same name
+   * as the context namespace. The inherited function tests therefore operate on the context
+   * namespace instead of the default {@code FUNCTION_NAMESPACE}.
+   */
+  @Override
+  protected String getFunctionNamespace() {
+    return TEST_NAMESPACE;
+  }
+
+  @Override
+  protected void createFunctionTableSchema() throws Exception {
+    super.createFunctionTableSchema();
+    // Also create a namespace prefixed by the context namespace to verify prefix-based access.
+    transactionAdmin.createNamespace(PREFIXED_FUNCTION_NAMESPACE, true);
+    transactionAdmin.createTable(
+        PREFIXED_FUNCTION_NAMESPACE, FUNCTION_TABLE, FUNCTION_TABLE_METADATA, true);
   }
 
   @BeforeAll
@@ -146,10 +189,82 @@ public abstract class LedgerOnlyContextNamespaceIntegrationTestBase
     }
   }
 
+  @Test
+  void executeContract_FunctionAccessingNamespacePrefixedByContextNamespace_ShouldSucceed()
+      throws Exception {
+    // Arrange: the function writes to a namespace whose name is prefixed by the context namespace
+    // (context_test -> context_test_sub), which is allowed under prefix-based access control.
+    String id = "prefixed_id";
+    JsonObject contractArgument =
+        Json.createObjectBuilder()
+            .add(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_1)
+            .add(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1)
+            .build();
+    JsonObject functionArgument =
+        Json.createObjectBuilder()
+            .add(ID_ATTRIBUTE_NAME, id)
+            .add(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_1)
+            .add(NAMESPACE_ATTRIBUTE_NAME, PREFIXED_FUNCTION_NAMESPACE)
+            .build();
+
+    // Act
+    clientServiceA.executeContract(
+        CREATE_CONTRACT_ID1, contractArgument, CREATE_FUNCTION_ID1, functionArgument);
+
+    // Assert
+    Get get =
+        Get.newBuilder()
+            .namespace(PREFIXED_FUNCTION_NAMESPACE)
+            .table(FUNCTION_TABLE)
+            .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, id))
+            .build();
+    Optional<Result> result = storage.get(get);
+    assertThat(result).isPresent();
+    assertThat(result.get().getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT_1);
+  }
+
+  @Test
+  void executeContract_FunctionAccessingNamespaceOtherThanContextNamespace_ShouldThrowException() {
+    // Arrange: the function tries to access FUNCTION_NAMESPACE, which differs from the context
+    // namespace. A function registered in a non-default namespace may only access the ScalarDB
+    // namespace with the same name as its context namespace, so this must be rejected.
+    JsonObject contractArgument =
+        Json.createObjectBuilder()
+            .add(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID_1)
+            .add(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT_1)
+            .build();
+    JsonObject functionArgument =
+        Json.createObjectBuilder()
+            .add(ID_ATTRIBUTE_NAME, "id1")
+            .add(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT_1)
+            .add(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE)
+            .build();
+
+    // Act & Assert
+    assertThatThrownBy(
+            () ->
+                clientServiceA.executeContract(
+                    CREATE_CONTRACT_ID1, contractArgument, CREATE_FUNCTION_ID1, functionArgument))
+        .isInstanceOfSatisfying(
+            ClientException.class,
+            e -> assertThat(e.getStatusCode()).isEqualTo(StatusCode.INVALID_FUNCTION));
+  }
+
   @AfterAll
   @Override
   void tearDownCluster() {
     logger.info("Tearing down context namespace cluster");
+
+    // Drop the prefixed function namespace created for prefix-access tests. This must run before
+    // super.tearDownCluster() closes transactionAdmin.
+    if (transactionAdmin != null) {
+      try {
+        transactionAdmin.dropTable(PREFIXED_FUNCTION_NAMESPACE, FUNCTION_TABLE);
+        transactionAdmin.dropNamespace(PREFIXED_FUNCTION_NAMESPACE);
+      } catch (Exception e) {
+        logger.warn("Failed to drop prefixed function namespace", e);
+      }
+    }
 
     // Drop the test namespace (this also removes the namespace's asset tables)
     if (adminClientService != null) {


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/570
- **Commit to backport:** 6f700823f55a890f902798c112e7cbca7f89e1e1

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-570 &&
git cherry-pick --no-rerere-autoupdate -m1 6f700823f55a890f902798c112e7cbca7f89e1e1
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!