### PR TITLE
Make create-namespace only accessible via scalardl subcommand

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -126,13 +126,6 @@ task LedgerValidation(type: CreateStartScripts) {
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
 
-task NamespaceCreation(type: CreateStartScripts) {
-    mainClass = 'com.scalar.dl.client.tool.NamespaceCreation'
-    applicationName = 'create-namespace'
-    outputDir = new File(project.buildDir, 'scriptsTmp')
-    classpath = jar.outputs.files + project.configurations.runtimeClasspath
-}
-
 task StateUpdaterSimpleBench(type: CreateStartScripts) {
     mainClass = 'com.scalar.dl.client.tool.StateUpdaterSimpleBench'
     applicationName = 'state-updater-simple-bench'
@@ -181,7 +174,6 @@ distributions {
                 from(ContractsListing)
                 from(ContractExecution)
                 from(LedgerValidation)
-                from(NamespaceCreation)
                 from(ScalarDl)
                 from(ScalarDlGc)
                 from(StateUpdaterSimpleBench)

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespaceCreation.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespaceCreation.java
@@ -15,11 +15,6 @@ public class NamespaceCreation extends AbstractClientCommand {
       description = "A namespace name to create.")
   private String namespace;
 
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new NamespaceCreation()).execute(args);
-    System.exit(exitCode);
-  }
-
   @Override
   protected Integer execute(ClientService service) throws ClientException {
     service.createNamespace(namespace);

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespaceDropping.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespaceDropping.java
@@ -16,11 +16,6 @@ public class NamespaceDropping extends AbstractClientCommand {
       description = "A namespace name to drop.")
   private String namespace;
 
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new NamespaceDropping()).execute(args);
-    System.exit(exitCode);
-  }
-
   @Override
   protected Integer execute(ClientService service) throws ClientException {
     if (!confirmDropping()) {

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespacesListing.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespacesListing.java
@@ -17,11 +17,6 @@ public class NamespacesListing extends AbstractClientCommand {
       description = "A pattern to filter namespaces (partial match).")
   private String pattern;
 
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new NamespacesListing()).execute(args);
-    System.exit(exitCode);
-  }
-
   @Override
   protected Integer execute(ClientService service) throws ClientException {
     JacksonSerDe serde = new JacksonSerDe(new ObjectMapper());

--- a/client/src/main/java/com/scalar/dl/client/tool/TransactionStatePurging.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/TransactionStatePurging.java
@@ -6,7 +6,6 @@ import com.scalar.dl.client.exception.ClientException;
 import com.scalar.dl.client.service.ClientService;
 import com.scalar.dl.ledger.model.TransactionStatePurgeResult;
 import java.io.Console;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -17,11 +16,6 @@ public class TransactionStatePurging extends AbstractClientCommand {
       names = {"-f", "--force"},
       description = "Purge stale transaction states without the confirmation prompt.")
   private boolean force;
-
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new TransactionStatePurging()).execute(args);
-    System.exit(exitCode);
-  }
 
   @Override
   protected Integer execute(ClientService service) throws ClientException {


### PR DESCRIPTION
## Description

The `create-namespace` command was unintentionally exposed as both a top-level command (`create-namespace`) and a `scalardl` subcommand (`scalardl create-namespace`), while its sibling namespace commands (`drop-namespace`, `list-namespaces`) have always been exposed only as `scalardl` subcommands. Since the namespace feature is still a public preview, this asymmetric top-level exposure of `create-namespace` is treated as a bug and removed here so that all namespace commands are consistently accessible only via `scalardl` subcommands.

While addressing this, the four subcommand-only tool classes (`NamespaceCreation`, `NamespaceDropping`, `NamespacesListing`, `TransactionStatePurging`) are also aligned with the `Bootstrap` convention by dropping their now-unused `main()` methods, so that "subcommand-only classes have no `main()`" is applied consistently across all such classes.

## Related issues and/or PRs

N/A

## Changes made

- Remove the top-level `create-namespace` start script and its distribution entry from `client/build.gradle`.
- Remove the unused `main()` methods from `NamespaceCreation`, `NamespaceDropping`, `NamespacesListing`, and `TransactionStatePurging` to match the `Bootstrap` pattern for subcommand-only classes.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

This is technically a breaking change for anyone invoking the top-level `create-namespace` script directly. However:

- The namespace feature is still a public preview.
- The top-level exposure was unintentional (its siblings `drop-namespace` and `list-namespaces` were only ever exposed as subcommands).
- The `scalardl create-namespace` subcommand has been available in parallel and is unchanged.

For these reasons, this is treated as a bug fix rather than a deprecation cycle.

## Release notes

Removed the top-level `create-namespace` command. Use `scalardl create-namespace` instead, which is consistent with the other namespace commands (`scalardl drop-namespace`, `scalardl list-namespaces`).
