### PR TITLE
Fix database reconnection during contract execution under the SecurityManager

### DIFF
--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/Privileged.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/Privileged.java
@@ -1,0 +1,88 @@
+package com.scalar.dl.ledger.database.scalardb;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudException;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * Runs a ScalarDB CRUD operation in a privileged block, so that a contract's restricted {@code
+ * ProtectionDomain} on the current stack is excluded from JVM-level permission checks (properties,
+ * ServiceLoader, sockets) performed by the underlying database driver and connection pool during
+ * connection setup.
+ *
+ * <p>Without this, a database access issued from within a contract (or a function) fails under the
+ * SecurityManager whenever it needs to establish a new physical connection (e.g., after a
+ * server-side idle timeout, a database restart, or a network interruption), because the driver's
+ * connection housekeeping is checked against the contract's restricted {@code ProtectionDomain} on
+ * the stack. Wrapping only the ScalarDB call in a privileged block cuts the permission-check stack
+ * walk at the framework frame while the contract code itself remains restricted.
+ *
+ * <p>Only ScalarDB CRUD operations may be passed here — never contract-derived code or callbacks.
+ * The functional interfaces below are intentionally narrow (tied to ScalarDB's exception
+ * signatures) so contract lambdas cannot be smuggled in. Also, keep the construction of operation
+ * objects (e.g., {@code Get}, {@code Scan}) and the exception translation outside the privileged
+ * block so that contract-derived data is not processed on a privileged frame.
+ *
+ * <p>Every ScalarDB call that is synchronously reachable from {@code Contract.invoke()} or {@code
+ * Function.invoke()} must go through here. That includes the obvious direct reads and writes on the
+ * ledger, and also the less obvious reads that fire on cache miss during nested contract invocation
+ * (looking up the callee contract, its signing certificate, or its HMAC secret) and the read that
+ * fires on every function invocation (since {@code FunctionManager} has no cache). Framework paths
+ * that run before {@code invoke()} or after it returns (registration, commit/abort, validation,
+ * background workers) do not need wrapping.
+ */
+public final class Privileged {
+  private Privileged() {}
+
+  /** A CRUD operation on a {@code DistributedTransaction}. */
+  @FunctionalInterface
+  public interface TransactionCrud<T> {
+    T call() throws CrudException;
+  }
+
+  /**
+   * A CRUD operation on a {@code DistributedStorage}, including {@code Scanner} iteration. An
+   * {@code IOException} from closing a {@code Scanner} should be handled inside the operation
+   * (e.g., logged), following the existing convention of the call sites.
+   */
+  @FunctionalInterface
+  public interface StorageCrud<T> {
+    T call() throws ExecutionException;
+  }
+
+  /**
+   * Runs the given {@code DistributedTransaction} CRUD operation in a privileged block.
+   *
+   * @param operation a CRUD operation on a {@code DistributedTransaction}
+   * @param <T> the result type
+   * @return the result of the operation
+   * @throws CrudException if the operation fails
+   */
+  public static <T> T transactionCrud(TransactionCrud<T> operation) throws CrudException {
+    try {
+      return AccessController.doPrivileged((PrivilegedExceptionAction<T>) operation::call);
+    } catch (PrivilegedActionException e) {
+      // TransactionCrud declares only CrudException, so the cause is always one.
+      throw (CrudException) e.getCause();
+    }
+  }
+
+  /**
+   * Runs the given {@code DistributedStorage} CRUD operation in a privileged block.
+   *
+   * @param operation a CRUD operation on a {@code DistributedStorage}
+   * @param <T> the result type
+   * @return the result of the operation
+   * @throws ExecutionException if the operation fails
+   */
+  public static <T> T storageCrud(StorageCrud<T> operation) throws ExecutionException {
+    try {
+      return AccessController.doPrivileged((PrivilegedExceptionAction<T>) operation::call);
+    } catch (PrivilegedActionException e) {
+      // StorageCrud declares only ExecutionException, so the cause is always one.
+      throw (ExecutionException) e.getCause();
+    }
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/Privileged.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/Privileged.java
@@ -30,8 +30,11 @@ import java.security.PrivilegedExceptionAction;
  * ledger, and also the less obvious reads that fire on cache miss during nested contract invocation
  * (looking up the callee contract, its signing certificate, or its HMAC secret) and the read that
  * fires on every function invocation (since {@code FunctionManager} has no cache). Framework paths
- * that run before {@code invoke()} or after it returns (registration, commit/abort, validation,
- * background workers) do not need wrapping.
+ * where no contract or function is on the stack (registration, execution-path commit/abort,
+ * recovery, background workers) do not need wrapping. The one exception is the commit in {@code
+ * TransactionAssetScanner}, which the validation path runs from within {@code contract.invoke()}:
+ * it is left unwrapped because it immediately follows a privileged scan on the same connection
+ * pool.
  */
 public final class Privileged {
   private Privileged() {}

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/Privileged.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/Privileged.java
@@ -46,9 +46,16 @@ public final class Privileged {
   }
 
   /**
-   * A CRUD operation on a {@code DistributedStorage}, including {@code Scanner} iteration. An
-   * {@code IOException} from closing a {@code Scanner} should be handled inside the operation
-   * (e.g., logged), following the existing convention of the call sites.
+   * A CRUD operation on a {@code DistributedStorage}. When scanning, wrap the {@code scan} and each
+   * fetch from the lazy {@code Scanner} separately instead of wrapping the whole iteration, so that
+   * the processing of the fetched records stays outside the privileged blocks while still fetching
+   * them one at a time.
+   *
+   * <p>This per-fetch style is specific to the privileged call sites; the others still iterate a
+   * {@code Scanner} as an {@code Iterable}. The two also differ in how a failure in the middle of a
+   * scan surfaces: the iterator wraps it in an unchecked exception, while {@code one()} reports the
+   * {@code ExecutionException} that the call site can translate into its own error. Unifying the
+   * styles is out of the scope of this class, but worth revisiting.
    */
   @FunctionalInterface
   public interface StorageCrud<T> {

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarCertificateRegistry.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarCertificateRegistry.java
@@ -100,9 +100,11 @@ public class ScalarCertificateRegistry implements CertificateRegistry, TableMeta
 
     Result result;
     try {
+      // Reached during contract execution when a contract invokes another contract (nested
+      // invocation) and the signature validator is not cached, so this read runs in the
+      // contract's restricted ProtectionDomain; see the Privileged class for details.
       result =
-          storage
-              .get(get)
+          Privileged.storageCrud(() -> storage.get(get))
               .orElseThrow(
                   () -> new MissingCertificateException(CommonError.CERTIFICATE_NOT_FOUND));
     } catch (ExecutionException e) {

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarContractRegistry.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarContractRegistry.java
@@ -219,8 +219,10 @@ public class ScalarContractRegistry implements ContractRegistry, TableMetadataPr
 
   private Result get(Get get) {
     try {
-      return storage
-          .get(get)
+      // Reached during contract execution when a contract invokes another contract (nested
+      // invocation) and the entry is not cached, so this read runs in the contract's restricted
+      // ProtectionDomain; see the Privileged class for details.
+      return Privileged.storageCrud(() -> storage.get(get))
           .orElseThrow(() -> new MissingContractException(CommonError.CONTRACT_NOT_FOUND));
     } catch (ExecutionException e) {
       throw new DatabaseException(CommonError.GETTING_CONTRACT_FAILED, e, e.getMessage());

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarFunctionRegistry.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarFunctionRegistry.java
@@ -96,7 +96,10 @@ public class ScalarFunctionRegistry implements FunctionRegistry, TableMetadataPr
             .forTable(FUNCTION_TABLE);
 
     try {
-      return storage.get(get).map(this::toFunctionEntry);
+      // Reached on every function invocation during contract execution (FunctionManager has no
+      // cache), so this read runs in the contract's restricted ProtectionDomain; see the Privileged
+      // class for details.
+      return Privileged.storageCrud(() -> storage.get(get)).map(this::toFunctionEntry);
     } catch (ExecutionException e) {
       throw new DatabaseException(LedgerError.GETTING_FUNCTION_FAILED, e, e.getMessage());
     }

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarMutableDatabase.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarMutableDatabase.java
@@ -27,6 +27,9 @@ import java.util.Optional;
  * namespace access control. The constructor is intentionally package-private so that instances can
  * only be created from within this package (in practice, by {@link ScalarTransactionManager}),
  * keeping the wrapping requirement contained to this package.
+ *
+ * <p>Every operation on this class is invoked from within function execution, so its ScalarDB calls
+ * are executed in a privileged block. See {@link Privileged} for details.
  */
 public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, Delete, Result> {
   private final DistributedTransaction transaction;
@@ -38,7 +41,7 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
   @Override
   public Optional<Result> get(Get get) {
     try {
-      return transaction.get(get);
+      return Privileged.transactionCrud(() -> transaction.get(get));
     } catch (IllegalArgumentException e) {
       throw new InvalidFunctionException(
           LedgerError.OPERATION_FAILED_DUE_TO_ILLEGAL_ARGUMENT, e, e.getMessage());
@@ -53,7 +56,7 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
   @Override
   public List<Result> scan(Scan scan) {
     try {
-      return transaction.scan(scan);
+      return Privileged.transactionCrud(() -> transaction.scan(scan));
     } catch (IllegalArgumentException e) {
       throw new InvalidFunctionException(
           LedgerError.OPERATION_FAILED_DUE_TO_ILLEGAL_ARGUMENT, e, e.getMessage());
@@ -69,7 +72,12 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
   public void put(Put put) {
     try {
       // Make put() consistent with Ledger's put(), which always pre-read implicitly.
-      transaction.put(Put.newBuilder(put).implicitPreReadEnabled(true).build());
+      Put withImplicitPreRead = Put.newBuilder(put).implicitPreReadEnabled(true).build();
+      Privileged.transactionCrud(
+          () -> {
+            transaction.put(withImplicitPreRead);
+            return null;
+          });
     } catch (IllegalArgumentException e) {
       throw new InvalidFunctionException(
           LedgerError.OPERATION_FAILED_DUE_TO_ILLEGAL_ARGUMENT, e, e.getMessage());
@@ -84,7 +92,11 @@ public class ScalarMutableDatabase implements MutableDatabase<Get, Scan, Put, De
   @Override
   public void delete(Delete delete) {
     try {
-      transaction.delete(delete);
+      Privileged.transactionCrud(
+          () -> {
+            transaction.delete(delete);
+            return null;
+          });
     } catch (IllegalArgumentException e) {
       throw new InvalidFunctionException(
           LedgerError.OPERATION_FAILED_DUE_TO_ILLEGAL_ARGUMENT, e, e.getMessage());

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarSecretRegistry.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarSecretRegistry.java
@@ -108,9 +108,11 @@ public class ScalarSecretRegistry implements SecretRegistry, TableMetadataProvid
 
     Result result;
     try {
+      // Reached during contract execution when a contract invokes another contract (nested
+      // invocation) and the signature validator is not cached, so this read runs in the
+      // contract's restricted ProtectionDomain; see the Privileged class for details.
       result =
-          storage
-              .get(get)
+          Privileged.storageCrud(() -> storage.get(get))
               .orElseThrow(() -> new MissingSecretException(CommonError.SECRET_NOT_FOUND));
     } catch (ExecutionException e) {
       throw new DatabaseException(CommonError.GETTING_SECRET_KEY_FAILED, e, e.getMessage());

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
@@ -51,6 +51,16 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
+/**
+ * A {@link TamperEvidentAssetLedger} implementation backed by a ScalarDB {@link
+ * DistributedTransaction}.
+ *
+ * <p>Read operations invoked from within contract execution ({@link #get}, {@link #scan}, and the
+ * internal helpers they use) execute their ScalarDB calls in a privileged block; see {@link
+ * Privileged} for details. Writes are buffered on the snapshot and flushed by {@link #commit()},
+ * which runs after {@code contract.invoke()} has returned and therefore does not need a privileged
+ * block.
+ */
 @ThreadSafe
 public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger {
   static final String TABLE = "asset";
@@ -292,7 +302,7 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
                   new Key(AssetAttribute.toAgeValue(age)))
               .forNamespace(namespaceResolver.resolve(namespace))
               .forTable(TABLE);
-      return transaction.get(get);
+      return Privileged.transactionCrud(() -> transaction.get(get));
     } catch (CrudConflictException e) {
       throw new ConflictException(
           LedgerError.RETRIEVING_ASSET_FAILED_DUE_TO_CONFLICT, e, e.getMessage());
@@ -309,7 +319,7 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
               .withLimit(1)
               .forNamespace(namespaceResolver.resolve(namespace))
               .forTable(TABLE);
-      List<Result> results = transaction.scan(scan);
+      List<Result> results = Privileged.transactionCrud(() -> transaction.scan(scan));
       if (results.isEmpty()) {
         return Optional.empty();
       }
@@ -324,7 +334,7 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
 
   private List<Result> scan(Scan scan) {
     try {
-      return transaction.scan(scan);
+      return Privileged.transactionCrud(() -> transaction.scan(scan));
     } catch (CrudConflictException e) {
       throw new ConflictException(
           LedgerError.RETRIEVING_ASSET_FAILED_DUE_TO_CONFLICT, e, e.getMessage());
@@ -401,7 +411,7 @@ public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger 
 
       Optional<Result> result;
       try {
-        result = transaction.get(get);
+        result = Privileged.transactionCrud(() -> transaction.get(get));
       } catch (CrudConflictException e) {
         throw new ConflictException(
             LedgerError.RETRIEVING_ASSET_METADATA_FAILED_DUE_TO_CONFLICT, e, e.getMessage());

--- a/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/database/scalardb/ScalarTamperEvidentAssetLedger.java
@@ -58,8 +58,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>Read operations invoked from within contract execution ({@link #get}, {@link #scan}, and the
  * internal helpers they use) execute their ScalarDB calls in a privileged block; see {@link
  * Privileged} for details. Writes are buffered on the snapshot and flushed by {@link #commit()},
- * which runs after {@code contract.invoke()} has returned and therefore does not need a privileged
- * block.
+ * which does not need a privileged block; see {@link Privileged} for the one path that commits from
+ * within a contract.
  */
 @ThreadSafe
 public class ScalarTamperEvidentAssetLedger implements TamperEvidentAssetLedger {

--- a/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerModule.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/service/LedgerModule.java
@@ -47,13 +47,10 @@ import com.scalar.dl.ledger.database.scalardb.TransactionStateManager;
 import com.scalar.dl.ledger.function.FunctionLoader;
 import com.scalar.dl.ledger.function.FunctionManager;
 import com.scalar.dl.ledger.namespace.NamespaceManager;
-import java.net.SocketPermission;
 import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.security.ProtectionDomain;
-import java.sql.SQLPermission;
 import java.util.Base64;
-import java.util.PropertyPermission;
 import javax.annotation.Nullable;
 
 public class LedgerModule extends AbstractModule {
@@ -196,29 +193,23 @@ public class LedgerModule extends AbstractModule {
     }
   }
 
+  /**
+   * Returns the {@code ProtectionDomain} that sandboxes contracts and functions. Their classes are
+   * defined with this domain (see {@code ContractLoader} and {@code FunctionLoader}). Since the
+   * domain is constructed directly with the permission collection below, the policy file is not
+   * consulted for it.
+   *
+   * @return the {@code ProtectionDomain} for contracts and functions
+   */
   public static ProtectionDomain getProtectionDomain() {
     // (null, null) means that it denies all if java.security.manager is enabled
     PermissionCollection permissionCollection = new Permissions();
     permissionCollection.add(new RuntimePermission("createClassLoader"));
-    // For ScalarDB on Cosmos DB
-    permissionCollection.add(new RuntimePermission("getenv.*"));
-    permissionCollection.add(new PropertyPermission("log4j2.flowMessageFactory", "read"));
-    permissionCollection.add(new PropertyPermission("org.jooq.settings", "read"));
-    permissionCollection.add(new PropertyPermission("org.jooq.no-logo", "read"));
-    permissionCollection.add(new PropertyPermission("COSMOS.*", "read"));
-    permissionCollection.add(new PropertyPermission("line.separator", "read"));
-    // For ScalarDB on DynamoDB
-    permissionCollection.add(new PropertyPermission("aws.executionEnvironment", "read"));
-    permissionCollection.add(new PropertyPermission("com.amazonaws.xray.traceHeader", "read"));
-    // These permissions are required by ScalarDB on DynamoDB, Cloud Storage, and JDBC databases.
-    // They are set regardless of the storage type so that multi-storage configurations and storages
-    // added in the future are handled without changes here.
-    permissionCollection.add(new SocketPermission("*", "connect,resolve"));
-    // The PostgreSQL JDBC driver reads this property to decide SOCKS proxy resolution.
-    permissionCollection.add(new PropertyPermission("socksProxyHost", "read"));
-    // HikariCP calls these methods when validating/closing connections.
-    permissionCollection.add(new SQLPermission("setNetworkTimeout"));
-    permissionCollection.add(new SQLPermission("callAbort"));
+    // Note that no storage-specific permission is granted here. Database accesses issued from
+    // within contracts are executed in a privileged block on the framework side (see
+    // com.scalar.dl.ledger.database.scalardb.Privileged), so the storage drivers' housekeeping
+    // (property and environment variable reads, ServiceLoader, socket connections) does not
+    // require permissions in this domain.
     return new ProtectionDomain(null, permissionCollection);
   }
 }

--- a/ledger/src/permission-test/java/com/scalar/dl/ledger/service/BadNetworkContract.java
+++ b/ledger/src/permission-test/java/com/scalar/dl/ledger/service/BadNetworkContract.java
@@ -1,0 +1,22 @@
+package com.scalar.dl.ledger.service;
+
+import com.scalar.dl.ledger.contract.Contract;
+import com.scalar.dl.ledger.database.Ledger;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.Socket;
+import java.util.Optional;
+import javax.json.Json;
+import javax.json.JsonObject;
+
+public class BadNetworkContract extends Contract {
+
+  @Override
+  public JsonObject invoke(Ledger ledger, JsonObject argument, Optional<JsonObject> properties) {
+    try (Socket socket = new Socket("localhost", 12345)) {
+      return Json.createObjectBuilder().add("connected", socket.isConnected()).build();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/ledger/src/permission-test/java/com/scalar/dl/ledger/service/BadPropertyContract.java
+++ b/ledger/src/permission-test/java/com/scalar/dl/ledger/service/BadPropertyContract.java
@@ -1,0 +1,15 @@
+package com.scalar.dl.ledger.service;
+
+import com.scalar.dl.ledger.contract.Contract;
+import com.scalar.dl.ledger.database.Ledger;
+import java.util.Optional;
+import javax.json.Json;
+import javax.json.JsonObject;
+
+public class BadPropertyContract extends Contract {
+
+  @Override
+  public JsonObject invoke(Ledger ledger, JsonObject argument, Optional<JsonObject> properties) {
+    return Json.createObjectBuilder().add("os_name", System.getProperty("os.name")).build();
+  }
+}

--- a/ledger/src/permission-test/java/com/scalar/dl/ledger/service/LedgerServicePermissionTest.java
+++ b/ledger/src/permission-test/java/com/scalar/dl/ledger/service/LedgerServicePermissionTest.java
@@ -64,6 +64,10 @@ public class LedgerServicePermissionTest {
   private static final String BADREAD_CONTRACT_NAME = PACKAGE + "BadReadContract";
   private static final String BADWRITE_CONTRACT_ID = "BadWriteInOrg1";
   private static final String BADWRITE_CONTRACT_NAME = PACKAGE + "BadWriteContract";
+  private static final String BADNETWORK_CONTRACT_ID = "BadNetworkInOrg1";
+  private static final String BADNETWORK_CONTRACT_NAME = PACKAGE + "BadNetworkContract";
+  private static final String BADPROPERTY_CONTRACT_ID = "BadPropertyInOrg1";
+  private static final String BADPROPERTY_CONTRACT_NAME = PACKAGE + "BadPropertyContract";
   private static final String ASSET_ATTRIBUTE_ID = "asset";
   static final String BALANCE_ATTRIBUTE_NAME = "balance";
   static final String CONTRACT_ID_ATTRIBUTE_NAME = "contract_id";
@@ -90,6 +94,18 @@ public class LedgerServicePermissionTest {
   public void setUp() {
     MockitoAnnotations.openMocks(this);
 
+    service = createService(new ProtectionDomain(null, null));
+    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt())).thenReturn(validator);
+    when(signer.sign(any())).thenReturn("any_bytes".getBytes(StandardCharsets.UTF_8));
+    when(validator.validate(any(), any())).thenReturn(true);
+
+    // Set up the security manager
+    System.setProperty("java.security.manager", "default");
+    System.setProperty("java.security.policy", "src/dist/security.policy");
+    System.setSecurityManager(new SecurityManager());
+  }
+
+  private LedgerService createService(ProtectionDomain protectionDomain) {
     Properties props = new Properties();
     props.setProperty(DatabaseConfig.CONTACT_POINTS, "localhost");
     props.setProperty(LedgerConfig.PROOF_ENABLED, "false");
@@ -99,30 +115,25 @@ public class LedgerServicePermissionTest {
     AccessController.doPrivileged(
         (PrivilegedAction<Void>)
             () -> {
-              contractLoader.set(new ContractLoader(new ProtectionDomain(null, null)));
+              contractLoader.set(new ContractLoader(protectionDomain));
               return null;
             });
     ContractManager contractManager =
         new ContractManager(registry, contractLoader.get(), clientKeyValidator);
     ContractExecutor contractExecutor =
         new ContractExecutor(config, contractManager, functionManager, transactionManager);
-    service =
-        new LedgerService(
-            new BaseService(
-                certManager, secretManager, clientKeyValidator, contractManager, namespaceManager),
-            config,
-            clientKeyValidator,
-            auditorKeyValidator,
-            contractExecutor,
-            functionManager);
-    when(clientKeyValidator.getValidator(anyString(), anyString(), anyInt())).thenReturn(validator);
-    when(signer.sign(any())).thenReturn("any_bytes".getBytes(StandardCharsets.UTF_8));
-    when(validator.validate(any(), any())).thenReturn(true);
+    return new LedgerService(
+        new BaseService(
+            certManager, secretManager, clientKeyValidator, contractManager, namespaceManager),
+        config,
+        clientKeyValidator,
+        auditorKeyValidator,
+        contractExecutor,
+        functionManager);
+  }
 
-    // Set up the security manager
-    System.setProperty("java.security.manager", "default");
-    System.setProperty("java.security.policy", "src/dist/security.policy");
-    System.setSecurityManager(new SecurityManager());
+  private static ProtectionDomain createActualProtectionDomain() {
+    return LedgerModule.getProtectionDomain();
   }
 
   private JsonObject prepareArgument(String contractId) {
@@ -294,5 +305,56 @@ public class LedgerServicePermissionTest {
     assertThat(thrown)
         .isInstanceOf(java.security.AccessControlException.class)
         .hasMessageContaining("java.io.FilePermission");
+  }
+
+  @Test
+  public void
+      execute_ContractOpeningSocketWithActualProtectionDomain_ShouldThrowAccessControlException() {
+    // Arrange: use the actual ProtectionDomain for contracts, which must not allow contracts to
+    // open sockets directly. Database accesses issued via the framework are handled in a
+    // privileged block (com.scalar.dl.ledger.database.scalardb.Privileged) instead.
+    service = createService(createActualProtectionDomain());
+    JsonObject argument = prepareArgument(BADNETWORK_CONTRACT_ID);
+    CertificateEntry.Key certKey = new CertificateEntry.Key(ENTITY_ID, KEY_VERSION);
+    ContractEntry entry =
+        prepareContractEntry(BADNETWORK_CONTRACT_ID, BADNETWORK_CONTRACT_NAME, certKey);
+    ContractExecutionRequest request =
+        prepareExecutionRequest(signer, BADNETWORK_CONTRACT_ID, argument);
+    ContractEntry.Key key = new ContractEntry.Key(BADNETWORK_CONTRACT_ID, certKey);
+    when(registry.lookup(anyString(), eq(key))).thenReturn(entry);
+    ledger = prepareLedger(request);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> service.execute(request));
+
+    // Assert
+    assertThat(thrown)
+        .isInstanceOf(java.security.AccessControlException.class)
+        .hasMessageContaining("java.net.SocketPermission");
+  }
+
+  @Test
+  public void
+      execute_ContractReadingSystemPropertyWithActualProtectionDomain_ShouldThrowAccessControlException() {
+    // Arrange
+    service = createService(createActualProtectionDomain());
+    JsonObject argument = prepareArgument(BADPROPERTY_CONTRACT_ID);
+    CertificateEntry.Key certKey = new CertificateEntry.Key(ENTITY_ID, KEY_VERSION);
+    ContractEntry entry =
+        prepareContractEntry(BADPROPERTY_CONTRACT_ID, BADPROPERTY_CONTRACT_NAME, certKey);
+    ContractExecutionRequest request =
+        prepareExecutionRequest(signer, BADPROPERTY_CONTRACT_ID, argument);
+    ContractEntry.Key key = new ContractEntry.Key(BADPROPERTY_CONTRACT_ID, certKey);
+    when(registry.lookup(anyString(), eq(key))).thenReturn(entry);
+    ledger = prepareLedger(request);
+
+    // Act
+    Throwable thrown = catchThrowable(() -> service.execute(request));
+
+    // Assert
+    assertThat(thrown)
+        .isInstanceOf(java.security.AccessControlException.class)
+        .hasMessageContaining("java.util.PropertyPermission")
+        .hasMessageContaining("os.name");
   }
 }

--- a/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/PrivilegedTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/database/scalardb/PrivilegedTest.java
@@ -1,0 +1,89 @@
+package com.scalar.dl.ledger.database.scalardb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.scalar.db.exception.storage.ExecutionException;
+import com.scalar.db.exception.transaction.CrudException;
+import org.junit.jupiter.api.Test;
+
+public class PrivilegedTest {
+
+  @Test
+  public void transactionCrud_OperationSucceeding_ShouldReturnResult() throws CrudException {
+    // Arrange Act
+    String result = Privileged.transactionCrud(() -> "result");
+
+    // Assert
+    assertThat(result).isEqualTo("result");
+  }
+
+  @Test
+  public void transactionCrud_OperationThrowingCrudException_ShouldThrowItAsIs() {
+    // Arrange
+    CrudException toThrow = new CrudException("failed", "tx-id");
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                Privileged.transactionCrud(
+                    () -> {
+                      throw toThrow;
+                    }))
+        .isSameAs(toThrow);
+  }
+
+  @Test
+  public void transactionCrud_OperationThrowingRuntimeException_ShouldThrowItAsIs() {
+    // Arrange
+    RuntimeException toThrow = new IllegalArgumentException("failed");
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                Privileged.transactionCrud(
+                    () -> {
+                      throw toThrow;
+                    }))
+        .isSameAs(toThrow);
+  }
+
+  @Test
+  public void storageCrud_OperationSucceeding_ShouldReturnResult() throws ExecutionException {
+    // Arrange Act
+    String result = Privileged.storageCrud(() -> "result");
+
+    // Assert
+    assertThat(result).isEqualTo("result");
+  }
+
+  @Test
+  public void storageCrud_OperationThrowingExecutionException_ShouldThrowItAsIs() {
+    // Arrange
+    ExecutionException toThrow = new ExecutionException("failed");
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                Privileged.storageCrud(
+                    () -> {
+                      throw toThrow;
+                    }))
+        .isSameAs(toThrow);
+  }
+
+  @Test
+  public void storageCrud_OperationThrowingRuntimeException_ShouldThrowItAsIs() {
+    // Arrange
+    RuntimeException toThrow = new IllegalStateException("failed");
+
+    // Act Assert
+    assertThatThrownBy(
+            () ->
+                Privileged.storageCrud(
+                    () -> {
+                      throw toThrow;
+                    }))
+        .isSameAs(toThrow);
+  }
+}

--- a/testing/src/integration-test/java/com/scalar/dl/testing/ledger/LedgerJdbcReconnectTest.java
+++ b/testing/src/integration-test/java/com/scalar/dl/testing/ledger/LedgerJdbcReconnectTest.java
@@ -1,0 +1,10 @@
+package com.scalar.dl.testing.ledger;
+
+import com.scalar.dl.testing.testcase.LedgerJdbcReconnectIntegrationTestBase;
+
+/**
+ * Integration test that verifies Ledger re-establishes JDBC connections during contract execution
+ * under the SecurityManager. Storage type is determined from system properties (default: jdbc with
+ * MySQL container); the test is skipped for non-JDBC storages.
+ */
+class LedgerJdbcReconnectTest extends LedgerJdbcReconnectIntegrationTestBase {}

--- a/testing/src/main/java/com/scalar/dl/testing/contract/Constants.java
+++ b/testing/src/main/java/com/scalar/dl/testing/contract/Constants.java
@@ -27,6 +27,8 @@ public final class Constants {
   public static final String GET_BALANCE_CONTRACT_ID3 = "GetBalanceWithJackson";
   public static final String GET_BALANCE_CONTRACT_ID4 = "GetBalanceWithString";
   public static final String HOLDER_CHECKER_CONTRACT_ID = "HolderChecker";
+  public static final String NESTED_INVOKER_CONTRACT_ID = "NestedInvoker";
+  public static final String NOOP_CONTRACT_ID = "Noop";
   public static final String NAMESPACE_AWARE_CREATE_ID = "NamespaceAwareCreate";
   public static final String NAMESPACE_AWARE_PAYMENT_ID = "NamespaceAwarePayment";
   public static final String NAMESPACE_AWARE_GET_BALANCE_ID = "NamespaceAwareGetBalance";
@@ -37,6 +39,7 @@ public final class Constants {
   public static final String CREATE_FUNCTION_ID2 = "CreateFunctionWithJsonp";
   public static final String CREATE_FUNCTION_ID3 = "CreateFunctionWithJackson";
   public static final String CREATE_FUNCTION_ID4 = "CreateFunctionWithString";
+  public static final String UPSERT_FUNCTION_ID = "UpsertFunction";
 
   private Constants() {}
 }

--- a/testing/src/main/java/com/scalar/dl/testing/contract/NestedInvoker.java
+++ b/testing/src/main/java/com/scalar/dl/testing/contract/NestedInvoker.java
@@ -1,0 +1,21 @@
+package com.scalar.dl.testing.contract;
+
+import com.scalar.dl.ledger.contract.Contract;
+import com.scalar.dl.ledger.database.Ledger;
+import java.util.Optional;
+import javax.json.JsonObject;
+
+/**
+ * A contract that only invokes the contract specified in the argument (nested invocation) and
+ * returns its result. It deliberately performs no ledger access of its own, so that the nested
+ * contract's registry lookup is the first registry-side database access of the execution when this
+ * contract's own entry is already cached.
+ */
+public class NestedInvoker extends Contract {
+
+  @Override
+  public JsonObject invoke(Ledger ledger, JsonObject argument, Optional<JsonObject> properties) {
+    String contractId = argument.getString(Constants.CONTRACT_ID_ATTRIBUTE_NAME);
+    return invoke(contractId, ledger, argument);
+  }
+}

--- a/testing/src/main/java/com/scalar/dl/testing/contract/Noop.java
+++ b/testing/src/main/java/com/scalar/dl/testing/contract/Noop.java
@@ -1,0 +1,18 @@
+package com.scalar.dl.testing.contract;
+
+import com.scalar.dl.ledger.contract.Contract;
+import com.scalar.dl.ledger.database.Ledger;
+import java.util.Optional;
+import javax.json.JsonObject;
+
+/**
+ * A contract that performs no ledger access. Pairing it with a function allows a test to make the
+ * function's database access the first transaction-side database access of the execution.
+ */
+public class Noop extends Contract {
+
+  @Override
+  public JsonObject invoke(Ledger ledger, JsonObject argument, Optional<JsonObject> properties) {
+    return null;
+  }
+}

--- a/testing/src/main/java/com/scalar/dl/testing/function/UpsertFunction.java
+++ b/testing/src/main/java/com/scalar/dl/testing/function/UpsertFunction.java
@@ -1,0 +1,58 @@
+package com.scalar.dl.testing.function;
+
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Put;
+import com.scalar.db.api.Result;
+import com.scalar.db.io.Key;
+import com.scalar.dl.ledger.database.Database;
+import com.scalar.dl.ledger.exception.ContractContextException;
+import com.scalar.dl.ledger.function.Function;
+import com.scalar.dl.testing.contract.Constants;
+import com.scalar.dl.testing.schema.SchemaConstants;
+import java.util.Optional;
+import javax.json.JsonObject;
+
+/**
+ * A function that reads the current balance of the specified ID and writes the sum of it and the
+ * given balance. Unlike {@link CreateFunction}, it issues a read; the JDBC reconnection test relies
+ * on this because a put alone is buffered until commit under Consensus Commit and does not access
+ * the database from the function's context.
+ */
+public class UpsertFunction extends Function {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void invoke(
+      Database database,
+      Optional<JsonObject> functionArgument,
+      JsonObject contractArgument,
+      Optional<JsonObject> contractProperties) {
+    if (!functionArgument.isPresent()
+        || !functionArgument.get().containsKey(Constants.ID_ATTRIBUTE_NAME)
+        || !functionArgument.get().containsKey(Constants.BALANCE_ATTRIBUTE_NAME)) {
+      throw new ContractContextException("improper function argument");
+    }
+
+    String id = functionArgument.get().getString(Constants.ID_ATTRIBUTE_NAME);
+    int balance = functionArgument.get().getInt(Constants.BALANCE_ATTRIBUTE_NAME);
+    String namespace =
+        functionArgument.get().containsKey(Constants.NAMESPACE_ATTRIBUTE_NAME)
+            ? functionArgument.get().getString(Constants.NAMESPACE_ATTRIBUTE_NAME)
+            : SchemaConstants.FUNCTION_NAMESPACE;
+
+    Get get =
+        new Get(new Key(Constants.ID_ATTRIBUTE_NAME, id))
+            .forNamespace(namespace)
+            .forTable(SchemaConstants.FUNCTION_TABLE);
+    Optional<Result> existing = database.get(get);
+    int newBalance =
+        existing.map(r -> r.getInt(Constants.BALANCE_ATTRIBUTE_NAME)).orElse(0) + balance;
+
+    Put put =
+        new Put(new Key(Constants.ID_ATTRIBUTE_NAME, id))
+            .withValue(Constants.BALANCE_ATTRIBUTE_NAME, newBalance)
+            .forNamespace(namespace)
+            .forTable(SchemaConstants.FUNCTION_TABLE);
+    database.put(put);
+  }
+}

--- a/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcReconnectIntegrationTestBase.java
+++ b/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcReconnectIntegrationTestBase.java
@@ -1,0 +1,296 @@
+package com.scalar.dl.testing.testcase;
+
+import static com.scalar.dl.testing.contract.Constants.AMOUNT_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.ASSET_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.BALANCE_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.CONTRACT_ID_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.CREATE_CONTRACT_ID1;
+import static com.scalar.dl.testing.contract.Constants.GET_BALANCE_CONTRACT_ID1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.scalar.db.schemaloader.SchemaLoader;
+import com.scalar.dl.client.config.ClientConfig;
+import com.scalar.dl.client.exception.ClientException;
+import com.scalar.dl.client.service.ClientService;
+import com.scalar.dl.client.service.ClientServiceFactory;
+import com.scalar.dl.client.util.Common;
+import com.scalar.dl.ledger.config.AuthenticationMethod;
+import com.scalar.dl.ledger.model.ContractExecutionResult;
+import com.scalar.dl.testing.config.TransactionMode;
+import com.scalar.dl.testing.container.AbstractTestCluster;
+import com.scalar.dl.testing.container.LedgerContainer;
+import com.scalar.dl.testing.container.LedgerTestCluster;
+import com.scalar.dl.testing.contract.Create;
+import com.scalar.dl.testing.contract.GetBalance;
+import com.scalar.dl.testing.schema.TestSchemas;
+import com.scalar.dl.testing.util.ConnectionKiller;
+import com.scalar.dl.testing.util.TestCertificates;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import javax.json.Json;
+import javax.json.JsonObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for the JDBC reconnection regression test.
+ *
+ * <p>This test verifies that Ledger can re-establish database connections while executing a
+ * contract. When all pooled connections are lost (e.g., due to a server-side idle timeout, a
+ * database restart, or a network interruption), the next in-contract database access forces
+ * HikariCP to open new physical connections from within the contract's restricted {@code
+ * ProtectionDomain} (the connection-adding worker thread inherits the restricted {@code
+ * AccessControlContext} of the thread that requests a connection). If the {@code ProtectionDomain}
+ * lacks permissions that the JDBC driver needs during connection setup, the execution fails with an
+ * {@code AccessControlException} under the SecurityManager.
+ *
+ * <p>The scenario only applies to JDBC storages; the test is skipped for other storages.
+ *
+ * <p>Subclasses can override {@link #createCluster()} and {@link
+ * #createServerConnectionProperties()} to run the same scenario against a different cluster
+ * configuration (e.g., with Auditor).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class LedgerJdbcReconnectIntegrationTestBase {
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private static final String SOME_ASSET_ID = "reconnect-test-asset";
+  private static final int SOME_AMOUNT = 100;
+
+  // Time to let the connection pools in the server containers finish their initial fill, so that
+  // no connection survives the kill by being created concurrently with it.
+  private static final long POOL_SETTLE_MILLIS = 3000;
+  // HikariCP's connection-adding worker threads die after being idle for 5 seconds. Waiting
+  // longer than that ensures the next in-contract connection request spawns a new worker thread
+  // from the contract's restricted context.
+  private static final long WORKER_EXPIRY_MILLIS = 7000;
+
+  private static final ClientServiceFactory clientServiceFactory = new ClientServiceFactory();
+
+  protected AbstractTestCluster cluster;
+  protected ClientService clientService;
+
+  /**
+   * Returns the authentication method for this test.
+   *
+   * @return The AuthenticationMethod to use
+   */
+  protected AuthenticationMethod getAuthenticationMethod() {
+    return AuthenticationMethod.HMAC;
+  }
+
+  /**
+   * Returns the transaction mode for this test.
+   *
+   * @return The TransactionMode to use
+   */
+  protected TransactionMode getTransactionMode() {
+    return TransactionMode.CONSENSUS_COMMIT;
+  }
+
+  /**
+   * Returns the Ledger Docker image to use. Override to use a custom image.
+   *
+   * @return The Docker image tag
+   */
+  protected String getLedgerImage() {
+    return System.getProperty("scalardl.ledger.image", LedgerContainer.DEFAULT_IMAGE);
+  }
+
+  /**
+   * Creates the test cluster. Override to use a different cluster configuration (e.g., with
+   * Auditor).
+   *
+   * @return The test cluster to use
+   */
+  protected AbstractTestCluster createCluster() {
+    return new LedgerTestCluster(getAuthenticationMethod(), getTransactionMode(), getLedgerImage());
+  }
+
+  @BeforeAll
+  void setUpCluster() throws Exception {
+    cluster = createCluster();
+    cluster.start();
+
+    createClientService();
+    registerContracts();
+  }
+
+  @AfterAll
+  void tearDownCluster() {
+    if (cluster != null) {
+      try {
+        Properties props = cluster.getStorageConfig().getPropertiesForHost();
+        unloadSchemas(props);
+      } catch (Exception e) {
+        logger.warn("Failed to unload table", e);
+      }
+      cluster.close();
+    }
+  }
+
+  /**
+   * Unloads the schemas created for this test. Override to unload additional schemas.
+   *
+   * @param props ScalarDB properties (host-side view)
+   * @throws Exception if the unload fails
+   */
+  protected void unloadSchemas(Properties props) throws Exception {
+    SchemaLoader.unload(props, TestSchemas.getLedgerSchema(), true);
+  }
+
+  /**
+   * Creates client properties for connecting to the servers. Override to add additional connection
+   * settings (e.g., for Auditor).
+   *
+   * @return Properties containing the server connection settings
+   */
+  protected Properties createServerConnectionProperties() {
+    Properties props = new Properties();
+    props.setProperty(ClientConfig.SERVER_HOST, "localhost");
+    props.setProperty(ClientConfig.SERVER_PORT, String.valueOf(cluster.getLedger().getPort()));
+    props.setProperty(
+        ClientConfig.SERVER_PRIVILEGED_PORT,
+        String.valueOf(cluster.getLedger().getPrivilegedPort()));
+    return props;
+  }
+
+  private void createClientService() throws IOException {
+    Properties props = createServerConnectionProperties();
+    props.setProperty(ClientConfig.AUTHENTICATION_METHOD, getAuthenticationMethod().getMethod());
+    props.setProperty(ClientConfig.ENTITY_ID, TestCertificates.ENTITY_ID_A);
+    if (getAuthenticationMethod().equals(AuthenticationMethod.DIGITAL_SIGNATURE)) {
+      props.setProperty(ClientConfig.DS_PRIVATE_KEY_PEM, TestCertificates.PRIVATE_KEY_A);
+      props.setProperty(ClientConfig.DS_CERT_PEM, TestCertificates.CERTIFICATE_A);
+      props.setProperty(ClientConfig.DS_CERT_VERSION, "1");
+    } else {
+      props.setProperty(ClientConfig.HMAC_SECRET_KEY, TestCertificates.SECRET_KEY_A);
+      props.setProperty(ClientConfig.HMAC_SECRET_KEY_VERSION, "1");
+    }
+    clientService = clientServiceFactory.create(new ClientConfig(props));
+  }
+
+  private void registerContracts() {
+    clientService.registerContract(
+        CREATE_CONTRACT_ID1,
+        Create.class.getName(),
+        Common.getClassBytes(Create.class),
+        (String) null);
+    clientService.registerContract(
+        GET_BALANCE_CONTRACT_ID1,
+        GetBalance.class.getName(),
+        Common.getClassBytes(GetBalance.class),
+        Json.createObjectBuilder()
+            .add(CONTRACT_ID_ATTRIBUTE_NAME, GET_BALANCE_CONTRACT_ID1)
+            .build()
+            .toString());
+  }
+
+  @Test
+  void executeContract_AfterAllDatabaseConnectionsKilled_ShouldReconnectAndSucceed()
+      throws Exception {
+    Properties storageProperties = cluster.getStorageConfig().getPropertiesForHost();
+    assumeTrue(
+        ConnectionKiller.isSupported(storageProperties), "This test only applies to JDBC storages");
+
+    // Arrange: create an asset, and confirm that an in-contract read works with warm pools.
+    JsonObject createArgument =
+        Json.createObjectBuilder()
+            .add(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID)
+            .add(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT)
+            .build();
+    clientService.executeContract(CREATE_CONTRACT_ID1, createArgument);
+    JsonObject getBalanceArgument =
+        Json.createObjectBuilder().add(ASSET_ATTRIBUTE_NAME, SOME_ASSET_ID).build();
+    JsonObject warmResult =
+        clientService
+            .executeContract(GET_BALANCE_CONTRACT_ID1, getBalanceArgument)
+            .getResult()
+            .get();
+    assertThat(warmResult.getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
+
+    // Act: kill all database connections so that the next in-contract read must open a new
+    // physical connection. Kill twice to also remove connections that were created between the
+    // first kill and the expiry of HikariCP's connection-adding worker threads. The first kill
+    // must have terminated at least one server-side session; otherwise the reconnection scenario
+    // is not actually exercised (e.g., if the configured user lacks the privilege to see other
+    // sessions), and a subsequent green result would be a false pass.
+    Thread.sleep(POOL_SETTLE_MILLIS);
+    int firstKilled = ConnectionKiller.killAllOtherConnections(storageProperties);
+    assertThat(firstKilled)
+        .as("Expected at least one server-side session to be terminated by the first kill")
+        .isGreaterThan(0);
+    Thread.sleep(WORKER_EXPIRY_MILLIS);
+    ConnectionKiller.killAllOtherConnections(storageProperties);
+    Thread.sleep(WORKER_EXPIRY_MILLIS);
+
+    ContractExecutionResult result;
+    try {
+      result = clientService.executeContract(GET_BALANCE_CONTRACT_ID1, getBalanceArgument);
+    } catch (ClientException e) {
+      fail(
+          "Contract execution failed after all database connections were killed. This usually"
+              + " means the JDBC driver could not re-establish a connection under the contract's"
+              + " restricted ProtectionDomain. Status: "
+              + e.getStatusCode()
+              + ", message: "
+              + e.getMessage()
+              + extractPermissionFailures());
+      throw e; // unreachable
+    }
+
+    // Assert
+    assertThat(result.getResult().get().getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
+  }
+
+  /**
+   * Returns the logs of the server containers keyed by container name, used to diagnose failures.
+   * Override to add additional containers (e.g., Auditor).
+   *
+   * @return Container logs keyed by container name
+   */
+  protected Map<String, String> getServerLogsByName() {
+    Map<String, String> logs = new LinkedHashMap<>();
+    logs.put("ledger", cluster.getLedger().getLogs());
+    return logs;
+  }
+
+  private String extractPermissionFailures() {
+    StringBuilder builder = new StringBuilder();
+    try {
+      for (Map.Entry<String, String> entry : getServerLogsByName().entrySet()) {
+        String suspiciousLines =
+            Arrays.stream(entry.getValue().split("\n"))
+                .filter(
+                    line ->
+                        line.contains("AccessControlException")
+                            || line.contains("access denied")
+                            || line.contains("SQLTransientConnectionException")
+                            || line.contains("does not support authentication protocol"))
+                .distinct()
+                .map(line -> "[" + entry.getKey() + "] " + line)
+                .collect(Collectors.joining("\n"));
+        if (!suspiciousLines.isEmpty()) {
+          builder.append("\n").append(suspiciousLines);
+        }
+      }
+    } catch (Exception e) {
+      logger.warn("Failed to extract server container logs", e);
+      return "";
+    }
+    if (builder.length() == 0) {
+      return "";
+    }
+    return "\nSuspicious lines in the server container logs:" + builder;
+  }
+}

--- a/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcReconnectIntegrationTestBase.java
+++ b/testing/src/main/java/com/scalar/dl/testing/testcase/LedgerJdbcReconnectIntegrationTestBase.java
@@ -6,11 +6,26 @@ import static com.scalar.dl.testing.contract.Constants.BALANCE_ATTRIBUTE_NAME;
 import static com.scalar.dl.testing.contract.Constants.CONTRACT_ID_ATTRIBUTE_NAME;
 import static com.scalar.dl.testing.contract.Constants.CREATE_CONTRACT_ID1;
 import static com.scalar.dl.testing.contract.Constants.GET_BALANCE_CONTRACT_ID1;
+import static com.scalar.dl.testing.contract.Constants.ID_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.NAMESPACE_ATTRIBUTE_NAME;
+import static com.scalar.dl.testing.contract.Constants.NESTED_INVOKER_CONTRACT_ID;
+import static com.scalar.dl.testing.contract.Constants.NOOP_CONTRACT_ID;
+import static com.scalar.dl.testing.contract.Constants.UPSERT_FUNCTION_ID;
+import static com.scalar.dl.testing.schema.SchemaConstants.FUNCTION_NAMESPACE;
+import static com.scalar.dl.testing.schema.SchemaConstants.FUNCTION_TABLE;
+import static com.scalar.dl.testing.schema.SchemaConstants.FUNCTION_TABLE_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.scalar.db.api.DistributedStorage;
+import com.scalar.db.api.DistributedTransactionAdmin;
+import com.scalar.db.api.Get;
+import com.scalar.db.api.Result;
+import com.scalar.db.io.Key;
 import com.scalar.db.schemaloader.SchemaLoader;
+import com.scalar.db.service.StorageFactory;
+import com.scalar.db.service.TransactionFactory;
 import com.scalar.dl.client.config.ClientConfig;
 import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.ClientService;
@@ -24,15 +39,21 @@ import com.scalar.dl.testing.container.LedgerContainer;
 import com.scalar.dl.testing.container.LedgerTestCluster;
 import com.scalar.dl.testing.contract.Create;
 import com.scalar.dl.testing.contract.GetBalance;
+import com.scalar.dl.testing.contract.NestedInvoker;
+import com.scalar.dl.testing.contract.Noop;
+import com.scalar.dl.testing.function.UpsertFunction;
 import com.scalar.dl.testing.schema.TestSchemas;
 import com.scalar.dl.testing.util.ConnectionKiller;
 import com.scalar.dl.testing.util.TestCertificates;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.json.Json;
 import javax.json.JsonObject;
 import org.junit.jupiter.api.AfterAll;
@@ -54,10 +75,22 @@ import org.slf4j.LoggerFactory;
  * lacks permissions that the JDBC driver needs during connection setup, the execution fails with an
  * {@code AccessControlException} under the SecurityManager.
  *
- * <p>The scenario only applies to JDBC storages; the test is skipped for other storages.
+ * <p>The scenarios only apply to JDBC storages; the tests are skipped for other storages.
+ *
+ * <p>Only the first access that has to open a new physical connection after a kill exercises the
+ * reconnection, so each scenario performs its own kill and arranges its target operation to be the
+ * first database access of the execution (per connection pool; the registries and the transaction
+ * manager use separate pools). Three scenarios pin the privileged wraps that can be
+ * deterministically exercised: an in-contract asset read ({@code ScalarTamperEvidentAssetLedger}),
+ * a nested contract invocation whose callee is looked up for the first time after the kill ({@code
+ * ScalarContractRegistry}), and an in-function database read ({@code ScalarMutableDatabase}). The
+ * remaining wraps cannot be pinned here: the function-registry read always fires first on the
+ * framework stack (before the contract is invoked) and re-warms its pool, and the
+ * certificate/secret registries are shielded by caches that request signature validation keeps warm
+ * on every request.
  *
  * <p>Subclasses can override {@link #createCluster()} and {@link
- * #createServerConnectionProperties()} to run the same scenario against a different cluster
+ * #createServerConnectionProperties()} to run the same scenarios against a different cluster
  * configuration (e.g., with Auditor).
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -65,7 +98,14 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   private static final String SOME_ASSET_ID = "reconnect-test-asset";
+  private static final String NESTED_ASSET_ID = "reconnect-test-nested-asset";
+  private static final String SOME_FUNCTION_ROW_ID = "reconnect-test-function-row";
   private static final int SOME_AMOUNT = 100;
+
+  // A copy of GetBalance registered under a dedicated ID. It must not be invoked before the
+  // nested-invocation test kills the connections, so that its registry lookup there is an actual
+  // database read (contract registration does not populate the registry cache, but lookups do).
+  private static final String NESTED_TARGET_CONTRACT_ID = "GetBalanceNestedTarget";
 
   // Time to let the connection pools in the server containers finish their initial fill, so that
   // no connection survives the kill by being created concurrently with it.
@@ -79,6 +119,8 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
 
   protected AbstractTestCluster cluster;
   protected ClientService clientService;
+  private DistributedStorage storage;
+  private DistributedTransactionAdmin transactionAdmin;
 
   /**
    * Returns the authentication method for this test.
@@ -122,12 +164,27 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
     cluster = createCluster();
     cluster.start();
 
+    createStorageAccess();
+    createFunctionTableSchema();
     createClientService();
     registerContracts();
+    registerFunctions();
   }
 
   @AfterAll
   void tearDownCluster() {
+    if (transactionAdmin != null) {
+      try {
+        transactionAdmin.dropTable(FUNCTION_NAMESPACE, FUNCTION_TABLE);
+        transactionAdmin.dropNamespace(FUNCTION_NAMESPACE);
+      } catch (Exception e) {
+        logger.warn("Failed to drop function table", e);
+      }
+      transactionAdmin.close();
+    }
+    if (storage != null) {
+      storage.close();
+    }
     if (cluster != null) {
       try {
         Properties props = cluster.getStorageConfig().getPropertiesForHost();
@@ -137,6 +194,17 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
       }
       cluster.close();
     }
+  }
+
+  private void createStorageAccess() {
+    Properties props = cluster.getStorageConfig().getPropertiesForHost();
+    storage = StorageFactory.create(props).getStorage();
+    transactionAdmin = TransactionFactory.create(props).getTransactionAdmin();
+  }
+
+  private void createFunctionTableSchema() throws Exception {
+    transactionAdmin.createNamespace(FUNCTION_NAMESPACE, true);
+    transactionAdmin.createTable(FUNCTION_NAMESPACE, FUNCTION_TABLE, FUNCTION_TABLE_METADATA, true);
   }
 
   /**
@@ -181,6 +249,11 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
   }
 
   private void registerContracts() {
+    String getBalanceProperties =
+        Json.createObjectBuilder()
+            .add(CONTRACT_ID_ATTRIBUTE_NAME, GET_BALANCE_CONTRACT_ID1)
+            .build()
+            .toString();
     clientService.registerContract(
         CREATE_CONTRACT_ID1,
         Create.class.getName(),
@@ -190,10 +263,26 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
         GET_BALANCE_CONTRACT_ID1,
         GetBalance.class.getName(),
         Common.getClassBytes(GetBalance.class),
-        Json.createObjectBuilder()
-            .add(CONTRACT_ID_ATTRIBUTE_NAME, GET_BALANCE_CONTRACT_ID1)
-            .build()
-            .toString());
+        getBalanceProperties);
+    clientService.registerContract(
+        NESTED_TARGET_CONTRACT_ID,
+        GetBalance.class.getName(),
+        Common.getClassBytes(GetBalance.class),
+        getBalanceProperties);
+    clientService.registerContract(
+        NESTED_INVOKER_CONTRACT_ID,
+        NestedInvoker.class.getName(),
+        Common.getClassBytes(NestedInvoker.class),
+        (String) null);
+    clientService.registerContract(
+        NOOP_CONTRACT_ID, Noop.class.getName(), Common.getClassBytes(Noop.class), (String) null);
+  }
+
+  private void registerFunctions() {
+    clientService.registerFunction(
+        UPSERT_FUNCTION_ID,
+        UpsertFunction.class.getName(),
+        Common.getClassBytes(UpsertFunction.class));
   }
 
   @Test
@@ -220,11 +309,110 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
     assertThat(warmResult.getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
 
     // Act: kill all database connections so that the next in-contract read must open a new
-    // physical connection. Kill twice to also remove connections that were created between the
-    // first kill and the expiry of HikariCP's connection-adding worker threads. The first kill
-    // must have terminated at least one server-side session; otherwise the reconnection scenario
-    // is not actually exercised (e.g., if the configured user lacks the privilege to see other
-    // sessions), and a subsequent green result would be a false pass.
+    // physical connection.
+    killAllConnectionsAndAwaitWorkerExpiry(storageProperties);
+    ContractExecutionResult result =
+        executeAssertingReconnection(GET_BALANCE_CONTRACT_ID1, getBalanceArgument, null, null);
+
+    // Assert
+    assertThat(result.getResult().get().getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
+  }
+
+  @Test
+  void executeContract_NestedInvocationAfterAllDatabaseConnectionsKilled_ShouldReconnectAndSucceed()
+      throws Exception {
+    Properties storageProperties = cluster.getStorageConfig().getPropertiesForHost();
+    assumeTrue(
+        ConnectionKiller.isSupported(storageProperties), "This test only applies to JDBC storages");
+
+    // Arrange: create an asset, and warm the invoker contract by nesting an already-used callee,
+    // so that the invoker's own registry lookup (which happens on the framework stack) is cached.
+    // The dedicated nested target must stay untouched here: after the kill, its registry lookup
+    // has to be the first registry-side database access of the execution, issued from within the
+    // invoker contract's restricted ProtectionDomain.
+    JsonObject createArgument =
+        Json.createObjectBuilder()
+            .add(ASSET_ATTRIBUTE_NAME, NESTED_ASSET_ID)
+            .add(AMOUNT_ATTRIBUTE_NAME, SOME_AMOUNT)
+            .build();
+    clientService.executeContract(CREATE_CONTRACT_ID1, createArgument);
+    JsonObject warmArgument =
+        Json.createObjectBuilder()
+            .add(ASSET_ATTRIBUTE_NAME, NESTED_ASSET_ID)
+            .add(CONTRACT_ID_ATTRIBUTE_NAME, GET_BALANCE_CONTRACT_ID1)
+            .build();
+    JsonObject warmResult =
+        clientService.executeContract(NESTED_INVOKER_CONTRACT_ID, warmArgument).getResult().get();
+    assertThat(warmResult.getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
+
+    // Act: kill all database connections and invoke the contract that nests the never-used
+    // callee, so that the callee's registry lookup must open a new physical connection.
+    killAllConnectionsAndAwaitWorkerExpiry(storageProperties);
+    JsonObject nestedArgument =
+        Json.createObjectBuilder()
+            .add(ASSET_ATTRIBUTE_NAME, NESTED_ASSET_ID)
+            .add(CONTRACT_ID_ATTRIBUTE_NAME, NESTED_TARGET_CONTRACT_ID)
+            .build();
+    ContractExecutionResult result =
+        executeAssertingReconnection(NESTED_INVOKER_CONTRACT_ID, nestedArgument, null, null);
+
+    // Assert
+    assertThat(result.getResult().get().getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
+  }
+
+  @Test
+  void executeFunction_AfterAllDatabaseConnectionsKilled_ShouldReconnectAndSucceed()
+      throws Exception {
+    Properties storageProperties = cluster.getStorageConfig().getPropertiesForHost();
+    assumeTrue(
+        ConnectionKiller.isSupported(storageProperties), "This test only applies to JDBC storages");
+
+    // Arrange: nothing to warm. The contract is a no-op, so the function's read is the first
+    // transaction-side database access after the kill and is issued from within the function's
+    // restricted ProtectionDomain. (The function-registry read that precedes it runs on the
+    // framework stack and re-warms only the registry-side connection pool.)
+    JsonObject contractArgument = Json.createObjectBuilder().build();
+    JsonObject functionArgument =
+        Json.createObjectBuilder()
+            .add(ID_ATTRIBUTE_NAME, SOME_FUNCTION_ROW_ID)
+            .add(BALANCE_ATTRIBUTE_NAME, SOME_AMOUNT)
+            .add(NAMESPACE_ATTRIBUTE_NAME, FUNCTION_NAMESPACE)
+            .build();
+
+    // Act
+    killAllConnectionsAndAwaitWorkerExpiry(storageProperties);
+    executeAssertingReconnection(
+        NOOP_CONTRACT_ID, contractArgument, UPSERT_FUNCTION_ID, functionArgument);
+
+    // Assert
+    Get get =
+        Get.newBuilder()
+            .namespace(FUNCTION_NAMESPACE)
+            .table(FUNCTION_TABLE)
+            .partitionKey(Key.ofText(ID_ATTRIBUTE_NAME, SOME_FUNCTION_ROW_ID))
+            .build();
+    Optional<Result> row = storage.get(get);
+    assertThat(row).isPresent();
+    assertThat(row.get().getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
+  }
+
+  /**
+   * Kills all server-side database connections so that the next database access must open a new
+   * physical connection. Kills twice to also remove connections that were created between the first
+   * kill and the expiry of HikariCP's connection-adding worker threads. The first kill must have
+   * terminated at least one server-side session; otherwise the reconnection scenario is not
+   * actually exercised (e.g., if the configured user lacks the privilege to see other sessions),
+   * and a subsequent green result would be a false pass.
+   *
+   * <p>Note that only the first access that opens a new physical connection per connection pool
+   * exercises the reconnection, so every scenario needs its own kill.
+   *
+   * @param storageProperties ScalarDB properties (host-side view)
+   * @throws InterruptedException if interrupted while sleeping
+   * @throws SQLException if killing the connections fails
+   */
+  private void killAllConnectionsAndAwaitWorkerExpiry(Properties storageProperties)
+      throws InterruptedException, SQLException {
     Thread.sleep(POOL_SETTLE_MILLIS);
     int firstKilled = ConnectionKiller.killAllOtherConnections(storageProperties);
     assertThat(firstKilled)
@@ -233,10 +421,19 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
     Thread.sleep(WORKER_EXPIRY_MILLIS);
     ConnectionKiller.killAllOtherConnections(storageProperties);
     Thread.sleep(WORKER_EXPIRY_MILLIS);
+  }
 
-    ContractExecutionResult result;
+  private ContractExecutionResult executeAssertingReconnection(
+      String contractId,
+      JsonObject contractArgument,
+      @Nullable String functionId,
+      @Nullable JsonObject functionArgument) {
     try {
-      result = clientService.executeContract(GET_BALANCE_CONTRACT_ID1, getBalanceArgument);
+      if (functionId == null) {
+        return clientService.executeContract(contractId, contractArgument);
+      }
+      return clientService.executeContract(
+          contractId, contractArgument, functionId, functionArgument);
     } catch (ClientException e) {
       fail(
           "Contract execution failed after all database connections were killed. This usually"
@@ -248,9 +445,6 @@ public abstract class LedgerJdbcReconnectIntegrationTestBase {
               + extractPermissionFailures());
       throw e; // unreachable
     }
-
-    // Assert
-    assertThat(result.getResult().get().getInt(BALANCE_ATTRIBUTE_NAME)).isEqualTo(SOME_AMOUNT);
   }
 
   /**

--- a/testing/src/main/java/com/scalar/dl/testing/util/ConnectionKiller.java
+++ b/testing/src/main/java/com/scalar/dl/testing/util/ConnectionKiller.java
@@ -1,0 +1,216 @@
+package com.scalar.dl.testing.util;
+
+import com.scalar.db.config.DatabaseConfig;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility that forcibly terminates all database connections except the one it uses. It is used to
+ * simulate connection loss (e.g., a server-side idle timeout, a database restart, or a network
+ * interruption) so that tests can verify components re-establish connections properly.
+ *
+ * <p>Supported JDBC databases: MySQL, MariaDB, PostgreSQL (and compatibles), SQL Server, Oracle,
+ * and Db2. The configured user must have the privilege to terminate other sessions (e.g., an
+ * administrative user).
+ */
+@SuppressFBWarnings(
+    value = {"OBL_UNSATISFIED_OBLIGATION", "SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"},
+    justification =
+        "OBL: the Statement and ResultSet are closed by try-with-resources; this is a known"
+            + " SpotBugs false positive when the try-with-resources resource is reused afterward."
+            + " SQL: the session/application identifiers are numeric values read from the result"
+            + " set, and the KILL/ALTER SYSTEM statements cannot take bind parameters, so there is"
+            + " no injection risk. This is a test-only utility.")
+public final class ConnectionKiller {
+  private static final Logger logger = LoggerFactory.getLogger(ConnectionKiller.class);
+
+  private ConnectionKiller() {}
+
+  /**
+   * Returns true if the given storage properties point to a JDBC database that this utility
+   * supports.
+   *
+   * @param storageProperties ScalarDB properties (host-side view)
+   * @return true if connections can be killed for this storage
+   */
+  public static boolean isSupported(Properties storageProperties) {
+    String storage = storageProperties.getProperty(DatabaseConfig.STORAGE, "");
+    String url = storageProperties.getProperty(DatabaseConfig.CONTACT_POINTS, "");
+    return storage.equals("jdbc")
+        && (url.startsWith("jdbc:mysql:")
+            || url.startsWith("jdbc:mariadb:")
+            || url.startsWith("jdbc:postgresql:")
+            || url.startsWith("jdbc:sqlserver:")
+            || url.startsWith("jdbc:oracle:")
+            || url.startsWith("jdbc:db2:"));
+  }
+
+  /**
+   * Terminates all database connections other than the one used by this method.
+   *
+   * @param storageProperties ScalarDB properties (host-side view) containing the JDBC URL and
+   *     administrative credentials
+   * @return the number of other sessions that were successfully terminated
+   * @throws SQLException if the sessions cannot be enumerated
+   */
+  public static int killAllOtherConnections(Properties storageProperties) throws SQLException {
+    String url = storageProperties.getProperty(DatabaseConfig.CONTACT_POINTS);
+    Properties info = new Properties();
+    String username = storageProperties.getProperty(DatabaseConfig.USERNAME);
+    String password = storageProperties.getProperty(DatabaseConfig.PASSWORD);
+    if (username != null) {
+      info.put("user", username);
+    }
+    if (password != null) {
+      info.put("password", password);
+    }
+
+    if (url.startsWith("jdbc:mysql:") || url.startsWith("jdbc:mariadb:")) {
+      // ScalarDB uses the MariaDB driver for MySQL, so let it accept the jdbc:mysql scheme.
+      String mariadbUrl = url.replaceFirst("^jdbc:mysql:", "jdbc:mariadb:");
+      return killMySqlConnections(mariadbUrl, info);
+    } else if (url.startsWith("jdbc:postgresql:")) {
+      return killPostgresConnections(url, info);
+    } else if (url.startsWith("jdbc:sqlserver:")) {
+      return killSqlServerConnections(url, info);
+    } else if (url.startsWith("jdbc:oracle:")) {
+      return killOracleConnections(url, info);
+    } else if (url.startsWith("jdbc:db2:")) {
+      return killDb2Connections(url, info);
+    } else {
+      throw new IllegalArgumentException("Unsupported JDBC URL: " + url);
+    }
+  }
+
+  private static int killMySqlConnections(String url, Properties info) throws SQLException {
+    try (Connection connection = DriverManager.getConnection(url, info);
+        Statement statement = connection.createStatement()) {
+      List<Long> ids = new ArrayList<>();
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT id FROM information_schema.processlist WHERE id <> CONNECTION_ID()")) {
+        while (resultSet.next()) {
+          ids.add(resultSet.getLong(1));
+        }
+      }
+      int killed = 0;
+      for (long id : ids) {
+        try {
+          statement.execute("KILL " + id);
+          killed++;
+        } catch (SQLException e) {
+          logger.debug("Failed to kill connection {} (it may already be gone)", id);
+        }
+      }
+      logger.info("Killed {} MySQL/MariaDB connections", killed);
+      return killed;
+    }
+  }
+
+  private static int killPostgresConnections(String url, Properties info) throws SQLException {
+    try (Connection connection = DriverManager.getConnection(url, info);
+        Statement statement = connection.createStatement()) {
+      int killed = 0;
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT pg_terminate_backend(pid) FROM pg_stat_activity"
+                  + " WHERE pid <> pg_backend_pid() AND backend_type = 'client backend'")) {
+        while (resultSet.next()) {
+          if (resultSet.getBoolean(1)) {
+            killed++;
+          }
+        }
+      }
+      logger.info("Killed {} PostgreSQL connections", killed);
+      return killed;
+    }
+  }
+
+  private static int killSqlServerConnections(String url, Properties info) throws SQLException {
+    try (Connection connection = DriverManager.getConnection(url, info);
+        Statement statement = connection.createStatement()) {
+      List<Integer> ids = new ArrayList<>();
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT session_id FROM sys.dm_exec_sessions"
+                  + " WHERE is_user_process = 1 AND session_id <> @@SPID")) {
+        while (resultSet.next()) {
+          ids.add(resultSet.getInt(1));
+        }
+      }
+      int killed = 0;
+      for (int id : ids) {
+        try {
+          statement.execute("KILL " + id);
+          killed++;
+        } catch (SQLException e) {
+          logger.debug("Failed to kill session {} (it may already be gone)", id);
+        }
+      }
+      logger.info("Killed {} SQL Server sessions", killed);
+      return killed;
+    }
+  }
+
+  private static int killOracleConnections(String url, Properties info) throws SQLException {
+    try (Connection connection = DriverManager.getConnection(url, info);
+        Statement statement = connection.createStatement()) {
+      List<String> sessions = new ArrayList<>();
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT sid, serial# FROM v$session"
+                  + " WHERE type = 'USER' AND sid <> SYS_CONTEXT('USERENV', 'SID')")) {
+        while (resultSet.next()) {
+          sessions.add(resultSet.getLong(1) + "," + resultSet.getLong(2));
+        }
+      }
+      int killed = 0;
+      for (String session : sessions) {
+        try {
+          statement.execute("ALTER SYSTEM KILL SESSION '" + session + "' IMMEDIATE");
+          killed++;
+        } catch (SQLException e) {
+          logger.debug("Failed to kill session {} (it may already be gone)", session);
+        }
+      }
+      logger.info("Killed {} Oracle sessions", killed);
+      return killed;
+    }
+  }
+
+  private static int killDb2Connections(String url, Properties info) throws SQLException {
+    try (Connection connection = DriverManager.getConnection(url, info);
+        Statement statement = connection.createStatement()) {
+      List<Long> handles = new ArrayList<>();
+      try (ResultSet resultSet =
+          statement.executeQuery(
+              "SELECT application_handle FROM TABLE(MON_GET_CONNECTION(CAST(NULL AS BIGINT), -2))"
+                  + " WHERE application_handle <> MON_GET_APPLICATION_HANDLE()")) {
+        while (resultSet.next()) {
+          handles.add(resultSet.getLong(1));
+        }
+      }
+      int killed = 0;
+      for (long handle : handles) {
+        try {
+          statement.execute("CALL SYSPROC.ADMIN_CMD('FORCE APPLICATION (" + handle + ")')");
+          killed++;
+        } catch (SQLException e) {
+          logger.debug("Failed to force application {} (it may already be gone)", handle);
+        }
+      }
+      // FORCE APPLICATION is asynchronous; callers should wait before relying on the result.
+      logger.info("Forced {} Db2 applications", killed);
+      return killed;
+    }
+  }
+}


### PR DESCRIPTION
## Description

When the SecurityManager is enabled, contracts are executed in a restricted `ProtectionDomain`. If all pooled database connections are lost (e.g., after a server-side idle timeout, a database restart, or a network interruption), the next database access issued from within a contract has to establish a new physical connection, and the JDBC driver's connection housekeeping (system property reads, authentication plugin discovery via `ServiceLoader`, socket connections) is then checked against the contract's restricted `ProtectionDomain` on the stack. This makes the connection establishment fail, and the execution ends up with a connection pool timeout.

#558 addressed this by granting the required permissions to the contract's `ProtectionDomain`, but that approach cannot work in general:

- The required permission set differs per driver, per driver version, and per SSL use. For example, with all the #558 permissions in place, MySQL (with SSL) still fails on reading `javax.net.ssl.trustStore` and SQL Server fails on reading `java.vm.name`.
- The MariaDB Connector/J driver (used for MySQL) discovers its authentication plugins via `ServiceLoader`. In a restricted context, classpath resource URLs are silently filtered out by the permission check, so the plugin list becomes empty and the connection fails with "Client does not support authentication protocol" regardless of the granted permissions.
- The granted permissions also apply to the contract code itself; in particular, `SocketPermission("*", "connect,resolve")` allowed contracts to open arbitrary outbound sockets directly.

This PR takes the opposite approach: run the ScalarDB CRUD operations issued during contract/function execution in a privileged block, so that the permission-check stack walk is cut at the framework frame while the contract code itself remains restricted. This works uniformly for every storage and driver, and the contract's `ProtectionDomain` no longer needs any storage-specific permission, so they are all removed (superseding the unconditional grants of #588; the privileged block is storage-independent, so the multi-storage case that #588 addressed is also covered).

The wrapped operations are the asset ledger reads, the function database operations, and the registry lookups reachable via nested contract/function invocations. Registration paths, commit, and abort are not wrapped because contracts/functions are no longer on the stack at those points. Note that this does not affect the namespace-based access control, which is enforced outside the privileged blocks.

## Related issues and/or PRs

- Follow-up to #558, which introduced the per-storage permission grants that this PR replaces.
- Supersedes #588, which generalized the #558 grants to all storage types for multi-storage support.
- Paired with the corresponding Enterprise PR that applies the same fix to Auditor (scalar-labs/scalardl-enterprise#1776).

## Changes made

- Run the ScalarDB CRUD operations issued during contract/function execution in a privileged block via the new `Privileged` helper.
- Remove all the storage-specific permissions from the contract's `ProtectionDomain`, and add permission tests that pin that contracts can no longer open sockets or read system properties.
- Add a reconnection integration test with a `ConnectionKiller` utility (supporting MySQL, MariaDB, PostgreSQL, SQL Server, Oracle, and Db2) for the storage compatibility check.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

The failure was reproduced deterministically with an integration test that kills all database connections server-side and then executes a contract that reads an asset. The mechanism is subtle: the connection failure occurs on HikariCP's connection-adding worker thread, which is created lazily and inherits the restricted `AccessControlContext` of the contract thread that requests a connection. Wrapping the ScalarDB call in a privileged block makes such worker threads inherit a privileged context instead, so the driver's connection setup succeeds.

Verified with the storage compatibility check workflows using a feature snapshot before switching to this branch:

- JDBC matrix (Enterprise workflow): reconnection tests green on all 6 databases in both the Ledger-only and the Ledger + Auditor configurations, with no storage-specific permission granted (https://github.com/scalar-labs/scalardl-enterprise/actions/runs/29477666388).
- Non-JDBC storages (Core workflow): Cassandra, Cosmos DB, DynamoDB, Blob Storage, Cloud Storage, and S3 all green with the stripped `ProtectionDomain` (https://github.com/scalar-labs/scalardl/actions/runs/29477664481).

## Release notes

Fixed an issue where contract execution failed when database connections needed to be re-established (for example, after a database restart or an idle timeout) with the SecurityManager enabled.