### PR TITLE
Increase heap size for jreleaserDeploy in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,9 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
-        run: ./gradlew jreleaserDeploy -Dorg.gradle.jvmargs="-Xmx4g"
+        # The mavenCentral deployer loads the whole bundle zip (> 1 GB) into memory when
+        # uploading it, so it needs a heap size of several times the bundle size.
+        run: ./gradlew jreleaserDeploy -Dorg.gradle.jvmargs="-Xmx8g"
 
       - name: Upload JReleaser outputs
         if: always()


### PR DESCRIPTION
## Description

The v3.14.0 release workflow failed with `Java heap space` while `jreleaserDeploy` was uploading the bundle zip to Maven Central ([failed run](https://github.com/scalar-labs/scalardl/actions/runs/30894844044/job/91945191542)). The JReleaser `mavenCentral` deployer loads the whole bundle zip into memory when uploading it, so it needs a heap size of several times the bundle size. The bundle, which contains the distribution tar/zip files of all the modules, is about 1.07 GB for 3.14.0 (about 100 MB larger than 3.13.0, mainly due to switching to `grpc-netty-shaded` in #634), so the current 4 GB heap is no longer enough.

I reproduced the failure locally: `jreleaserDeploy` fails with the same `Java heap space` error at the same point with `-Xmx4g`, and gets past the bundle loading and upload phase with `-Xmx8g`.

## Related issues and/or PRs

- Failed release run: https://github.com/scalar-labs/scalardl/actions/runs/30894844044

## Changes made

- Increased the heap size for the `jreleaserDeploy` task in the release workflow from 4 GB to 8 GB.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- `release-snapshot.yaml` is left unchanged because the `nexus2` deployer used for snapshots uploads artifacts file by file and does not create a large bundle.
- This change needs to be backported to the `3.14` branch (or applied when re-tagging `v3.14.0`) since the release workflow runs with the workflow definition at the tagged commit.

## Release notes

N/A (CI-only change)
