### PR TITLE
Fix wording of purge and lease error messages

### DIFF
--- a/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
+++ b/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
@@ -450,7 +450,7 @@ public enum CommonError implements ScalarDlError {
       "017",
       "The lease table does not exist.",
       "",
-      "Create the lease table by running the schema loader. It is also created automatically on the next coordination round if the database user has permission to create tables."),
+      "Create the lease table by running Schema Loader. It is also created automatically on the next coordination round if the database user has permission to create tables."),
 
   //
   // Errors for RUNTIME_ERROR(502)

--- a/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/error/LedgerError.java
@@ -114,7 +114,7 @@ public enum LedgerError implements ScalarDlError {
       "007",
       "Transaction state purge is disabled.",
       "",
-      "Set 'scalar.dl.ledger.transaction_state_purge.enabled' to true in the Ledger configuration (e.g., ledger.properties) and restart the Ledger to allow purge."),
+      "Set 'scalar.dl.ledger.transaction_state_purge.enabled' to true in the Ledger configuration (for example, ledger.properties) and restart Ledger to allow purge."),
 
   //
   // Errors for ASSET_NOT_FOUND(409)


### PR DESCRIPTION
## Description

This PR reflects the wording fixes made during the docs review (scalar-labs/docs-internal-scalardl#1009) back into the error message definitions.

## Related issues and/or PRs

- scalar-labs/docs-internal-scalardl#1009

## Changes made

- Fix wording of purge and lease error messages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed wording of purge and lease error messages.