### PR TITLE
Bump ScalarDB to 3.15.8 and switch to MariaDB Connector/J for testing

### DIFF
--- a/.github/workflows/scalar.yml
+++ b/.github/workflows/scalar.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           cd ledger
           java -cp "build/test-libs/*:build/libs/*:build/classes/java/integrationTest" org.junit.platform.console.ConsoleLauncher execute -c=com.scalar.dl.ledger.service.LedgerServiceIntegrationTest
-          java -cp "build/test-libs/*:build/libs/*:build/classes/java/integrationTest" -Dscalardb.storage=jdbc -Dscalardb.contact_points=jdbc:mysql://localhost/ -Dscalardb.username=root -Dscalardb.password=mysql org.junit.platform.console.ConsoleLauncher execute -c=com.scalar.dl.ledger.service.LedgerServiceEndToEndTest
+          java -cp "build/test-libs/*:build/libs/*:build/classes/java/integrationTest" -Dscalardb.storage=jdbc -Dscalardb.contact_points=jdbc:mysql://localhost/?sslMode=REQUIRED -Dscalardb.username=root -Dscalardb.password=mysql org.junit.platform.console.ConsoleLauncher execute -c=com.scalar.dl.ledger.service.LedgerServiceEndToEndTest
 
   ledger-service-integration-test-with-mysql-jdbc-transaction:
     name: Ledger service integration test with JDBC transaction manager on MySQL
@@ -120,7 +120,7 @@ jobs:
       - name: Run integration tests
         run: |
           cd ledger
-          java -cp "build/test-libs/*:build/libs/*:build/classes/java/integrationTest" -Dscalardb.storage=jdbc -Dscalardb.contact_points=jdbc:mysql://localhost/ -Dscalardb.username=root -Dscalardb.password=mysql -Dscalardb.transaction_manager=jdbc org.junit.platform.console.ConsoleLauncher execute -c=com.scalar.dl.ledger.service.LedgerServiceEndToEndTest
+          java -cp "build/test-libs/*:build/libs/*:build/classes/java/integrationTest" -Dscalardb.storage=jdbc -Dscalardb.contact_points=jdbc:mysql://localhost/?sslMode=REQUIRED -Dscalardb.username=root -Dscalardb.password=mysql -Dscalardb.transaction_manager=jdbc org.junit.platform.console.ConsoleLauncher execute -c=com.scalar.dl.ledger.service.LedgerServiceEndToEndTest
 
   e2e-integration-test-for-ledger:
     name: End-to-end integration test for Ledger
@@ -176,7 +176,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Run integration tests
-        run:  ./gradlew :generic-contracts:integrationTest
+        run:  ./gradlew :generic-contracts:integrationTest -Dscalardb.contact_points=jdbc:mysql://localhost/?sslMode=REQUIRED
 
       - name: Upload Gradle test reports
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
         jsonpVersion = '1.1.4'
         jacksonVersion = '2.21.4'
         toml4jVersion = '0.7.2'
-        scalarDbVersion = '3.15.6'
+        scalarDbVersion = '3.15.8'
         scalarAdminVersion = '2.2.1'
         resilience4jRetryVersion = '1.7.1'
         dropwizardMetricsVersion = '4.2.32'

--- a/ledger/build.gradle
+++ b/ledger/build.gradle
@@ -139,7 +139,7 @@ task integrationTestMysql(type: Test) {
     shouldRunAfter test
     options {
         systemProperty('scalardb.storage', 'jdbc')
-        systemProperty('scalardb.contact_points', 'jdbc:mysql://localhost/')
+        systemProperty('scalardb.contact_points', 'jdbc:mysql://localhost/?sslMode=REQUIRED')
         systemProperty('scalardb.username', 'root')
         systemProperty('scalardb.password', 'mysql')
         systemProperty('scalardb.transaction_manager', 'jdbc')

--- a/testing/src/main/java/com/scalar/dl/testing/container/AbstractTestCluster.java
+++ b/testing/src/main/java/com/scalar/dl/testing/container/AbstractTestCluster.java
@@ -114,11 +114,16 @@ public abstract class AbstractTestCluster implements AutoCloseable {
       case "jdbc":
         logger.info("Starting MySQL container");
         mysqlContainer =
-            new MySQLContainer(MYSQL_IMAGE)
-                .withNetwork(network)
+            new MySQLContainer(MYSQL_IMAGE) {
+              @Override
+              public String getDriverClassName() {
+                return "org.mariadb.jdbc.Driver";
+              }
+            }.withNetwork(network)
                 .withNetworkAliases(MYSQL_NETWORK_ALIAS)
                 .withUsername("root")
                 .withPassword("mysql")
+                .withUrlParam("permitMysqlScheme", "true")
                 .withLogConsumer(new Slf4jLogConsumer(logger).withPrefix("mysql"));
         mysqlContainer.start();
         logger.info(


### PR DESCRIPTION
## Description

This PR bumps ScalarDB to 3.15.8 to replace MySQL Connector/J with MariaDB Connector/J due to licensing concerns. (Backport of #609)

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/3428

## Changes made

- Bump ScalarDB to 3.15.8 and switch to MariaDB Connector/J for testing.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Upgraded ScalarDB version to 3.15.8 to replace MySQL Connector/J with MariaDB Connector/J.