### PR TITLE
Revert grpc-java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
     }
 
     ext {
-        grpcVersion = '1.83.0'
+        grpcVersion = '1.82.0' // transient fix until merging the PR #634
         protocVersion = '3.25.9'
         picoCliVersion = '4.7.7'
         guiceVersion = '7.0.0'


### PR DESCRIPTION
## Description

This PR fixes `grpc-java` version bumped in #627 because it introduces a Netty conflict issue. It will be rebumped in #634, which fixes the issue.

## Related issues and/or PRs

- #627
- #634

## Changes made

- Downgrade `grpc-java` to 1.82.0

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Reverted the grpc-java version.