### PR TITLE
Release UBI-based ledger container image as a feature snapshot

### DIFF
--- a/.github/workflows/release-feature-snapshot.yaml
+++ b/.github/workflows/release-feature-snapshot.yaml
@@ -45,8 +45,12 @@ jobs:
       - name: Create container images
         run: ./gradlew docker -PprojectVersion=${{ steps.version.outputs.version }}
 
+      - name: Create UBI-based container images
+        run: ./gradlew :ledger:docker -Pubi -PprojectVersion=${{ steps.version.outputs.version }}
+
       - name: Push container images
         run: |
           docker push ghcr.io/scalar-labs/scalardl-ledger:${{ steps.version.outputs.version }}
+          docker push ghcr.io/scalar-labs/scalardl-ledger-ubi:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-client:${{ steps.version.outputs.version }}
           docker push ghcr.io/scalar-labs/scalardl-schema-loader:${{ steps.version.outputs.version }}

--- a/.github/workflows/remove-feature-snapshot.yaml
+++ b/.github/workflows/remove-feature-snapshot.yaml
@@ -37,6 +37,7 @@ jobs:
           )
           IMAGES=(
             "scalardl-ledger"
+            "scalardl-ledger-ubi"
             "scalardl-client"
             "scalardl-schema-loader"
           )


### PR DESCRIPTION
## Description

This PR adds a release (push container image) step for a UBI-based container image to the feature snapshot release workflow.

Previously, I added the UBI-based container image for ScalarDL Ledger, however, the feature snapshot container image based on UBI is not released for now. This might break the integration test workflow in the PR against the feature branch.

Therefore, I'd like to release the feature snapshot container image based on UBI as well as the normal (Temurin-based) container image.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/548
  - I added the UBI-based container image in this PR.

## Changes made

- Release feature snapshot container images of both Temurin-based and UBI-based.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A

