### PR TITLE
Clean up stale Dependabot ignore rules and Dockerfile comments

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,12 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
-      - dependency-name: "com.diffplug.spotless"
+      # Error Prone runs inside javac and SpotBugs runs on a worker JVM, and both are launched
+      # from the compilation toolchain, which is still Java 8 for every module except ledger.
+      # Error Prone 2.11 and later require JDK 11 or later, and SpotBugs 4.9.0 raised its minimum
+      # runtime to Java 11. Keep them pinned until the Java 8 toolchain is dropped.
       - dependency-name: "com.google.errorprone:*"
       - dependency-name: "com.github.spotbugs:*"
-      - dependency-name: "com.palantir.docker"
 
   # For GitHub Actions, update all actions on the default, support and release branches
   - package-ecosystem: "github-actions"

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends \
 
 WORKDIR /scalar
 
-# The path should be relative from build/docker. Running `gradle build`
-# (provided by com.palantir.docker plugin) will copy this Dockerfile and
-# client.tar to build/docker.
+# The path should be relative from build/docker. The Gradle task
+# copyFilesToDockerBuildContextDir copies this Dockerfile and client.tar to
+# build/docker before building the image.
 ADD --chown=201:201 ./client.tar .
 
 COPY --chown=201:201 \

--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -20,9 +20,9 @@ COPY --from=tools grpc_health_probe /usr/local/bin/
 
 WORKDIR /scalar
 
-# The path should be relative from build/docker. Running `gradle build`
-# (provided by com.palantir.docker plugin) will copy this Dockerfile and
-# ledger.tar to build/docker.
+# The path should be relative from build/docker. The Gradle task
+# copyFilesToDockerBuildContextDir copies this Dockerfile and ledger.tar to
+# build/docker before building the image.
 ADD --chown=201:201 ./ledger.tar .
 
 COPY --chown=201:201 \

--- a/ledger/Dockerfile.ubi
+++ b/ledger/Dockerfile.ubi
@@ -24,9 +24,9 @@ COPY --from=tools grpc_health_probe /usr/local/bin/
 
 WORKDIR /scalar
 
-# The path should be relative from build/docker. Running `gradle build`
-# (provided by com.palantir.docker plugin) will copy this Dockerfile and
-# ledger.tar to build/docker.
+# The path should be relative from build/docker. The Gradle task
+# copyFilesToDockerBuildContextDir copies this Dockerfile and ledger.tar to
+# build/docker before building the image.
 ADD --chown=201:201 ./ledger.tar .
 
 COPY --chown=201:201 \


### PR DESCRIPTION
## Description

The gradle Dependabot configuration carries two ignore rules that no longer do anything. `com.diffplug.spotless` no longer matches how the plugin is declared, and it is not needed either — the pin was only ever required while the whole build ran on Java 8, and Spotless runs on the Gradle daemon JVM. `com.palantir.docker` was replaced by plain `Copy` and `Exec` tasks in #395, so the dependency does not exist any more. Leaving both in place makes the file read as if more dependencies are deliberately pinned than actually are.

The Error Prone and SpotBugs rules, in contrast, are load-bearing: every module except `ledger` still compiles with the Java 8 toolchain, Error Prone runs inside javac, and SpotBugs runs on a worker JVM launched from that toolchain, and Error Prone 2.11 and later require JDK 11 or later while SpotBugs 4.9.0 raised its minimum runtime to Java 11. That reason was not recorded anywhere, so this PR writes it into the configuration.

#395 also left the `client` and `ledger` Dockerfile comments crediting the removed plugin for copying files into `build/docker`.

## Related issues and/or PRs

- #395 — replaced the `com.palantir.docker` plugin with `Copy`/`Exec` tasks and introduced the per-module toolchains
- The counterpart clean-up in the `scalardl-enterprise` repository: https://github.com/scalar-labs/scalardl-enterprise/pull/1812

## Changes made

- Remove the inert `com.diffplug.spotless` and `com.palantir.docker` ignore rules from `.github/dependabot.yml`, and document why the Error Prone and SpotBugs rules stay
- Update the `client` and `ledger` Dockerfile comments to name the `copyFilesToDockerBuildContextDir` task instead of the removed `com.palantir.docker` plugin

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- No behavioral change for Dependabot in this repository — both removed rules are already inert, confirmed against the Dependabot job log.
- Two `@dependabot ignore` command rules remain stored on the repository (`com.diffplug.spotless > 6.13.0` and `com.google.errorprone:error_prone_core > 2.10.0`). Those live outside this file and cannot be removed by editing it; they will be cleared with `@dependabot unignore` on a Dependabot PR. Neither changes current behavior.

## Release notes

N/A
