### PR TITLE
Validate that the nonce of ContractExecutionRequest is a canonical UUID

### DIFF
--- a/common-test/src/main/java/com/scalar/dl/ledger/service/Constants.java
+++ b/common-test/src/main/java/com/scalar/dl/ledger/service/Constants.java
@@ -39,7 +39,7 @@ public class Constants {
 
   public static final String SOME_ASSET_ID_1 = "A";
   public static final String SOME_ASSET_ID_2 = "B";
-  public static final String SOME_NONCE = "nonce";
+  public static final String SOME_NONCE = "8b6f5c2e-4d3a-4f1b-a9c7-2e8d0b5f7a19";
   public static final int SOME_AMOUNT_1 = 1000;
   public static final int SOME_AMOUNT_2 = 100;
   public static final int SOME_AMOUNT_3 = 200;

--- a/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
+++ b/common/src/main/java/com/scalar/dl/ledger/error/CommonError.java
@@ -315,6 +315,12 @@ public enum CommonError implements ScalarDlError {
       "The specified namespace is reserved and cannot be created or deleted. Name: %s",
       "",
       "Use a different namespace name that is not reserved. Reserved namespaces are managed by the system and cannot be modified."),
+  INVALID_NONCE_FORMAT(
+      StatusCode.INVALID_ARGUMENT,
+      "022",
+      "The format of the nonce is invalid. Nonce: %s",
+      "",
+      "Specify the nonce in the canonical UUID format."),
 
   //
   // Errors for SECRET_NOT_FOUND(415)

--- a/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
@@ -30,6 +30,8 @@ public class ContractExecutionRequest extends AbstractRequest {
   private static final Pattern CANONICAL_UUID_PATTERN =
       Pattern.compile(
           "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+  private static final CharMatcher NON_PRINTABLE_ASCII =
+      CharMatcher.inRange((char) 0x20, (char) 0x7e).negate();
   private static final int MAX_NONCE_LENGTH_IN_MESSAGE = 64;
   private final String nonce;
   private final String contractId;
@@ -103,8 +105,13 @@ public class ContractExecutionRequest extends AbstractRequest {
     }
   }
 
+  // A valid nonce is a canonical UUID, so every character outside printable ASCII is unexpected
+  // input. Replacing all of them, rather than only the ISO control characters, also covers the
+  // Unicode line and paragraph separators and the bidi formatting characters that some log viewers
+  // and regex-based log processors treat as line breaks or render misleadingly, plus any lone
+  // surrogate left behind by the truncation below.
   private static String sanitizeNonce(String nonce) {
-    String sanitized = CharMatcher.javaIsoControl().replaceFrom(nonce, '?');
+    String sanitized = NON_PRINTABLE_ASCII.replaceFrom(nonce, '?');
     if (sanitized.length() > MAX_NONCE_LENGTH_IN_MESSAGE) {
       return sanitized.substring(0, MAX_NONCE_LENGTH_IN_MESSAGE)
           + "... ("

--- a/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
@@ -6,7 +6,6 @@ import com.google.common.base.CharMatcher;
 import com.scalar.dl.ledger.crypto.SignatureValidator;
 import com.scalar.dl.ledger.error.CommonError;
 import com.scalar.dl.ledger.error.CommonLedgerError;
-import com.scalar.dl.ledger.exception.LedgerException;
 import com.scalar.dl.ledger.exception.SignatureException;
 import com.scalar.dl.ledger.util.Argument;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -92,16 +91,19 @@ public class ContractExecutionRequest extends AbstractRequest {
   @Override
   protected final void finalize() {}
 
-  private static void validateNonceFormat(@Nullable String nonce) {
-    if (nonce == null || !CANONICAL_UUID_PATTERN.matcher(nonce).matches()) {
-      throw new LedgerException(CommonError.INVALID_NONCE_FORMAT, sanitizeNonce(nonce));
+  // This throws IllegalArgumentException to stay consistent with the other argument checks in this
+  // constructor and in Argument. Note that CommonService maps it to StatusCode.RUNTIME_ERROR even
+  // though CommonError.INVALID_NONCE_FORMAT is an INVALID_ARGUMENT error. That mapping is a
+  // pre-existing inconsistency shared by every IllegalArgumentException thrown on a request path,
+  // and it should be revisited for all of them at once rather than only here.
+  private static void validateNonceFormat(String nonce) {
+    if (!CANONICAL_UUID_PATTERN.matcher(nonce).matches()) {
+      throw new IllegalArgumentException(
+          CommonError.INVALID_NONCE_FORMAT.buildMessage(sanitizeNonce(nonce)));
     }
   }
 
-  private static String sanitizeNonce(@Nullable String nonce) {
-    if (nonce == null) {
-      return "null";
-    }
+  private static String sanitizeNonce(String nonce) {
     String sanitized = CharMatcher.javaIsoControl().replaceFrom(nonce, '?');
     if (sanitized.length() > MAX_NONCE_LENGTH_IN_MESSAGE) {
       return sanitized.substring(0, MAX_NONCE_LENGTH_IN_MESSAGE)

--- a/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.scalar.dl.ledger.crypto.SignatureValidator;
 import com.scalar.dl.ledger.error.CommonError;
 import com.scalar.dl.ledger.error.CommonLedgerError;
+import com.scalar.dl.ledger.exception.LedgerException;
 import com.scalar.dl.ledger.exception.SignatureException;
 import com.scalar.dl.ledger.util.Argument;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -25,6 +27,12 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 // non-final for mocking
 public class ContractExecutionRequest extends AbstractRequest {
+  private static final Pattern CANONICAL_UUID_PATTERN =
+      Pattern.compile(
+          "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+  private static final Pattern ISO_CONTROL_CHARACTER_PATTERN =
+      Pattern.compile("[\\u0000-\\u001F\\u007F-\\u009F]");
+  private static final int MAX_NONCE_LENGTH_IN_MESSAGE = 64;
   private final String nonce;
   private final String contractId;
   private final String contractArgument;
@@ -37,7 +45,8 @@ public class ContractExecutionRequest extends AbstractRequest {
    * Constructs a {@code ContractExecutionRequest} with the specified nonce, contract id, argument,
    * entity ID, key version, a list of {@code AssetProof} and signature of the request.
    *
-   * @param nonce the unique id of a request
+   * @param nonce the unique id of a request in the canonical UUID format (e.g.,
+   *     "550e8400-e29b-41d4-a716-446655440000")
    * @param contractId a contract id of a registered contract to execute
    * @param contractArgument an argument to a contract
    * @param functionIds a list of function ids
@@ -65,6 +74,7 @@ public class ContractExecutionRequest extends AbstractRequest {
     checkArgument(contractArgument != null && !contractArgument.isEmpty());
     checkArgument(signature != null && signature.length > 0);
     this.nonce = (nonce == null || nonce.isEmpty()) ? Argument.getNonce(contractArgument) : nonce;
+    validateNonceFormat(this.nonce);
     this.contractId = contractId;
     this.contractArgument = contractArgument;
     this.functionIds =
@@ -74,6 +84,33 @@ public class ContractExecutionRequest extends AbstractRequest {
     this.functionArgument = functionArgument;
     this.signature = signature;
     this.auditorSignature = auditorSignature;
+  }
+
+  /**
+   * SpotBugs detects Bug Type "CT_CONSTRUCTOR_THROW" saying that "The object under construction
+   * remains partially initialized and may be vulnerable to Finalizer attacks."
+   */
+  @Override
+  protected final void finalize() {}
+
+  private static void validateNonceFormat(@Nullable String nonce) {
+    if (nonce == null || !CANONICAL_UUID_PATTERN.matcher(nonce).matches()) {
+      throw new LedgerException(CommonError.INVALID_NONCE_FORMAT, sanitizeNonce(nonce));
+    }
+  }
+
+  private static String sanitizeNonce(@Nullable String nonce) {
+    if (nonce == null) {
+      return "null";
+    }
+    String sanitized = ISO_CONTROL_CHARACTER_PATTERN.matcher(nonce).replaceAll("?");
+    if (sanitized.length() > MAX_NONCE_LENGTH_IN_MESSAGE) {
+      return sanitized.substring(0, MAX_NONCE_LENGTH_IN_MESSAGE)
+          + "... ("
+          + nonce.length()
+          + " chars)";
+    }
+    return sanitized;
   }
 
   /**

--- a/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
+++ b/common/src/main/java/com/scalar/dl/ledger/model/ContractExecutionRequest.java
@@ -2,6 +2,7 @@ package com.scalar.dl.ledger.model;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.CharMatcher;
 import com.scalar.dl.ledger.crypto.SignatureValidator;
 import com.scalar.dl.ledger.error.CommonError;
 import com.scalar.dl.ledger.error.CommonLedgerError;
@@ -30,8 +31,6 @@ public class ContractExecutionRequest extends AbstractRequest {
   private static final Pattern CANONICAL_UUID_PATTERN =
       Pattern.compile(
           "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
-  private static final Pattern ISO_CONTROL_CHARACTER_PATTERN =
-      Pattern.compile("[\\u0000-\\u001F\\u007F-\\u009F]");
   private static final int MAX_NONCE_LENGTH_IN_MESSAGE = 64;
   private final String nonce;
   private final String contractId;
@@ -103,7 +102,7 @@ public class ContractExecutionRequest extends AbstractRequest {
     if (nonce == null) {
       return "null";
     }
-    String sanitized = ISO_CONTROL_CHARACTER_PATTERN.matcher(nonce).replaceAll("?");
+    String sanitized = CharMatcher.javaIsoControl().replaceFrom(nonce, '?');
     if (sanitized.length() > MAX_NONCE_LENGTH_IN_MESSAGE) {
       return sanitized.substring(0, MAX_NONCE_LENGTH_IN_MESSAGE)
           + "... ("

--- a/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
+++ b/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
@@ -187,7 +187,11 @@ public class Argument {
     Version version = getVersion(argument);
     switch (version) {
       case V1:
-        return jacksonSerDe.deserialize(argument).path(NONCE_KEY_NAME).asText();
+        JsonNode nonceNode = jacksonSerDe.deserialize(argument).get(NONCE_KEY_NAME);
+        if (nonceNode == null) {
+          throw new IllegalArgumentException(CommonError.ILLEGAL_ARGUMENT_FORMAT.buildMessage());
+        }
+        return nonceNode.asText();
       case V2:
       case V3:
         List<String> elements = getElements(argument, version);

--- a/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
+++ b/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
@@ -187,7 +187,8 @@ public class Argument {
     Version version = getVersion(argument);
     switch (version) {
       case V1:
-        return jacksonSerDe.deserialize(argument).get(NONCE_KEY_NAME).asText();
+        JsonNode nonceNode = jacksonSerDe.deserialize(argument).get(NONCE_KEY_NAME);
+        return nonceNode == null ? "" : nonceNode.asText();
       case V2:
       case V3:
         List<String> elements = getElements(argument, version);

--- a/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
+++ b/common/src/main/java/com/scalar/dl/ledger/util/Argument.java
@@ -187,8 +187,7 @@ public class Argument {
     Version version = getVersion(argument);
     switch (version) {
       case V1:
-        JsonNode nonceNode = jacksonSerDe.deserialize(argument).get(NONCE_KEY_NAME);
-        return nonceNode == null ? "" : nonceNode.asText();
+        return jacksonSerDe.deserialize(argument).path(NONCE_KEY_NAME).asText();
       case V2:
       case V3:
         List<String> elements = getElements(argument, version);

--- a/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class ContractExecutionRequestTest {
-  private static final String NONCE = "nonce";
+  private static final String NONCE = "550e8400-e29b-41d4-a716-446655440000";
   private static final String CONTEXT_NAMESPACE = "test_namespace";
   private static final String ENTITY_ID = "entity_id";
   private static final int KEY_VERSION = 1;

--- a/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.scalar.dl.ledger.exception.LedgerException;
-import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.ledger.util.Argument;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -394,136 +392,121 @@ public class ContractExecutionRequestTest {
   }
 
   @Test
-  public void constructor_CommaContainingNonceGiven_ShouldThrowLedgerException() {
+  public void constructor_CommaContainingNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest("abc,def", CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
   public void
-      constructor_EmptyNonceAndEmptyNonceInContractArgumentGiven_ShouldThrowLedgerException() {
+      constructor_EmptyNonceAndEmptyNonceInContractArgumentGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     String contractArgument = "{\"" + Argument.NONCE_KEY_NAME + "\":\"\"}";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest("", contractArgument))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_NonCanonicalUuidNonceGiven_ShouldThrowLedgerException() {
+  public void constructor_NonCanonicalUuidNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest("1-1-1-1-1", CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_SeparatorContainingNonceOf36CharsGiven_ShouldThrowLedgerException() {
+  public void
+      constructor_SeparatorContainingNonceOf36CharsGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     // 36 characters, but contains the nonce separator character (U+0001)
     String nonce = "550e8400-e29b-41d4-a716-44665544000\u0001";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_TooShortNearUuidNonceGiven_ShouldThrowLedgerException() {
+  public void constructor_TooShortNearUuidNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     // 35 characters
     String nonce = "550e8400-e29b-41d4-a716-44665544000";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_TooLongNearUuidNonceGiven_ShouldThrowLedgerException() {
+  public void constructor_TooLongNearUuidNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     // 37 characters
     String nonce = "550e8400-e29b-41d4-a716-4466554400000";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_NonHexLetterContainingNonceGiven_ShouldThrowLedgerException() {
+  public void constructor_NonHexLetterContainingNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     // 36 characters, but contains a non-hex letter 'g'
     String nonce = "g50e8400-e29b-41d4-a716-446655440000";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_NullNonceAndV2ArgumentWithEmptyNonceGiven_ShouldThrowLedgerException() {
+  public void
+      constructor_NullNonceAndV2ArgumentWithEmptyNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     String contractArgument = "V2" + FUNCTION_ID + "" + CONTRACT_ARGUMENT;
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(null, contractArgument))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_NullNonceAndV1ArgumentWithEmptyNonceGiven_ShouldThrowLedgerException() {
+  public void
+      constructor_NullNonceAndV1ArgumentWithEmptyNonceGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     String contractArgument = "{\"" + Argument.NONCE_KEY_NAME + "\":\"\"}";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(null, contractArgument))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022");
   }
 
   @Test
-  public void constructor_NullNonceAndV1ArgumentWithoutNonceKeyGiven_ShouldThrowLedgerException() {
+  public void
+      constructor_NullNonceAndV1ArgumentWithoutNonceKeyGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     String contractArgument = "{\"key\":\"value\"}";
 
     // Act Assert
+    // The nonce is absent rather than malformed, so Argument rejects the argument format itself.
     assertThatThrownBy(() -> buildRequest(null, contractArgument))
-        .isInstanceOf(LedgerException.class)
-        .satisfies(
-            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
-        .hasMessageContaining("DL-COMMON-414022");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DL-COMMON-414017");
   }
 
   @Test
@@ -571,7 +554,7 @@ public class ContractExecutionRequestTest {
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022")
         .hasMessageContaining("abc?def")
         .satisfies(e -> assertThat(e.getMessage()).doesNotContain("\n"));
@@ -588,7 +571,7 @@ public class ContractExecutionRequestTest {
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
-        .isInstanceOf(LedgerException.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("DL-COMMON-414022")
         .hasMessageContaining("(1000 chars)")
         .satisfies(e -> assertThat(e.getMessage()).doesNotContain(nonce));

--- a/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.scalar.dl.ledger.exception.LedgerException;
+import com.scalar.dl.ledger.service.StatusCode;
 import com.scalar.dl.ledger.util.Argument;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -348,6 +350,248 @@ public class ContractExecutionRequestTest {
 
     // Assert
     assertThat(result).isFalse();
+  }
+
+  private static ContractExecutionRequest buildRequest(String nonce, String contractArgument) {
+    return new ContractExecutionRequest(
+        nonce,
+        CONTRACT_ID,
+        contractArgument,
+        Collections.singletonList(FUNCTION_ID),
+        FUNCTION_ARGUMENT,
+        CONTEXT_NAMESPACE,
+        ENTITY_ID,
+        KEY_VERSION,
+        SIGNATURE,
+        AUDITOR_SIGNATURE);
+  }
+
+  @Test
+  public void constructor_LowercaseCanonicalUuidNonceGiven_ShouldInstantiate() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> buildRequest("550e8400-e29b-41d4-a716-446655440000", CONTRACT_ARGUMENT))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void constructor_UppercaseCanonicalUuidNonceGiven_ShouldInstantiate() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> buildRequest("550E8400-E29B-41D4-A716-446655440000", CONTRACT_ARGUMENT))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void constructor_MixedCaseCanonicalUuidNonceGiven_ShouldInstantiate() {
+    // Arrange
+
+    // Act Assert
+    assertThatCode(() -> buildRequest("550e8400-E29B-41d4-A716-446655440000", CONTRACT_ARGUMENT))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void constructor_CommaContainingNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest("abc,def", CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void
+      constructor_EmptyNonceAndEmptyNonceInContractArgumentGiven_ShouldThrowLedgerException() {
+    // Arrange
+    String contractArgument = "{\"" + Argument.NONCE_KEY_NAME + "\":\"\"}";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest("", contractArgument))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_NonCanonicalUuidNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest("1-1-1-1-1", CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_SeparatorContainingNonceOf36CharsGiven_ShouldThrowLedgerException() {
+    // Arrange
+    // 36 characters, but contains the argument separator character (U+0001)
+    String nonce = "550e8400-e29b-41d4-a716-44665544000";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_TooShortNearUuidNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+    // 35 characters
+    String nonce = "550e8400-e29b-41d4-a716-44665544000";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_TooLongNearUuidNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+    // 37 characters
+    String nonce = "550e8400-e29b-41d4-a716-4466554400000";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_NonHexLetterContainingNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+    // 36 characters, but contains a non-hex letter 'g'
+    String nonce = "g50e8400-e29b-41d4-a716-446655440000";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_NullNonceAndV2ArgumentWithEmptyNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+    String contractArgument = "V2" + FUNCTION_ID + "" + CONTRACT_ARGUMENT;
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(null, contractArgument))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_NullNonceAndV1ArgumentWithEmptyNonceGiven_ShouldThrowLedgerException() {
+    // Arrange
+    String contractArgument = "{\"" + Argument.NONCE_KEY_NAME + "\":\"\"}";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(null, contractArgument))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_NullNonceAndV1ArgumentWithoutNonceKeyGiven_ShouldThrowLedgerException() {
+    // Arrange
+    String contractArgument = "{\"key\":\"value\"}";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(null, contractArgument))
+        .isInstanceOf(LedgerException.class)
+        .satisfies(
+            e -> assertThat(((LedgerException) e).getCode()).isEqualTo(StatusCode.INVALID_ARGUMENT))
+        .hasMessageContaining("DL-COMMON-414022");
+  }
+
+  @Test
+  public void constructor_NullNonceAndV1ArgumentWithUuidNonceGiven_ShouldGetNonceFromArgument() {
+    // Arrange
+    String contractArgument = "{\"" + Argument.NONCE_KEY_NAME + "\":\"" + NONCE + "\"}";
+
+    // Act
+    ContractExecutionRequest request = buildRequest(null, contractArgument);
+
+    // Assert
+    assertThat(request.getNonce()).isEqualTo(NONCE);
+  }
+
+  @Test
+  public void constructor_NullNonceAndV2ArgumentWithUuidNonceGiven_ShouldGetNonceFromArgument() {
+    // Arrange
+    String contractArgument = "V2" + NONCE + "" + FUNCTION_ID + "" + CONTRACT_ARGUMENT;
+
+    // Act
+    ContractExecutionRequest request = buildRequest(null, contractArgument);
+
+    // Assert
+    assertThat(request.getNonce()).isEqualTo(NONCE);
+  }
+
+  @Test
+  public void constructor_NullNonceAndV3ArgumentWithUuidNonceGiven_ShouldGetNonceFromArgument() {
+    // Arrange
+    String contractArgument =
+        Argument.format(
+            CONTRACT_ARGUMENT, NONCE, CONTEXT_NAMESPACE, Collections.singletonList(FUNCTION_ID));
+
+    // Act
+    ContractExecutionRequest request = buildRequest(null, contractArgument);
+
+    // Assert
+    assertThat(request.getNonce()).isEqualTo(NONCE);
+  }
+
+  @Test
+  public void constructor_ControlCharacterContainingNonceGiven_ShouldSanitizeExceptionMessage() {
+    // Arrange
+    String nonce = "abc\ndef";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .hasMessageContaining("DL-COMMON-414022")
+        .hasMessageContaining("abc?def")
+        .satisfies(e -> assertThat(e.getMessage()).doesNotContain("\n"));
+  }
+
+  @Test
+  public void constructor_VeryLongNonceGiven_ShouldTruncateNonceInExceptionMessage() {
+    // Arrange
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < 1000; i++) {
+      builder.append('a');
+    }
+    String nonce = builder.toString();
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(LedgerException.class)
+        .hasMessageContaining("DL-COMMON-414022")
+        .hasMessageContaining("(1000 chars)")
+        .satisfies(e -> assertThat(e.getMessage()).doesNotContain(nonce));
   }
 
   @Test

--- a/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
@@ -434,8 +434,8 @@ public class ContractExecutionRequestTest {
   @Test
   public void constructor_SeparatorContainingNonceOf36CharsGiven_ShouldThrowLedgerException() {
     // Arrange
-    // 36 characters, but contains the argument separator character (U+0001)
-    String nonce = "550e8400-e29b-41d4-a716-44665544000";
+    // 36 characters, but contains the nonce separator character (U+0001)
+    String nonce = "550e8400-e29b-41d4-a716-44665544000\u0001";
 
     // Act Assert
     assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))

--- a/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/model/ContractExecutionRequestTest.java
@@ -561,6 +561,37 @@ public class ContractExecutionRequestTest {
   }
 
   @Test
+  public void constructor_LineSeparatorContainingNonceGiven_ShouldSanitizeExceptionMessage() {
+    // Arrange
+    // U+2028 LINE SEPARATOR is not an ISO control character, but some log viewers and regex-based
+    // log processors treat it as a line break.
+    String nonce = "abc\u2028def";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DL-COMMON-414022")
+        .hasMessageContaining("abc?def")
+        .satisfies(e -> assertThat(e.getMessage()).doesNotContain("\u2028"));
+  }
+
+  @Test
+  public void constructor_BidiOverrideContainingNonceGiven_ShouldSanitizeExceptionMessage() {
+    // Arrange
+    // U+202E RIGHT-TO-LEFT OVERRIDE is not an ISO control character, but it reverses how the rest
+    // of
+    // the line is rendered.
+    String nonce = "abc\u202Edef";
+
+    // Act Assert
+    assertThatThrownBy(() -> buildRequest(nonce, CONTRACT_ARGUMENT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DL-COMMON-414022")
+        .hasMessageContaining("abc?def")
+        .satisfies(e -> assertThat(e.getMessage()).doesNotContain("\u202E"));
+  }
+
+  @Test
   public void constructor_VeryLongNonceGiven_ShouldTruncateNonceInExceptionMessage() {
     // Arrange
     StringBuilder builder = new StringBuilder();

--- a/common/src/test/java/com/scalar/dl/ledger/util/ArgumentTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/util/ArgumentTest.java
@@ -42,6 +42,18 @@ public class ArgumentTest {
   }
 
   @Test
+  public void getNonce_V1FormatWithoutNonceKeyGiven_ShouldReturnEmptyString() {
+    // Arrange
+    String argument = Json.createObjectBuilder().add("key", "value").build().toString();
+
+    // Act
+    String nonce = Argument.getNonce(argument);
+
+    // Assert
+    assertThat(nonce).isEmpty();
+  }
+
+  @Test
   public void getContractArgument_V1FormatGiven_ShouldReturnOriginalArgument() {
     // Arrange Act
     String contractArg = Argument.getContractArgument(V1_ARGUMENT);

--- a/common/src/test/java/com/scalar/dl/ledger/util/ArgumentTest.java
+++ b/common/src/test/java/com/scalar/dl/ledger/util/ArgumentTest.java
@@ -42,15 +42,14 @@ public class ArgumentTest {
   }
 
   @Test
-  public void getNonce_V1FormatWithoutNonceKeyGiven_ShouldReturnEmptyString() {
+  public void getNonce_V1FormatWithoutNonceKeyGiven_ShouldThrowIllegalArgumentException() {
     // Arrange
     String argument = Json.createObjectBuilder().add("key", "value").build().toString();
 
-    // Act
-    String nonce = Argument.getNonce(argument);
-
-    // Assert
-    assertThat(nonce).isEmpty();
+    // Act Assert
+    assertThatThrownBy(() -> Argument.getNonce(argument))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("DL-COMMON-414017");
   }
 
   @Test

--- a/ledger/src/test/java/com/scalar/dl/ledger/server/LedgerServiceTest.java
+++ b/ledger/src/test/java/com/scalar/dl/ledger/server/LedgerServiceTest.java
@@ -49,7 +49,7 @@ public class LedgerServiceTest {
   private static final int SOME_ASSET_AGE = 1;
   private static final byte[] SOME_HASH = "hash".getBytes(StandardCharsets.UTF_8);
   private static final byte[] SOME_PREV_HASH = "prev_hash".getBytes(StandardCharsets.UTF_8);
-  private static final String SOME_NONCE = "nonce";
+  private static final String SOME_NONCE = "3f2f0c1d-6b8a-4e5f-9d2c-7a1b4c8e0f36";
   private static final String SOME_INPUT = "input";
   private static final byte[] SOME_SIGNATURE = "signature".getBytes(StandardCharsets.UTF_8);
   private static final String SOME_ARGUMENT = "{\"nonce\": \"xxx\"}";


### PR DESCRIPTION
## Description

The nonce of `ContractExecutionRequest` is client-specified and has never been format-checked, while downstream components trust its shape. In the Auditor, `lock_taken_by` stores READ-lock owners as a comma-separated list of nonces, so a nonce that contains a comma is stored as multiple tokens and can never release its own lock, and an empty nonce creates a `(READ, count=1, takenBy="")` entry that the emptiness-consistency check misreads as corruption and force-releases live locks. Both were surfaced while fixing the stuck-lock issue in scalardl-enterprise; that fix hardened the defense side, but the malformed input can still enter.

A canonical UUID is 36 fixed-length characters of hex digits and hyphens. No UUID is a substring of another, none contains a comma or an argument separator, and every UUID is regex-literal. Validating the format at the server entry point removes the entire malformed-input class instead of patching each downstream consumer, and it covers both Ledger-only and Auditor deployments because `AuditorService` consumes the same `ContractExecutionRequest`.

This is not expected to be a breaking change in practice: the Java SDK always generates `UUID.randomUUID()` nonces, and a client that supplies a non-UUID nonce is exactly the case this validation should reject.

## Related issues and/or PRs

- Follows up on the stuck-lock fix in scalardl-enterprise(https://github.com/scalar-labs/scalardl-enterprise/pull/1792). See the review discussion on that PR.
- Depends on [scalardl-enterprise#1806](https://github.com/scalar-labs/scalardl-enterprise/pull/1806), which switches the Auditor test nonce to a canonical UUID. That PR should merge first so the Auditor build stays green when this change is published.

## Changes made

- Reject a `ContractExecutionRequest` whose resolved nonce is not a canonical UUID with a new `CommonError.INVALID_NONCE_FORMAT` entry, validating the value after the existing contract-argument fallback so V1/V2/V3 encodings are checked the same way as a directly supplied nonce.
- Make `Argument.getNonce` reject a V1 argument that has no `nonce` key with `CommonError.ILLEGAL_ARGUMENT_FORMAT` instead of throwing `NullPointerException`, since the nonce is absent rather than malformed.
- Sanitize the nonce echoed in the error message (control characters replaced, length bounded) because this check runs before signature validation.
- Update test nonces to canonical UUIDs and add coverage for the accepted and rejected formats.
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

**Validation format:** `UUID.fromString()` is deliberately not used because it accepts non-canonical input such as `1-1-1-1-1`. The check is a fixed-length pattern, and uppercase hex is accepted since it is still a valid canonical UUID even though current SDKs emit lowercase.

**Exception type:** The rejection throws `IllegalArgumentException` carrying the `CommonError` message, matching the other argument checks in this constructor and in `Argument`. `CommonService` maps anything that is not a `LedgerException` to `StatusCode.RUNTIME_ERROR`, so the message reports `DL-COMMON-414022` while the wire status is `INTERNAL`. That mismatch is pre-existing and shared by every `IllegalArgumentException` thrown on a request path — the `checkArgument` calls in `AbstractRequest` and the request models, plus eight sites in `Argument`. Fixing only this one call site would leave the inconsistency in place, so the mapping should be revisited for all of them in a separate PR; a code comment records this.

**Scope:** `ExecutionAbortRequest` and `ExecutionFinishRequest` are intentionally left unvalidated. They reference already-registered transactions and create no new lock owners, and validating them would make in-flight transactions whose nonce predates this change impossible to abort or finish.

**Behavior change worth noting.** A client that passes a custom non-UUID nonce through the deprecated `executeContract(String nonce, ...)` overloads now gets an error instead of a successful execution.

## Release notes

Added validation that the nonce of a contract execution request is a canonical UUID.
