### PR TITLE
Backport to branch(3.13) : Make create-namespace only accessible via scalardl subcommand

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -121,13 +121,6 @@ task LedgerValidation(type: CreateStartScripts) {
     classpath = jar.outputs.files + project.configurations.runtimeClasspath
 }
 
-task NamespaceCreation(type: CreateStartScripts) {
-    mainClass = 'com.scalar.dl.client.tool.NamespaceCreation'
-    applicationName = 'create-namespace'
-    outputDir = new File(project.buildDir, 'scriptsTmp')
-    classpath = jar.outputs.files + project.configurations.runtimeClasspath
-}
-
 task StateUpdaterSimpleBench(type: CreateStartScripts) {
     mainClass = 'com.scalar.dl.client.tool.StateUpdaterSimpleBench'
     applicationName = 'state-updater-simple-bench'
@@ -169,7 +162,6 @@ distributions {
                 from(ContractsListing)
                 from(ContractExecution)
                 from(LedgerValidation)
-                from(NamespaceCreation)
                 from(ScalarDl)
                 from(ScalarDlGc)
                 from(StateUpdaterSimpleBench)

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespaceCreation.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespaceCreation.java
@@ -15,11 +15,6 @@ public class NamespaceCreation extends AbstractClientCommand {
       description = "A namespace name to create.")
   private String namespace;
 
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new NamespaceCreation()).execute(args);
-    System.exit(exitCode);
-  }
-
   @Override
   protected Integer execute(ClientService service) throws ClientException {
     service.createNamespace(namespace);

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespaceDropping.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespaceDropping.java
@@ -16,11 +16,6 @@ public class NamespaceDropping extends AbstractClientCommand {
       description = "A namespace name to drop.")
   private String namespace;
 
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new NamespaceDropping()).execute(args);
-    System.exit(exitCode);
-  }
-
   @Override
   protected Integer execute(ClientService service) throws ClientException {
     if (!confirmDropping()) {

--- a/client/src/main/java/com/scalar/dl/client/tool/NamespacesListing.java
+++ b/client/src/main/java/com/scalar/dl/client/tool/NamespacesListing.java
@@ -17,11 +17,6 @@ public class NamespacesListing extends AbstractClientCommand {
       description = "A pattern to filter namespaces (partial match).")
   private String pattern;
 
-  public static void main(String[] args) {
-    int exitCode = new CommandLine(new NamespacesListing()).execute(args);
-    System.exit(exitCode);
-  }
-
   @Override
   protected Integer execute(ClientService service) throws ClientException {
     JacksonSerDe serde = new JacksonSerDe(new ObjectMapper());


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/622
- **Commit to backport:** c9d92a81c034a012d0575bb25399fb8f5c0ab0a1

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-622 &&
git cherry-pick --no-rerere-autoupdate -m1 c9d92a81c034a012d0575bb25399fb8f5c0ab0a1
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!