### PR TITLE
Fix GateKeeper pause race

### DIFF
--- a/common/src/main/java/com/scalar/dl/ledger/server/GateKeeper.java
+++ b/common/src/main/java/com/scalar/dl/ledger/server/GateKeeper.java
@@ -2,16 +2,29 @@ package com.scalar.dl.ledger.server;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A gatekeeper that manages the front gate of the server that processes requests. */
 @ThreadSafe
 public class GateKeeper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GateKeeper.class.getName());
 
   @GuardedBy("this")
   private boolean isOpen;
+
+  /**
+   * True while a pause request is between closing the gate and deciding whether it has to undo that
+   * closure. Pause requests are serialized on this flag, so that one of them can never reach a
+   * paused state and report it while another is still in a position to reopen the gate underneath
+   * it. Clearing it notifies the monitor, so a pause waiting for its turn can take the gate.
+   */
+  @GuardedBy("this")
+  private boolean pauseInProgress;
 
   @GuardedBy("this")
   private int numOutstandingRequests;
@@ -27,13 +40,107 @@ public class GateKeeper {
   }
 
   /**
-   * Closes the gate to disallow incoming requests to be processed. After this call returns, new
-   * requests are rejected. Note that this method will not wait for outstanding requests to finish
-   * before returning. awaitDrained(long, TimeUnit) needs to be called to wait for outstanding
-   * requests to finish.
+   * Closes the gate on behalf of a pause request, without waiting for outstanding requests to
+   * finish. After this method returns {@link PauseResult#PAUSED}, new requests are held at the
+   * gate.
+   *
+   * <p>Unlike {@link #pauseAndAwaitDrained(long, TimeUnit)}, this method never waits for a pause
+   * that is already in progress: its caller asked not to wait, and that pause can still reopen the
+   * gate, so there is nothing to report but {@link PauseResult#PAUSE_IN_PROGRESS}.
+   *
+   * @return {@link PauseResult#PAUSED} if the gate is closed on the caller's behalf; {@link
+   *     PauseResult#PAUSE_IN_PROGRESS} if another pause request is already in progress
    */
-  public synchronized void close() {
-    isOpen = false;
+  public synchronized PauseResult pause() {
+    if (pauseInProgress) {
+      return PauseResult.PAUSE_IN_PROGRESS;
+    }
+    close();
+    return PauseResult.PAUSED;
+  }
+
+  /**
+   * Closes the gate on behalf of a pause request and waits for outstanding requests to finish,
+   * giving up if the timeout is reached.
+   *
+   * <p>If a paused state is not reached, a closure made by this call is undone before returning, so
+   * that a pause which failed does not leave the server paused. A closure merely inherited from an
+   * earlier pause is left alone, because that pause has already been reported as successful to its
+   * own caller and reopening the gate would silently revoke it.
+   *
+   * <p>Pause requests are serialized against each other: while one is in progress, another waits
+   * for it to finish instead of closing the gate behind its back. Waiting rather than failing fast
+   * matters because a caller that unpauses to recover from a failed pause would answer a fail-fast
+   * rejection with an unpause, and that unpause would reopen the gate the pause in progress had
+   * closed, taking that pause down as well. The wait is bounded by the caller's own timeout, which
+   * covers waiting for the pause in progress and draining together, so a pause never blocks longer
+   * than it was asked to. {@link #open()} is deliberately left unserialized, so an unpause can
+   * always interrupt a pause that is stuck draining.
+   *
+   * @param timeout the maximum time to wait, covering both waiting for a pause already in progress
+   *     and waiting for outstanding requests to finish
+   * @param unit the time unit of the timeout argument
+   * @return {@link PauseResult#PAUSED} if the gate is closed and all outstanding requests have
+   *     finished; {@link PauseResult#TIMED_OUT} if the timeout was reached with requests still
+   *     outstanding and the gate has been reopened; {@link PauseResult#TIMED_OUT_STILL_PAUSED} if
+   *     the timeout was reached but the gate stays closed under an earlier pause; {@link
+   *     PauseResult#GATE_OPEN} if a concurrent unpause reopened the gate; {@link
+   *     PauseResult#PAUSE_IN_PROGRESS} if another pause request was still in progress when the
+   *     timeout was reached
+   */
+  public synchronized PauseResult pauseAndAwaitDrained(long timeout, TimeUnit unit) {
+    long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+    boolean interrupted = false;
+    try {
+      // The two waits below are indistinguishable to the caller until the call returns, yet they
+      // call for different remedies: draining points at a long-running request, waiting here
+      // points at whoever holds the pause. Log them separately, in the order they happen.
+      if (pauseInProgress) {
+        LOGGER.info("Waiting for another pause request in progress to finish");
+      }
+      while (pauseInProgress) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          // The pause in progress owns the gate and may still reopen it, so this call can neither
+          // report a paused state nor touch the gate.
+          return PauseResult.PAUSE_IN_PROGRESS;
+        }
+        try {
+          NANOSECONDS.timedWait(this, remainingNanos);
+        } catch (InterruptedException ignored) {
+          interrupted = true;
+        }
+      }
+      pauseInProgress = true;
+      try {
+        boolean closedByThisCall = close();
+        LOGGER.info("Waiting until outstanding requests are all finished");
+        // Whatever is left of the caller's time limit after waiting for a pause in progress. A
+        // non-positive remainder still lets awaitDrained report an already-drained gate as paused.
+        PauseResult pauseResult = awaitDrained(deadlineNanos - System.nanoTime(), NANOSECONDS);
+        if (pauseResult == PauseResult.PAUSED) {
+          return pauseResult;
+        }
+        if (closedByThisCall) {
+          open();
+          return pauseResult;
+        }
+        // The gate is left as it is, so the caller has to be told that it is still closed.
+        // Otherwise it could take its own failure for an unpaused server and "recover" by
+        // unpausing, which would revoke the earlier pause that owns the gate.
+        return pauseResult == PauseResult.TIMED_OUT
+            ? PauseResult.TIMED_OUT_STILL_PAUSED
+            : pauseResult;
+      } finally {
+        pauseInProgress = false;
+        // Hand the gate over to a pause request waiting for this one to finish.
+        notifyAll();
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
   }
 
   /**
@@ -55,13 +162,32 @@ public class GateKeeper {
   }
 
   /**
-   * Waits for the server to finish outstanding requests, giving up if the timeout is reached.
+   * Closes the gate to disallow incoming requests to be processed.
+   *
+   * @return true if this call closed the gate, false if it was already closed. Only the caller that
+   *     closed the gate may reopen it to undo its own closure.
+   */
+  @VisibleForTesting
+  synchronized boolean close() {
+    if (!isOpen) {
+      return false;
+    }
+    isOpen = false;
+    return true;
+  }
+
+  /**
+   * Waits for the server to finish outstanding requests, giving up if the timeout is reached. The
+   * gate is expected to have been closed before this is called.
    *
    * @param timeout the maximum time to wait
    * @param unit the time unit of the timeout argument
-   * @return true if the server finishes outstanding requests and false otherwise
+   * @return {@link PauseResult#PAUSED} if the gate is still closed and all outstanding requests
+   *     have finished; {@link PauseResult#TIMED_OUT} if the timeout was reached with requests still
+   *     outstanding; {@link PauseResult#GATE_OPEN} if the gate is open
    */
-  public synchronized boolean awaitDrained(long timeout, TimeUnit unit) {
+  @VisibleForTesting
+  synchronized PauseResult awaitDrained(long timeout, TimeUnit unit) {
     boolean interrupted = false;
     try {
       long timeoutNanos = unit.toNanos(timeout);
@@ -75,7 +201,14 @@ public class GateKeeper {
           interrupted = true;
         }
       }
-      return numOutstandingRequests == 0;
+      // The outcome is decided under this synchronized method, so it is atomic w.r.t. open() /
+      // close() / letIn() / letOut(). That keeps a concurrent unpause (open()) from being mistaken
+      // for a drained pause, and lets the caller report the cause it actually observed instead of
+      // re-deriving it from a later, separately-locked state snapshot.
+      if (isOpen) {
+        return PauseResult.GATE_OPEN;
+      }
+      return numOutstandingRequests == 0 ? PauseResult.PAUSED : PauseResult.TIMED_OUT;
     } finally {
       if (interrupted) {
         Thread.currentThread().interrupt();
@@ -110,5 +243,37 @@ public class GateKeeper {
     if (--numOutstandingRequests == 0) {
       notifyAll();
     }
+  }
+
+  /** The outcome of a pause request. */
+  public enum PauseResult {
+    /**
+     * The gate is closed on the caller's behalf. When returned from {@link
+     * #pauseAndAwaitDrained(long, TimeUnit)}, no request is outstanding either; when returned from
+     * {@link #pause()}, outstanding requests are not waited for and may still be running.
+     */
+    PAUSED,
+    /**
+     * Requests were still outstanding when the timeout was reached, and the closure this call made
+     * has been undone, so the gate is open again.
+     */
+    TIMED_OUT,
+    /**
+     * Requests were still outstanding when the timeout was reached, but the gate stays closed
+     * because an earlier pause owns it. The server is paused even though this request failed, so
+     * unpausing to recover from this outcome would revoke that earlier pause.
+     */
+    TIMED_OUT_STILL_PAUSED,
+    /**
+     * The gate is open, so no paused state can be reported. For a caller that closed the gate
+     * first, this means a concurrent {@link #open()} reopened it.
+     */
+    GATE_OPEN,
+    /**
+     * Another pause request was in progress and this one did not get the gate before its time ran
+     * out, so it did not touch the gate. The other pause may hold the gate closed, so unpausing to
+     * recover from this outcome would revoke it; retrying is the only safe response.
+     */
+    PAUSE_IN_PROGRESS
   }
 }

--- a/common/src/main/java/com/scalar/dl/ledger/server/GateKeeper.java
+++ b/common/src/main/java/com/scalar/dl/ledger/server/GateKeeper.java
@@ -240,7 +240,14 @@ public class GateKeeper {
 
   /** Lets a processed request out. */
   public synchronized void letOut() {
-    if (--numOutstandingRequests == 0) {
+    // Clamped so that a call not paired with a letIn() cannot drive the count below zero. A
+    // negative count would leave the drain loop below with nothing to wait for while never
+    // satisfying its success condition either, so every later pause that waits for outstanding
+    // requests would report a timeout it never waited for, with no way back short of a restart.
+    if (numOutstandingRequests > 0) {
+      numOutstandingRequests--;
+    }
+    if (numOutstandingRequests == 0) {
       notifyAll();
     }
   }

--- a/common/src/test/java/com/scalar/dl/ledger/server/GateKeeperTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/server/GateKeeperTest.java
@@ -81,6 +81,19 @@ public class GateKeeperTest {
   }
 
   @Test
+  public void letOut_NotPairedWithLetIn_ShouldNotDriveOutstandingBelowZero() {
+    // Arrange: outstanding requests are tracked as a count here, so an unpaired letOut() would
+    // make it negative -- where the drain loop has nothing to wait for yet never sees zero
+    // either, permanently turning every later pause into a timeout it never waited for.
+    // Act
+    gateKeeper.letOut();
+
+    // Assert
+    assertThat(gateKeeper.getNumOutstandingRequests()).isEqualTo(0);
+    assertThat(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)).isEqualTo(PauseResult.PAUSED);
+  }
+
+  @Test
   public void open_OnAnyCondition_ShouldOpen() {
     // Arrange
     // Act

--- a/common/src/test/java/com/scalar/dl/ledger/server/GateKeeperTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/server/GateKeeperTest.java
@@ -1,14 +1,25 @@
 package com.scalar.dl.ledger.server;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static com.scalar.dl.ledger.server.ThreadTestUtils.awaitThreadState;
+import static com.scalar.dl.ledger.server.ThreadTestUtils.joinPromptly;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.util.concurrent.Uninterruptibles;
+import com.scalar.dl.ledger.server.GateKeeper.PauseResult;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class GateKeeperTest {
+
+  /**
+   * How long to give a waiter the chance to wake up when a test asserts that it must <em>not</em>
+   * wake up. Asserting immediately would let a regression slip through whenever the waiter simply
+   * had not been scheduled yet.
+   */
+  private static final long MUST_NOT_WAKE_UP_MILLIS = 100;
+
   private GateKeeper gateKeeper;
 
   @BeforeEach
@@ -27,25 +38,33 @@ public class GateKeeperTest {
   }
 
   @Test
-  public void letIn_GateClosed_ShouldWaitBeforeIncrementing() {
+  public void letIn_WhileGateIsClosed_ShouldBlockUntilGateIsReopened() throws InterruptedException {
     // Arrange
     gateKeeper.close();
-    AtomicBoolean letInFinished = new AtomicBoolean(false);
 
-    // Act
-    new Thread(
+    AtomicBoolean letIn = new AtomicBoolean(false);
+    Thread request =
+        new Thread(
             () -> {
               gateKeeper.letIn();
-              letInFinished.set(true);
-            })
-        .start();
+              letIn.set(true);
+            });
+    request.start();
+    try {
+      // A paused server must hold new requests at the gate. Reaching WAITING here is the assertion
+      // that the request was not admitted; if it were, the thread would have terminated instead.
+      awaitThreadState(request, Thread.State.WAITING);
+      assertThat(letIn.get()).isFalse();
+    } finally {
+      // Act -- and also the cleanup: letIn() waits without a timeout, so a failure above would
+      // otherwise leave this non-daemon thread blocked forever and hang the build instead of
+      // failing the test.
+      gateKeeper.open();
+    }
+    joinPromptly(request);
 
-    // Assert
-    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-    assertThat(letInFinished.get()).isFalse();
-    gateKeeper.open();
-    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-    assertThat(letInFinished.get()).isTrue();
+    // Assert: the held request is admitted once the gate reopens.
+    assertThat(letIn.get()).isTrue();
     assertThat(gateKeeper.getNumOutstandingRequests()).isEqualTo(1);
   }
 
@@ -72,57 +91,392 @@ public class GateKeeperTest {
   }
 
   @Test
-  public void close_OnAnyCondition_ShouldClose() {
+  public void close_WhenGateIsOpen_ShouldCloseGateAndReportOwnership() {
     // Arrange
     // Act
-    gateKeeper.close();
+    boolean closedByThisCall = gateKeeper.close();
 
-    // Assert
+    // Assert: the caller that made the transition owns the closure and may undo it.
+    assertThat(closedByThisCall).isTrue();
     assertThat(gateKeeper.isOpen()).isFalse();
   }
 
   @Test
-  public void awaitDrained_NoOutstandingExists_ShouldReturnTrueWithoutWaiting() {
+  public void close_WhenGateIsAlreadyClosed_ShouldReportNoOwnership() {
+    // Arrange: an earlier pause already closed the gate and may already have reported success for
+    // it.
+    gateKeeper.close();
+
+    // Act
+    boolean closedByThisCall = gateKeeper.close();
+
+    // Assert: inheriting an existing closure establishes nothing, so this caller must not undo it.
+    assertThat(closedByThisCall).isFalse();
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void close_WhenGateIsReopenedInBetween_ShouldReportOwnershipAgain() {
+    // Arrange
+    gateKeeper.close();
+    // An unpause reopens the gate, so the next close makes a genuinely new closure.
+    gateKeeper.open();
+
+    // Act
+    boolean closedByThisCall = gateKeeper.close();
+
+    // Assert
+    assertThat(closedByThisCall).isTrue();
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void awaitDrained_GateReopenedByUnpauseBeforeCall_ShouldReturnGateOpen() {
+    // Arrange
+    gateKeeper.close();
+    // A concurrent unpause reopens the gate before the drain check runs.
+    gateKeeper.open();
+
+    // Act
+    PauseResult pauseResult = gateKeeper.awaitDrained(10, TimeUnit.SECONDS);
+
+    // Assert: a reopened gate must not be reported as a drained pause, even with nothing
+    // outstanding.
+    assertThat(pauseResult).isEqualTo(PauseResult.GATE_OPEN);
+  }
+
+  @Test
+  public void awaitDrained_GateReopenedByUnpauseDuringWait_ShouldReturnGateOpen()
+      throws InterruptedException {
+    // Arrange
+    gateKeeper.letIn(); // register the in-flight request while the gate is still open
+    gateKeeper.close(); // one request still outstanding, so awaitDrained blocks
+
+    AtomicReference<PauseResult> pauseResult = new AtomicReference<>();
+    Thread pauseWaiter =
+        new Thread(() -> pauseResult.set(gateKeeper.awaitDrained(10, TimeUnit.SECONDS)));
+    pauseWaiter.start();
+    awaitThreadState(pauseWaiter, Thread.State.TIMED_WAITING);
+
+    // Act: a concurrent unpause reopens the gate while the pause is still waiting to drain.
+    gateKeeper.open();
+    joinPromptly(pauseWaiter);
+
+    // Assert
+    assertThat(pauseResult.get()).isEqualTo(PauseResult.GATE_OPEN);
+  }
+
+  @Test
+  public void awaitDrained_OutstandingRequestsDrainWhileStillClosed_ShouldReturnPaused()
+      throws InterruptedException {
+    // Arrange
+    gateKeeper.letIn(); // register the in-flight request while the gate is still open
+    gateKeeper.close();
+
+    AtomicReference<PauseResult> pauseResult = new AtomicReference<>();
+    Thread pauseWaiter =
+        new Thread(() -> pauseResult.set(gateKeeper.awaitDrained(10, TimeUnit.SECONDS)));
+    pauseWaiter.start();
+    awaitThreadState(pauseWaiter, Thread.State.TIMED_WAITING);
+
+    // Act: the outstanding request finishes with no concurrent unpause.
+    gateKeeper.letOut();
+    joinPromptly(pauseWaiter);
+
+    // Assert: reaching a genuine paused-and-drained state is a successful pause.
+    assertThat(pauseResult.get()).isEqualTo(PauseResult.PAUSED);
+  }
+
+  @Test
+  public void awaitDrained_NoOutstandingRequestsWhileClosed_ShouldReturnPaused() {
     // Arrange
     gateKeeper.close();
 
     // Act
-    boolean actual = gateKeeper.awaitDrained(1, TimeUnit.MILLISECONDS);
+    PauseResult pauseResult = gateKeeper.awaitDrained(10, TimeUnit.SECONDS);
 
     // Assert
-    assertThat(actual).isTrue();
+    assertThat(pauseResult).isEqualTo(PauseResult.PAUSED);
   }
 
   @Test
-  public void awaitDrained_OutstandingExists_ShouldWaitUntilNotifiedAndReturnTrue() {
+  public void awaitDrained_TimeoutWithOutstandingRequestsWhileClosed_ShouldReturnTimedOut() {
     // Arrange
-    new Thread(
-            () -> {
-              gateKeeper.letIn();
-              Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-              gateKeeper.letOut();
-            })
-        .start();
-    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-    gateKeeper.close();
+    gateKeeper.letIn(); // register the in-flight request while the gate is still open
+    gateKeeper.close(); // never drained, never reopened
 
     // Act
-    boolean actual = gateKeeper.awaitDrained(2, TimeUnit.SECONDS);
+    PauseResult pauseResult = gateKeeper.awaitDrained(50, TimeUnit.MILLISECONDS);
 
-    // Assert
-    assertThat(actual).isTrue();
+    // Assert: timeout with the gate still closed and work outstanding stays a failure.
+    assertThat(pauseResult).isEqualTo(PauseResult.TIMED_OUT);
   }
 
   @Test
-  public void awaitDrained_OutstandingExistsButTimedOut_ShouldWaitAndReturnFalse() {
+  public void
+      awaitDrained_WithMultipleOutstandingRequests_ShouldReturnPausedOnlyAfterTheLastFinishes()
+          throws InterruptedException {
     // Arrange
+    gateKeeper.letIn();
     gateKeeper.letIn();
     gateKeeper.close();
 
-    // Act
-    boolean actual = gateKeeper.awaitDrained(1, TimeUnit.MILLISECONDS);
+    AtomicReference<PauseResult> pauseResult = new AtomicReference<>();
+    Thread pauseWaiter =
+        new Thread(() -> pauseResult.set(gateKeeper.awaitDrained(10, TimeUnit.SECONDS)));
+    pauseWaiter.start();
+    awaitThreadState(pauseWaiter, Thread.State.TIMED_WAITING);
+
+    // Act: one of the two requests finishes.
+    gateKeeper.letOut();
+
+    // Assert: a partial drain is not a drained pause, so the waiter must stay put. Reporting
+    // success here would let a pause claim the server is quiet while a request is still running.
+    pauseWaiter.join(MUST_NOT_WAKE_UP_MILLIS);
+    assertThat(pauseWaiter.isAlive()).isTrue();
+    assertThat(pauseResult.get()).isNull();
+
+    // Act: the last outstanding request finishes.
+    gateKeeper.letOut();
+    joinPromptly(pauseWaiter);
 
     // Assert
-    assertThat(actual).isFalse();
+    assertThat(pauseResult.get()).isEqualTo(PauseResult.PAUSED);
+  }
+
+  @Test
+  public void pause_WhenGateIsOpen_ShouldCloseGate() {
+    // Arrange
+    // Act
+    PauseResult pauseResult = gateKeeper.pause();
+
+    // Assert
+    assertThat(pauseResult).isEqualTo(PauseResult.PAUSED);
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pause_WhileAnotherPauseIsDraining_ShouldReturnPauseInProgress()
+      throws InterruptedException {
+    // Arrange: a non-waiting pause must not be able to claim success on a gate that a draining
+    // pause is still entitled to reopen.
+    gateKeeper.letIn();
+
+    AtomicReference<PauseResult> firstResult = new AtomicReference<>();
+    // The first pause has to still be draining when the second one arrives, so give it a time limit
+    // it cannot reach during the test rather than one the second call has to beat.
+    Thread firstPause =
+        new Thread(() -> firstResult.set(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)));
+    firstPause.start();
+    awaitThreadState(firstPause, Thread.State.TIMED_WAITING);
+
+    // Act
+    PauseResult secondResult = gateKeeper.pause();
+
+    // Assert
+    assertThat(secondResult).isEqualTo(PauseResult.PAUSE_IN_PROGRESS);
+
+    // The first pause still completes normally once its request drains.
+    gateKeeper.letOut();
+    joinPromptly(firstPause);
+    assertThat(firstResult.get()).isEqualTo(PauseResult.PAUSED);
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_WhenDrained_ShouldReturnPausedAndKeepGateClosed() {
+    // Arrange
+    // Act
+    PauseResult pauseResult = gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS);
+
+    // Assert
+    assertThat(pauseResult).isEqualTo(PauseResult.PAUSED);
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_WhenItClosedTheGateAndTimedOut_ShouldReopenGate() {
+    // Arrange: the only pause in play is this one, so it owns the closure it makes.
+    gateKeeper.letIn();
+
+    // Act
+    PauseResult pauseResult = gateKeeper.pauseAndAwaitDrained(50, TimeUnit.MILLISECONDS);
+
+    // Assert: a pause that fails on its own must not leave the server paused.
+    assertThat(pauseResult).isEqualTo(PauseResult.TIMED_OUT);
+    assertThat(gateKeeper.isOpen()).isTrue();
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_WhenItClosedTheGateAndGateWasReopened_ShouldReturnGateOpen()
+      throws InterruptedException {
+    // Arrange: this call closes the gate itself, so it owns the closure and is entitled to undo it.
+    gateKeeper.letIn();
+
+    AtomicReference<PauseResult> pauseResult = new AtomicReference<>();
+    Thread pauseWaiter =
+        new Thread(() -> pauseResult.set(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)));
+    pauseWaiter.start();
+    awaitThreadState(pauseWaiter, Thread.State.TIMED_WAITING);
+
+    // Act: a concurrent unpause reopens the gate while this call is still draining.
+    gateKeeper.open();
+    joinPromptly(pauseWaiter);
+
+    // Assert: a reopened gate must not be reported as a drained pause, and the pause must leave it
+    // open rather than reasserting a closure the unpause deliberately undid.
+    assertThat(pauseResult.get()).isEqualTo(PauseResult.GATE_OPEN);
+    assertThat(gateKeeper.isOpen()).isTrue();
+  }
+
+  @Test
+  public void
+      pauseAndAwaitDrained_WhenItInheritedTheClosureAndGateWasReopened_ShouldReturnGateOpen()
+          throws InterruptedException {
+    // Arrange: an earlier pause closed the gate, and this call inherits that closure.
+    gateKeeper.letIn();
+    assertThat(gateKeeper.pause()).isEqualTo(PauseResult.PAUSED);
+
+    AtomicReference<PauseResult> pauseResult = new AtomicReference<>();
+    Thread pauseWaiter =
+        new Thread(() -> pauseResult.set(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)));
+    pauseWaiter.start();
+    awaitThreadState(pauseWaiter, Thread.State.TIMED_WAITING);
+
+    // Act: an unpause reopens the gate while this call is waiting.
+    gateKeeper.open();
+    joinPromptly(pauseWaiter);
+
+    // Assert: the gate really is open now, so this stays GATE_OPEN rather than being reported as
+    // still paused.
+    assertThat(pauseResult.get()).isEqualTo(PauseResult.GATE_OPEN);
+    assertThat(gateKeeper.isOpen()).isTrue();
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_WhenItInheritedTheClosureAndTimedOut_ShouldKeepGateClosed() {
+    // Arrange: an earlier pause already closed the gate and was told it succeeded, so this call
+    // inherits that closure rather than establishing one of its own.
+    gateKeeper.letIn();
+    assertThat(gateKeeper.pause()).isEqualTo(PauseResult.PAUSED);
+
+    // Act
+    PauseResult pauseResult = gateKeeper.pauseAndAwaitDrained(50, TimeUnit.MILLISECONDS);
+
+    // Assert: reopening here would revoke a pause whose caller was already told "Paused", letting
+    // new requests through while a backup tool believes the server is paused. The outcome has to
+    // say so, or this caller could take its own failure for an unpaused server.
+    assertThat(pauseResult).isEqualTo(PauseResult.TIMED_OUT_STILL_PAUSED);
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_WhileAnotherPauseIsDraining_ShouldWaitForItAndThenPause()
+      throws InterruptedException {
+    // Arrange: hold a request open so the first pause blocks while draining.
+    gateKeeper.letIn();
+
+    AtomicReference<PauseResult> firstResult = new AtomicReference<>();
+    Thread firstPause =
+        new Thread(() -> firstResult.set(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)));
+    firstPause.start();
+    awaitThreadState(firstPause, Thread.State.TIMED_WAITING);
+
+    // Act: a second pause arrives while the first is still draining. It waits for its turn instead
+    // of failing fast, because a caller that unpauses to recover from a failure would answer a
+    // rejection with an unpause, reopening the gate the first pause had closed and taking that
+    // pause down with it.
+    AtomicReference<PauseResult> secondResult = new AtomicReference<>();
+    Thread secondPause =
+        new Thread(() -> secondResult.set(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)));
+    secondPause.start();
+    awaitThreadState(secondPause, Thread.State.TIMED_WAITING);
+    assertThat(secondResult.get()).isNull();
+    // It waits without having touched the gate: the first pause still owns the closure it made.
+    assertThat(gateKeeper.isOpen()).isFalse();
+
+    gateKeeper.letOut();
+    joinPromptly(firstPause);
+    joinPromptly(secondPause);
+
+    // Assert: both pauses succeed and the gate stays closed, as they did before pauses were
+    // serialized -- but now without either of them being able to reopen the other's closure.
+    assertThat(firstResult.get()).isEqualTo(PauseResult.PAUSED);
+    assertThat(secondResult.get()).isEqualTo(PauseResult.PAUSED);
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_WhenAnotherPauseDoesNotFinishInTime_ShouldReturnPauseInProgress()
+      throws InterruptedException {
+    // Arrange: the first pause holds the gate for far longer than the second is willing to wait.
+    gateKeeper.letIn();
+
+    AtomicReference<PauseResult> firstResult = new AtomicReference<>();
+    Thread firstPause =
+        new Thread(() -> firstResult.set(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)));
+    firstPause.start();
+    awaitThreadState(firstPause, Thread.State.TIMED_WAITING);
+
+    // Act
+    PauseResult secondResult = gateKeeper.pauseAndAwaitDrained(50, TimeUnit.MILLISECONDS);
+
+    // Assert: waiting is bounded by the caller's own time limit, and giving up leaves the gate
+    // exactly as the first pause left it rather than closing it behind that pause's back.
+    assertThat(secondResult).isEqualTo(PauseResult.PAUSE_IN_PROGRESS);
+    assertThat(gateKeeper.isOpen()).isFalse();
+
+    // The first pause still completes normally once its request drains.
+    gateKeeper.letOut();
+    joinPromptly(firstPause);
+    assertThat(firstResult.get()).isEqualTo(PauseResult.PAUSED);
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_AfterAnEarlierPauseFinished_ShouldNotReportPauseInProgress() {
+    // Arrange: the in-progress marker must be cleared once a pause finishes, or every later pause
+    // would be rejected.
+    assertThat(gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS)).isEqualTo(PauseResult.PAUSED);
+
+    // Act
+    PauseResult pauseResult = gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS);
+
+    // Assert
+    assertThat(pauseResult).isEqualTo(PauseResult.PAUSED);
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_AfterAnEarlierPauseTimedOutAndReopenedTheGate_ShouldPause() {
+    // Arrange: a pause that fails has to clear the in-progress marker just as one that succeeds
+    // does. Leaving it set would turn a single timed-out pause into a permanently unusable pause
+    // endpoint, with every later request reported as PAUSE_IN_PROGRESS and nothing to recover it.
+    gateKeeper.letIn();
+    assertThat(gateKeeper.pauseAndAwaitDrained(50, TimeUnit.MILLISECONDS))
+        .isEqualTo(PauseResult.TIMED_OUT);
+    gateKeeper.letOut();
+
+    // Act
+    PauseResult pauseResult = gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS);
+
+    // Assert
+    assertThat(pauseResult).isEqualTo(PauseResult.PAUSED);
+    assertThat(gateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pauseAndAwaitDrained_AfterAnEarlierPauseTimedOutWhileStillPaused_ShouldPause() {
+    // Arrange: the other timeout outcome returns without reopening the gate, so it leaves the
+    // in-progress marker by a different path than the one above and needs its own coverage.
+    gateKeeper.letIn();
+    assertThat(gateKeeper.pause()).isEqualTo(PauseResult.PAUSED);
+    assertThat(gateKeeper.pauseAndAwaitDrained(50, TimeUnit.MILLISECONDS))
+        .isEqualTo(PauseResult.TIMED_OUT_STILL_PAUSED);
+    gateKeeper.letOut();
+
+    // Act
+    PauseResult pauseResult = gateKeeper.pauseAndAwaitDrained(10, TimeUnit.SECONDS);
+
+    // Assert
+    assertThat(pauseResult).isEqualTo(PauseResult.PAUSED);
+    assertThat(gateKeeper.isOpen()).isFalse();
   }
 }

--- a/common/src/test/java/com/scalar/dl/ledger/server/ThreadTestUtils.java
+++ b/common/src/test/java/com/scalar/dl/ledger/server/ThreadTestUtils.java
@@ -1,0 +1,53 @@
+package com.scalar.dl.ledger.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Helpers for ordering the interleaving of a concurrency test without sleeping, shared by the tests
+ * that drive a gatekeeper from more than one thread.
+ */
+final class ThreadTestUtils {
+
+  /** The deadline for a thread to reach the state a test is waiting for. */
+  private static final long THREAD_STATE_TIMEOUT_MILLIS = 5_000;
+
+  /**
+   * The deadline for a blocked thread to be woken up. Must stay well below the timeouts the tests
+   * give the threads they observe, so that a waiter that is never notified fails the test instead
+   * of quietly succeeding once its own timeout expires.
+   */
+  private static final long WAKE_UP_TIMEOUT_MILLIS = 2_000;
+
+  private ThreadTestUtils() {}
+
+  /** Spins until the thread is parked in the given state, giving up at the deadline. */
+  static void awaitThreadState(Thread thread, Thread.State state) {
+    long deadlineNanos =
+        System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(THREAD_STATE_TIMEOUT_MILLIS);
+    while (thread.getState() != state) {
+      if (System.nanoTime() - deadlineNanos > 0) {
+        fail(
+            "the thread did not reach %s within %d ms (last observed state: %s)",
+            state, THREAD_STATE_TIMEOUT_MILLIS, thread.getState());
+      }
+      LockSupport.parkNanos(1_000L);
+    }
+  }
+
+  /**
+   * Joins the thread, requiring it to have been woken up promptly. A bare join() would also pass
+   * when the thread is never notified and merely falls out of its own timeout much later.
+   */
+  static void joinPromptly(Thread thread) throws InterruptedException {
+    thread.join(WAKE_UP_TIMEOUT_MILLIS);
+    assertThat(thread.isAlive())
+        .withFailMessage(
+            "the thread was not woken up within %d ms, so it was never notified",
+            WAKE_UP_TIMEOUT_MILLIS)
+        .isFalse();
+  }
+}

--- a/ledger/src/main/java/com/scalar/dl/ledger/server/AdminService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/server/AdminService.java
@@ -23,9 +23,8 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   private static final long DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS = 30000; // 30 seconds
 
   /**
-   * The domain of the {@link ErrorInfo} detail attached to a failed pause. Deliberately distinct
-   * from ScalarDL's own error domain, because these reasons are {@link PauseResult} values rather
-   * than ScalarDL error codes, and the two must not be parsed by the same code.
+   * The domain of the {@link ErrorInfo} detail attached to a failed pause. Scoped to the admin
+   * service because the reasons it carries are {@link PauseResult} names.
    */
   private static final String ERROR_DOMAIN = "com.scalar.dl.admin";
 

--- a/ledger/src/main/java/com/scalar/dl/ledger/server/AdminService.java
+++ b/ledger/src/main/java/com/scalar/dl/ledger/server/AdminService.java
@@ -1,12 +1,16 @@
 package com.scalar.dl.ledger.server;
 
 import com.google.inject.Inject;
+import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
+import com.google.rpc.ErrorInfo;
 import com.scalar.admin.rpc.AdminGrpc;
 import com.scalar.admin.rpc.CheckPausedResponse;
 import com.scalar.admin.rpc.PauseRequest;
+import com.scalar.dl.ledger.server.GateKeeper.PauseResult;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
@@ -17,6 +21,14 @@ import org.slf4j.LoggerFactory;
 public class AdminService extends AdminGrpc.AdminImplBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminService.class.getName());
   private static final long DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS = 30000; // 30 seconds
+
+  /**
+   * The domain of the {@link ErrorInfo} detail attached to a failed pause. Deliberately distinct
+   * from ScalarDL's own error domain, because these reasons are {@link PauseResult} values rather
+   * than ScalarDL error codes, and the two must not be parsed by the same code.
+   */
+  private static final String ERROR_DOMAIN = "com.scalar.dl.admin";
+
   private final GateKeeper gateKeeper;
 
   @Inject
@@ -24,35 +36,151 @@ public class AdminService extends AdminGrpc.AdminImplBase {
     this.gateKeeper = gateKeeper;
   }
 
+  /**
+   * Pauses the server, optionally waiting for outstanding requests to finish first.
+   *
+   * <p>A request that waits is rejected with {@code INVALID_ARGUMENT} if it specifies a
+   * non-positive {@code max_pause_wait_time}, since such a limit has already elapsed when the wait
+   * begins and would make a request that asked to wait behave as one that did not. That rejection
+   * carries no {@link ErrorInfo} detail: no pause was attempted, so there is no outcome to report,
+   * and the status code says all there is to say.
+   *
+   * <p>A pause that was attempted and failed carries an {@link ErrorInfo} detail in the status
+   * trailers, whose domain is {@code com.scalar.dl.admin} and whose reason is the {@link
+   * PauseResult} name. The reason, rather than the status code or the description text, is what a
+   * caller branches on, because two outcomes share a status code while needing opposite recovery:
+   *
+   * <ul>
+   *   <li>{@code PAUSE_IN_PROGRESS} / {@code GATE_OPEN} ({@code ABORTED}) -- another admin call won
+   *       the race, so the gate is not this caller's to act on. Retry.
+   *   <li>{@code TIMED_OUT} ({@code FAILED_PRECONDITION}) -- the closure this call made has been
+   *       undone, so the gate is open again. Back off, or raise the wait time.
+   *   <li>{@code TIMED_OUT_STILL_PAUSED} ({@code FAILED_PRECONDITION}) -- the gate stays closed
+   *       under an earlier pause. The server is paused despite this failure, so unpausing to
+   *       "recover" would revoke a pause whose caller was already told it succeeded.
+   * </ul>
+   */
   @Override
   public void pause(PauseRequest request, StreamObserver<Empty> responseObserver) {
-    gateKeeper.close();
-
+    PauseResult pauseResult;
+    long maxPauseWaitTime = 0;
     if (request.getWaitOutstanding()) {
-      long maxPauseWaitTime =
-          request.getMaxPauseWaitTime() != 0
-              ? request.getMaxPauseWaitTime()
-              : DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS;
-
-      boolean drained = gateKeeper.awaitDrained(maxPauseWaitTime, TimeUnit.MILLISECONDS);
-      if (!drained) {
-        gateKeeper.open();
-        LOGGER.warn("failed to finish processing outstanding requests within the time limit.");
-        responseObserver.onError(new StatusRuntimeException(Status.FAILED_PRECONDITION));
-        return;
+      // The field is only validated here, on the path that uses it: a request that asked not to
+      // wait has always ignored the value, and rejecting it there would fail calls that work today.
+      if (request.hasMaxPauseWaitTime()) {
+        maxPauseWaitTime = request.getMaxPauseWaitTime();
+        if (maxPauseWaitTime <= 0) {
+          // Passing this on would silently turn a request that asked to wait into one that does
+          // not: the deadline would already have passed by the time the wait began. The field is
+          // optional, so a caller that has no time limit in mind leaves it unset instead.
+          String message =
+              "max_pause_wait_time must be greater than 0 ms, but was "
+                  + maxPauseWaitTime
+                  + " ms; leave it unset to use the default of "
+                  + DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS
+                  + " ms";
+          LOGGER.warn(message);
+          responseObserver.onError(
+              Status.INVALID_ARGUMENT.withDescription(message).asRuntimeException());
+          return;
+        }
+      } else {
+        maxPauseWaitTime = DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS;
       }
+      // The gatekeeper logs which phase the pause is actually in, since it is the only place that
+      // can tell waiting for another pause apart from draining outstanding requests.
+      LOGGER.info("Pausing...");
+      pauseResult = gateKeeper.pauseAndAwaitDrained(maxPauseWaitTime, TimeUnit.MILLISECONDS);
+    } else {
+      pauseResult = gateKeeper.pause();
+    }
+
+    if (pauseResult != PauseResult.PAUSED) {
+      // The outcome was decided atomically inside the gatekeeper, so it describes what actually
+      // happened rather than whatever the gate state looks like by now.
+      String message = failureMessage(pauseResult, maxPauseWaitTime);
+      LOGGER.warn(message);
+      responseObserver.onError(failureException(pauseResult, message));
+      return;
     }
     LOGGER.warn("Paused");
 
-    responseObserver.onNext(Empty.newBuilder().build());
+    responseObserver.onNext(Empty.getDefaultInstance());
     responseObserver.onCompleted();
+  }
+
+  /**
+   * Builds the error reported for a failed pause, carrying the outcome as a machine-readable {@link
+   * ErrorInfo} reason alongside the human-readable description.
+   *
+   * <p>The reason is the part a caller is meant to branch on, and it is what makes the outcomes
+   * distinguishable at all: {@link PauseResult#TIMED_OUT} and {@link
+   * PauseResult#TIMED_OUT_STILL_PAUSED} share a gRPC status code but need opposite recovery, since
+   * only the former leaves the gate open and may therefore be followed by an unpause. The
+   * description says the same thing for humans, but it is not a contract and must not be matched
+   * on.
+   *
+   * <p>The detail rides in the status trailers rather than the response message, so this adds no
+   * requirement on the {@code Admin} service definition, which is owned by a different project.
+   * Callers that ignore the detail keep the behavior they had before it existed.
+   */
+  private static StatusRuntimeException failureException(PauseResult pauseResult, String message) {
+    return StatusProto.toStatusRuntimeException(
+        com.google.rpc.Status.newBuilder()
+            .setCode(failureStatus(pauseResult).getCode().value())
+            .setMessage(message)
+            .addDetails(
+                Any.pack(
+                    ErrorInfo.newBuilder()
+                        .setReason(pauseResult.name())
+                        .setDomain(ERROR_DOMAIN)
+                        .build()))
+            .build());
+  }
+
+  private static String failureMessage(PauseResult pauseResult, long maxPauseWaitTime) {
+    switch (pauseResult) {
+      case GATE_OPEN:
+        return "Pause did not complete: the gate was reopened by a concurrent unpause";
+      case PAUSE_IN_PROGRESS:
+        return "Pause did not start: another pause request is in progress";
+      case TIMED_OUT_STILL_PAUSED:
+        return "Pause did not complete: outstanding requests were not drained within "
+            + maxPauseWaitTime
+            + " ms; the gate stays closed by an earlier pause";
+      case TIMED_OUT:
+        return "Pause did not complete: outstanding requests were not drained within "
+            + maxPauseWaitTime
+            + " ms; the gate has been reopened";
+      default:
+        // PAUSED is not a failure and is filtered out by the caller.
+        throw new AssertionError("Unexpected pause result: " + pauseResult);
+    }
+  }
+
+  private static Status failureStatus(PauseResult pauseResult) {
+    switch (pauseResult) {
+      case PAUSE_IN_PROGRESS:
+      case GATE_OPEN:
+        // Losing a race with another admin call is a transient conflict that the caller can simply
+        // retry, so it is reported as ABORTED rather than as a failed precondition.
+        return Status.ABORTED;
+      case TIMED_OUT:
+      case TIMED_OUT_STILL_PAUSED:
+        // A drain that ran out of time is not retryable on its own terms: retrying it unchanged
+        // will most likely time out again.
+        return Status.FAILED_PRECONDITION;
+      default:
+        // PAUSED is not a failure and is filtered out by the caller.
+        throw new AssertionError("Unexpected pause result: " + pauseResult);
+    }
   }
 
   @Override
   public void unpause(Empty request, StreamObserver<Empty> responseObserver) {
     gateKeeper.open();
     LOGGER.warn("Unpaused");
-    responseObserver.onNext(Empty.newBuilder().build());
+    responseObserver.onNext(Empty.getDefaultInstance());
     responseObserver.onCompleted();
   }
 

--- a/ledger/src/test/java/com/scalar/dl/ledger/server/AdminServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/server/AdminServiceTest.java
@@ -1,0 +1,514 @@
+package com.scalar.dl.ledger.server;
+
+import static com.scalar.dl.ledger.server.ThreadTestUtils.awaitThreadState;
+import static com.scalar.dl.ledger.server.ThreadTestUtils.joinPromptly;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.Empty;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.ErrorInfo;
+import com.scalar.admin.rpc.CheckPausedResponse;
+import com.scalar.admin.rpc.PauseRequest;
+import com.scalar.dl.ledger.server.GateKeeper.PauseResult;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class AdminServiceTest {
+
+  /** The fallback used when the request does not specify a maximum pause wait time. */
+  private static final long DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS = 30000;
+
+  private GateKeeper gateKeeper;
+  private AdminService adminService;
+
+  @BeforeEach
+  public void setUp() {
+    gateKeeper = mock(GateKeeper.class);
+    adminService = new AdminService(gateKeeper);
+  }
+
+  @Test
+  public void pause_WithWaitOutstandingAndPaused_ShouldPause() {
+    // Arrange
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any())).thenReturn(PauseResult.PAUSED);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1000), responseObserver);
+
+    // Assert
+    verify(gateKeeper).pauseAndAwaitDrained(1000L, TimeUnit.MILLISECONDS);
+    verify(responseObserver).onNext(Empty.getDefaultInstance());
+    verify(responseObserver).onCompleted();
+    verify(responseObserver, never()).onError(any());
+  }
+
+  @Test
+  public void pause_WithWaitOutstandingAndTimedOut_ShouldReturnFailedPrecondition() {
+    // Arrange
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any())).thenReturn(PauseResult.TIMED_OUT);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1000), responseObserver);
+
+    // Assert
+    verify(responseObserver, never()).onNext(any());
+    verify(responseObserver, never()).onCompleted();
+
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertReason(error, PauseResult.TIMED_OUT);
+    assertThat(error.getStatus().getDescription())
+        .contains("outstanding requests were not drained within 1000 ms")
+        .contains("the gate has been reopened");
+  }
+
+  @Test
+  public void pause_WithWaitOutstandingAndTimedOutStillPaused_ShouldSayGateStaysClosed() {
+    // Arrange
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any()))
+        .thenReturn(PauseResult.TIMED_OUT_STILL_PAUSED);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1000), responseObserver);
+
+    // Assert: the caller has to learn that the server is paused despite its own failure. Taking
+    // this for an unpaused server and "recovering" with an unpause would revoke the earlier pause.
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertReason(error, PauseResult.TIMED_OUT_STILL_PAUSED);
+    assertThat(error.getStatus().getDescription())
+        .contains("outstanding requests were not drained within 1000 ms")
+        .contains("the gate stays closed by an earlier pause")
+        .doesNotContain("has been reopened");
+  }
+
+  @Test
+  public void pause_WhenTimedOutWithAndWithoutAnEarlierPause_ShouldDifferOnlyByReason() {
+    // Arrange: these two outcomes need opposite recovery -- only TIMED_OUT leaves the gate open and
+    // may be followed by an unpause -- yet they deliberately share a gRPC status code.
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any()))
+        .thenReturn(PauseResult.TIMED_OUT, PauseResult.TIMED_OUT_STILL_PAUSED);
+    StreamObserver<Empty> reopenedResponseObserver = emptyResponseObserver();
+    StreamObserver<Empty> stillPausedResponseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1000), reopenedResponseObserver);
+    adminService.pause(pauseRequest(true, 1000), stillPausedResponseObserver);
+
+    // Assert: the status code alone cannot tell them apart, so a caller deciding whether unpausing
+    // is safe has to be able to do it without parsing the description.
+    StatusRuntimeException reopened = captureError(reopenedResponseObserver);
+    StatusRuntimeException stillPaused = captureError(stillPausedResponseObserver);
+    assertThat(reopened.getStatus().getCode()).isEqualTo(stillPaused.getStatus().getCode());
+    assertReason(reopened, PauseResult.TIMED_OUT);
+    assertReason(stillPaused, PauseResult.TIMED_OUT_STILL_PAUSED);
+  }
+
+  @Test
+  public void pause_WithWaitOutstandingAndGateOpen_ShouldReturnAborted() {
+    // Arrange
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any())).thenReturn(PauseResult.GATE_OPEN);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1000), responseObserver);
+
+    // Assert: losing a race with an unpause is a transient conflict, reported the same way as
+    // losing one with another pause so that a caller retrying on ABORTED covers both.
+    verify(responseObserver, never()).onNext(any());
+    verify(responseObserver, never()).onCompleted();
+
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.ABORTED);
+    assertReason(error, PauseResult.GATE_OPEN);
+    assertThat(error.getStatus().getDescription())
+        .contains("reopened by a concurrent unpause")
+        .doesNotContain("were not drained within");
+  }
+
+  @Test
+  public void pause_WithWaitOutstandingAndPauseInProgress_ShouldReturnAborted() {
+    // Arrange
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any()))
+        .thenReturn(PauseResult.PAUSE_IN_PROGRESS);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1000), responseObserver);
+
+    // Assert: losing a race with another pause is a transient conflict, so it is reported as a
+    // retryable ABORTED rather than as a failed precondition.
+    verify(responseObserver, never()).onNext(any());
+    verify(responseObserver, never()).onCompleted();
+
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.ABORTED);
+    assertReason(error, PauseResult.PAUSE_IN_PROGRESS);
+    assertThat(error.getStatus().getDescription()).contains("another pause request is in progress");
+  }
+
+  @Test
+  public void pause_WithoutWaitOutstanding_ShouldPauseWithoutAwaitingDrain() {
+    // Arrange
+    when(gateKeeper.pause()).thenReturn(PauseResult.PAUSED);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(false, 1000), responseObserver);
+
+    // Assert
+    verify(gateKeeper).pause();
+    verify(gateKeeper, never()).pauseAndAwaitDrained(anyLong(), any());
+    verify(responseObserver).onNext(Empty.getDefaultInstance());
+    verify(responseObserver).onCompleted();
+  }
+
+  @Test
+  public void pause_WithoutWaitOutstandingAndPauseInProgress_ShouldReturnAborted() {
+    // Arrange
+    when(gateKeeper.pause()).thenReturn(PauseResult.PAUSE_IN_PROGRESS);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(false, 1000), responseObserver);
+
+    // Assert
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.ABORTED);
+    assertReason(error, PauseResult.PAUSE_IN_PROGRESS);
+    assertThat(error.getStatus().getDescription()).contains("another pause request is in progress");
+  }
+
+  @Test
+  public void pause_WithoutMaxPauseWaitTime_ShouldAwaitDrainWithDefaultMaxPauseWaitTime() {
+    // Arrange: the field is left unset, which is how a caller with no time limit in mind asks for
+    // the default. An explicitly specified value is never substituted, not even 0.
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any())).thenReturn(PauseResult.PAUSED);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequestWithoutMaxPauseWaitTime(true), responseObserver);
+
+    // Assert
+    verify(gateKeeper)
+        .pauseAndAwaitDrained(DEFAULT_MAX_PAUSE_WAIT_TIME_MILLIS, TimeUnit.MILLISECONDS);
+    verify(responseObserver).onCompleted();
+  }
+
+  @Test
+  public void pause_WithZeroMaxPauseWaitTime_ShouldReturnInvalidArgument() {
+    // Arrange: 0 is a specified time limit, distinguishable from an unset field, so it must not be
+    // silently replaced by the default the way an unset field is.
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 0), responseObserver);
+
+    // Assert
+    verify(gateKeeper, never()).pauseAndAwaitDrained(anyLong(), any());
+    verify(gateKeeper, never()).pause();
+    verify(responseObserver, never()).onNext(any());
+    verify(responseObserver, never()).onCompleted();
+
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
+    assertThat(error.getStatus().getDescription())
+        .contains("max_pause_wait_time must be greater than 0 ms, but was 0 ms");
+  }
+
+  @Test
+  public void pause_WithNegativeMaxPauseWaitTime_ShouldReturnInvalidArgument() {
+    // Arrange: a negative limit has already elapsed when the wait begins, so passing it on would
+    // turn a request that asked to wait into one that does not, and report the failure as a drain
+    // timeout that never waited.
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, -1), responseObserver);
+
+    // Assert
+    verify(gateKeeper, never()).pauseAndAwaitDrained(anyLong(), any());
+    verify(responseObserver, never()).onCompleted();
+
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
+    assertThat(error.getStatus().getDescription())
+        .contains("max_pause_wait_time must be greater than 0 ms, but was -1 ms");
+  }
+
+  @Test
+  public void pause_WithoutWaitOutstandingAndNegativeMaxPauseWaitTime_ShouldPause() {
+    // Arrange: a request that asked not to wait has always ignored the field, so validating it
+    // there would fail calls that work today.
+    when(gateKeeper.pause()).thenReturn(PauseResult.PAUSED);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(false, -1), responseObserver);
+
+    // Assert
+    verify(gateKeeper).pause();
+    verify(responseObserver).onCompleted();
+    verify(responseObserver, never()).onError(any());
+  }
+
+  @Test
+  public void pause_WithMaxPauseWaitTime_ShouldAwaitDrainWithGivenMaxPauseWaitTime() {
+    // Arrange
+    when(gateKeeper.pauseAndAwaitDrained(anyLong(), any())).thenReturn(PauseResult.PAUSED);
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.pause(pauseRequest(true, 1234), responseObserver);
+
+    // Assert
+    verify(gateKeeper).pauseAndAwaitDrained(1234L, TimeUnit.MILLISECONDS);
+    verify(responseObserver).onCompleted();
+  }
+
+  @Test
+  public void unpause_ShouldOpenGate() {
+    // Arrange
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+
+    // Act
+    adminService.unpause(Empty.getDefaultInstance(), responseObserver);
+
+    // Assert
+    verify(gateKeeper).open();
+    verify(responseObserver).onNext(Empty.getDefaultInstance());
+    verify(responseObserver).onCompleted();
+  }
+
+  // The tests below run the service against a real GateKeeper rather than a mock, so that the two
+  // classes are verified as they actually compose. The race they guard against lives in that
+  // composition, not in either class alone.
+
+  @Test
+  public void pause_WhenLaterPauseTimesOutAfterEarlierPauseSucceeded_ShouldKeepGateClosed() {
+    // Arrange: a request is in flight, then a pause that does not wait for outstanding requests
+    // closes the gate and is told "Paused". Its client now relies on the gate staying closed.
+    GateKeeper realGateKeeper = new GateKeeper();
+    AdminService service = new AdminService(realGateKeeper);
+    realGateKeeper.letIn();
+
+    StreamObserver<Empty> firstResponseObserver = emptyResponseObserver();
+    service.pause(pauseRequest(false, 0), firstResponseObserver);
+
+    verify(firstResponseObserver).onCompleted();
+    verify(firstResponseObserver, never()).onError(any());
+    assertThat(realGateKeeper.isOpen()).isFalse();
+
+    // Act: a second pause arrives, inherits the already-closed gate, and times out because the
+    // request is still running.
+    StreamObserver<Empty> secondResponseObserver = emptyResponseObserver();
+    service.pause(pauseRequest(true, 50), secondResponseObserver);
+
+    // Assert: the second pause fails, but it must not reopen the gate. Doing so would revoke the
+    // first pause's already-reported success and let new requests through while a backup tool
+    // believes the server is paused.
+    StatusRuntimeException error = captureError(secondResponseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertReason(error, PauseResult.TIMED_OUT_STILL_PAUSED);
+    assertThat(error.getStatus().getDescription())
+        .contains("the gate stays closed by an earlier pause");
+    assertThat(realGateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pause_WhenItTimesOutWithoutAnEarlierPause_ShouldReopenGate() {
+    // Arrange: the only pause in play is this one, so it owns the closure it makes.
+    GateKeeper realGateKeeper = new GateKeeper();
+    AdminService service = new AdminService(realGateKeeper);
+    realGateKeeper.letIn();
+
+    // Act
+    StreamObserver<Empty> responseObserver = emptyResponseObserver();
+    service.pause(pauseRequest(true, 50), responseObserver);
+
+    // Assert: a pause that fails on its own must not strand the server paused.
+    StatusRuntimeException error = captureError(responseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.FAILED_PRECONDITION);
+    assertReason(error, PauseResult.TIMED_OUT);
+    assertThat(error.getStatus().getDescription()).contains("the gate has been reopened");
+    assertThat(realGateKeeper.isOpen()).isTrue();
+  }
+
+  @Test
+  public void pause_WhileAnotherPauseIsDraining_ShouldWaitForItAndPause()
+      throws InterruptedException {
+    // Arrange: hold a request open so the first pause blocks while draining.
+    GateKeeper realGateKeeper = new GateKeeper();
+    AdminService service = new AdminService(realGateKeeper);
+    realGateKeeper.letIn();
+
+    StreamObserver<Empty> firstResponseObserver = emptyResponseObserver();
+    Thread firstPause =
+        new Thread(() -> service.pause(pauseRequest(true, 10_000), firstResponseObserver));
+    firstPause.start();
+    awaitThreadState(firstPause, Thread.State.TIMED_WAITING);
+
+    // Act: a second pause arrives while the first is still draining, and waits for its turn.
+    StreamObserver<Empty> secondResponseObserver = emptyResponseObserver();
+    Thread secondPause =
+        new Thread(() -> service.pause(pauseRequest(true, 10_000), secondResponseObserver));
+    secondPause.start();
+    awaitThreadState(secondPause, Thread.State.TIMED_WAITING);
+
+    realGateKeeper.letOut();
+    joinPromptly(firstPause);
+    joinPromptly(secondPause);
+
+    // Assert: neither pause is failed, so a caller that unpauses to recover from a failure never
+    // issues the unpause that would reopen the gate under the other pause.
+    verify(firstResponseObserver).onCompleted();
+    verify(firstResponseObserver, never()).onError(any());
+    verify(secondResponseObserver).onCompleted();
+    verify(secondResponseObserver, never()).onError(any());
+    assertThat(realGateKeeper.isOpen()).isFalse();
+  }
+
+  @Test
+  public void pause_WhenAnotherPauseDoesNotFinishInTime_ShouldReturnAborted()
+      throws InterruptedException {
+    // Arrange: hold a request open so the first pause is still draining when the second arrives.
+    // Give it a time limit it cannot reach during the test rather than one the second call has to
+    // beat: if it could time out on its own, it would release the gate before the second call runs
+    // and this test would fail for a scheduling delay rather than for a regression.
+    GateKeeper realGateKeeper = new GateKeeper();
+    AdminService service = new AdminService(realGateKeeper);
+    realGateKeeper.letIn();
+
+    StreamObserver<Empty> blockedResponseObserver = emptyResponseObserver();
+    Thread blockedPause =
+        new Thread(() -> service.pause(pauseRequest(true, 10_000), blockedResponseObserver));
+    blockedPause.start();
+    awaitThreadState(blockedPause, Thread.State.TIMED_WAITING);
+
+    // Act: a short time limit is enough, and is all the test spends in real time. The pause in
+    // progress is already confirmed to hold the gate above, so this call gives up at its own
+    // deadline no matter how small that deadline is.
+    StreamObserver<Empty> rejectedResponseObserver = emptyResponseObserver();
+    service.pause(pauseRequest(true, 50), rejectedResponseObserver);
+
+    // Assert: waiting is bounded by the caller's own time limit, and giving up leaves the gate to
+    // the first pause rather than closing it behind that pause's back.
+    StatusRuntimeException error = captureError(rejectedResponseObserver);
+    assertThat(error.getStatus().getCode()).isEqualTo(Status.Code.ABORTED);
+    assertReason(error, PauseResult.PAUSE_IN_PROGRESS);
+    assertThat(error.getStatus().getDescription()).contains("another pause request is in progress");
+
+    // The first pause still completes normally once its request drains.
+    realGateKeeper.letOut();
+    joinPromptly(blockedPause);
+    verify(blockedResponseObserver).onCompleted();
+    verify(blockedResponseObserver, never()).onError(any());
+  }
+
+  @Test
+  public void checkPaused_WhenGateIsOpen_ShouldReturnNotPaused() {
+    // Arrange
+    when(gateKeeper.isOpen()).thenReturn(true);
+
+    @SuppressWarnings("unchecked")
+    StreamObserver<CheckPausedResponse> responseObserver =
+        (StreamObserver<CheckPausedResponse>) mock(StreamObserver.class);
+
+    // Act
+    adminService.checkPaused(Empty.getDefaultInstance(), responseObserver);
+
+    // Assert
+    ArgumentCaptor<CheckPausedResponse> captor = ArgumentCaptor.forClass(CheckPausedResponse.class);
+    verify(responseObserver).onNext(captor.capture());
+    assertThat(captor.getValue().getPaused()).isFalse();
+    verify(responseObserver).onCompleted();
+  }
+
+  @Test
+  public void checkPaused_WhenGateIsClosed_ShouldReturnPaused() {
+    // Arrange
+    when(gateKeeper.isOpen()).thenReturn(false);
+
+    @SuppressWarnings("unchecked")
+    StreamObserver<CheckPausedResponse> responseObserver =
+        (StreamObserver<CheckPausedResponse>) mock(StreamObserver.class);
+
+    // Act
+    adminService.checkPaused(Empty.getDefaultInstance(), responseObserver);
+
+    // Assert
+    ArgumentCaptor<CheckPausedResponse> captor = ArgumentCaptor.forClass(CheckPausedResponse.class);
+    verify(responseObserver).onNext(captor.capture());
+    assertThat(captor.getValue().getPaused()).isTrue();
+    verify(responseObserver).onCompleted();
+  }
+
+  private static PauseRequest pauseRequest(boolean waitOutstanding, long maxPauseWaitTime) {
+    return PauseRequest.newBuilder()
+        .setWaitOutstanding(waitOutstanding)
+        .setMaxPauseWaitTime(maxPauseWaitTime)
+        .build();
+  }
+
+  /**
+   * Builds a request that leaves {@code max_pause_wait_time} unset. The field tracks presence, so
+   * this is not the same as specifying 0: only an unset field falls back to the default.
+   */
+  private static PauseRequest pauseRequestWithoutMaxPauseWaitTime(boolean waitOutstanding) {
+    return PauseRequest.newBuilder().setWaitOutstanding(waitOutstanding).build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static StreamObserver<Empty> emptyResponseObserver() {
+    return (StreamObserver<Empty>) mock(StreamObserver.class);
+  }
+
+  /**
+   * Asserts the machine-readable outcome carried by the error. This, rather than the description
+   * text, is what a caller has to branch on to decide whether unpausing is safe, so it is asserted
+   * separately from the human-readable message everywhere a pause can fail.
+   */
+  private static void assertReason(StatusRuntimeException error, PauseResult expected) {
+    com.google.rpc.Status status = StatusProto.fromThrowable(error);
+    assertThat(status).isNotNull();
+
+    ErrorInfo errorInfo = null;
+    for (Any detail : status.getDetailsList()) {
+      if (detail.is(ErrorInfo.class)) {
+        try {
+          errorInfo = detail.unpack(ErrorInfo.class);
+        } catch (InvalidProtocolBufferException e) {
+          throw new AssertionError("the ErrorInfo detail could not be unpacked", e);
+        }
+        break;
+      }
+    }
+
+    assertThat(errorInfo).as("the error must carry an ErrorInfo detail").isNotNull();
+    assertThat(errorInfo.getReason()).isEqualTo(expected.name());
+    assertThat(errorInfo.getDomain()).isEqualTo("com.scalar.dl.admin");
+  }
+
+  private static StatusRuntimeException captureError(StreamObserver<Empty> responseObserver) {
+    ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+    verify(responseObserver).onError(captor.capture());
+    assertThat(captor.getValue()).isInstanceOf(StatusRuntimeException.class);
+    return (StatusRuntimeException) captor.getValue();
+  }
+}

--- a/ledger/src/test/java/com/scalar/dl/ledger/server/ThreadTestUtils.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/server/ThreadTestUtils.java
@@ -1,0 +1,53 @@
+package com.scalar.dl.ledger.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Helpers for ordering the interleaving of a concurrency test without sleeping, shared by the tests
+ * that drive a gatekeeper from more than one thread.
+ */
+final class ThreadTestUtils {
+
+  /** The deadline for a thread to reach the state a test is waiting for. */
+  private static final long THREAD_STATE_TIMEOUT_MILLIS = 5_000;
+
+  /**
+   * The deadline for a blocked thread to be woken up. Must stay well below the timeouts the tests
+   * give the threads they observe, so that a waiter that is never notified fails the test instead
+   * of quietly succeeding once its own timeout expires.
+   */
+  private static final long WAKE_UP_TIMEOUT_MILLIS = 2_000;
+
+  private ThreadTestUtils() {}
+
+  /** Spins until the thread is parked in the given state, giving up at the deadline. */
+  static void awaitThreadState(Thread thread, Thread.State state) {
+    long deadlineNanos =
+        System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(THREAD_STATE_TIMEOUT_MILLIS);
+    while (thread.getState() != state) {
+      if (System.nanoTime() - deadlineNanos > 0) {
+        fail(
+            "the thread did not reach %s within %d ms (last observed state: %s)",
+            state, THREAD_STATE_TIMEOUT_MILLIS, thread.getState());
+      }
+      LockSupport.parkNanos(1_000L);
+    }
+  }
+
+  /**
+   * Joins the thread, requiring it to have been woken up promptly. A bare join() would also pass
+   * when the thread is never notified and merely falls out of its own timeout much later.
+   */
+  static void joinPromptly(Thread thread) throws InterruptedException {
+    thread.join(WAKE_UP_TIMEOUT_MILLIS);
+    assertThat(thread.isAlive())
+        .withFailMessage(
+            "the thread was not woken up within %d ms, so it was never notified",
+            WAKE_UP_TIMEOUT_MILLIS)
+        .isFalse();
+  }
+}

--- a/rpc/build.gradle
+++ b/rpc/build.gradle
@@ -16,6 +16,11 @@ dependencies {
         exclude group: 'io.grpc', module: 'grpc-protobuf'
         exclude group: 'io.grpc', module: 'grpc-stub'
         exclude group: 'org.slf4j'
+        // Ships pre-2017 copies of the com.google.rpc / com.google.api classes compiled against
+        // protobuf 3.0. They duplicate (and, depending on classpath order, shadow) the ones from
+        // proto-google-common-protos brought in by grpc-protobuf, which breaks classes like
+        // com.google.rpc.ErrorInfo that only exist in the newer copy with a NoSuchFieldError.
+        exclude group: 'com.google.api.grpc', module: 'googleapis-common-protos'
     }
 }
 


### PR DESCRIPTION
## Description

`AdminService.pause()` could report **"Paused"** while the gate was actually **open**. This is the ScalarDL port of scalar-labs/scalardb-cluster#1915, which fixed the same three paths in ScalarDB Cluster; ScalarDL's `GateKeeper` / `AdminService` share the pre-fix structure, so all three are reachable here as well.

**A failed pause could undo an established one — with no concurrency at all.** The failure branch reopened the gate unconditionally, so a pause that inherited an already-closed gate and then timed out revoked a pause that had already been reported as successful. A `pause(wait_outstanding=false)` closes the gate and returns "Paused" while a long request is still running; a subsequent `pause(wait_outstanding=true)` inherits that gate, times out on the same request, and reopens it. The two calls can be strictly sequential — and "stop new work now, then wait for in-flight work to finish" is a natural use of the `wait_outstanding` flag.

**Concurrent unpause.** `GateKeeper.awaitDrained()` decided success only from the outstanding-request count and ignored `isOpen`, so a concurrent `unpause() → open()` during (or just before) the wait made it report success with an open gate. This is reachable through the standard "pause, and unpause if it fails" client pattern: `pause` does not check for gRPC context cancellation, so when a client gives up and issues its recovery `unpause`, the server is still inside `awaitDrained()`.

**Concurrent pause.** Two overlapping pauses could each close the gate, and the loser's rollback could undo the winner's established pause.

In every case a backup/snapshot tool that trusts the success response could then run while new requests proceed, silently defeating the pause guarantee.

Since `GateKeeper` and `AdminService` are shared, this single fix covers Ledger, and (via the published artifacts) Auditor and Gateway in the enterprise repo.

## Related issues and/or PRs

- scalar-labs/scalardb-cluster#1915 (same fix for ScalarDB Cluster)

## Changes made

- Serialized pause requests inside `GateKeeper` and made a pause undo only a closure it made itself, so a failed or concurrent pause can no longer reopen a gate an earlier pause established; the drain outcome is decided atomically and takes the gate state (`isOpen`) into account.
- `AdminService.pause()` now maps each `PauseResult` to a distinct outcome — `ABORTED` for transient races (retry), `FAILED_PRECONDITION` for drain timeouts — with a machine-readable `google.rpc.ErrorInfo` reason (`domain = "com.scalar.dl.admin"`) in the status trailers, including `TIMED_OUT_STILL_PAUSED` which tells a caller **not** to unpause to recover; a specified non-positive `max_pause_wait_time` is rejected with `INVALID_ARGUMENT` instead of silently skipping the wait.
- Excluded the pre-2017 `googleapis-common-protos` jar pulled in transitively by `scalar-admin`, whose old `com.google.rpc` classes shadow the ones from `proto-google-common-protos` and break `com.google.rpc.ErrorInfo` with a `NoSuchFieldError`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

`GateKeeper.close()` and `GateKeeper.awaitDrained()` changed signature and are now package-private; `pause()` and `pauseAndAwaitDrained()` take their place. `AdminService` only uses the public entry points, so the change does not depend on the two modules sharing a Java package. This is a source- and binary-incompatible narrowing on a class published as `scalardl-common`, but nothing in this repo or in scalardl-enterprise calls either method. The enterprise repo (Auditor / Gateway) uses `AdminService` and `GateKeeper` as-is and picks up the fix with no code change.

**One deliberate difference from the cluster implementation:** `letOut()` clamps at zero. ScalarDL counts outstanding requests where the cluster keeps a set of transaction IDs, and a set makes a duplicate removal a no-op for free. Without the clamp, an unpaired `letOut()` would make the count negative, leaving the drain loop with nothing to wait for while never satisfying its success condition either — every later pause that waits for outstanding requests would report a timeout it never waited for, with no recovery short of a restart. `CommonService` pairs the calls correctly today, so this is defence in depth rather than a live bug.

**`ABORTED` and `INVALID_ARGUMENT` are new on this RPC.** Previously every pause failure was `FAILED_PRECONDITION`. A caller that retries on `ABORTED` gets the correct behavior for both concurrency outcomes; one that treats any non-`FAILED_PRECONDITION` error as fatal would change behavior. Clients that branch on the `ErrorInfo` reason must skip the recovery unpause when the reason is `TIMED_OUT_STILL_PAUSED`, because the server is still paused by an earlier request. (Same caveats as the cluster PR; `scalar-admin`'s `RequestCoordinator` fan-out limitations apply here too.)

Known limitations (same as the cluster PR, deliberately not addressed here): `max_pause_wait_time` has no upper bound, and an abandoned pause holds its turn until its own deadline because gRPC context cancellation is not checked.

## Release notes

Fixed a race condition where pausing a Ledger (or Auditor/Gateway) server could report success while the server remained unpaused.