### PR TITLE
Fix the grpc_health_probe version in the UBI based Ledger image

### DIFF
--- a/.github/workflows/scalar.yml
+++ b/.github/workflows/scalar.yml
@@ -126,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image-type: temurin

--- a/ledger/Dockerfile.ubi
+++ b/ledger/Dockerfile.ubi
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.47
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.53
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/


### PR DESCRIPTION
## Description

This PR fixes the following two things based on the feedback in https://github.com/scalar-labs/scalardl/pull/563#pullrequestreview-4956369049.

- Fix the `grpc_health_probe` version in the UBI-based container image.
- Add `fail-fast: false` to the CI configuration.

Please take a look!

## Related issues and/or PRs

- #563

## Changes made

- Fix the `grpc_health_probe` version in the UBI-based container image.
- Add `fail-fast: false` to the CI configuration.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A
