### PR TITLE
Upgrade grpc_health_probe to v0.4.57 to fix security issues

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.53
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.56
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/

--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.56
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.57
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/

--- a/ledger/Dockerfile.ubi
+++ b/ledger/Dockerfile.ubi
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.53
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.56
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/

--- a/ledger/Dockerfile.ubi
+++ b/ledger/Dockerfile.ubi
@@ -1,6 +1,6 @@
 FROM docker.io/busybox:1.36 AS tools
 
-ENV GRPC_HEALTH_PROBE_VERSION=v0.4.56
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.57
 
 # Install grpc_health_probe for kubernetes.
 # https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/


### PR DESCRIPTION
## Description

Upgraded the grpc_health_probe binary from v0.4.53 to v0.4.57, which builds with the Go 1.26.8 toolchain and updates golang.org/x/net to 0.58.0, golang.org/x/text to 0.41.0, and google.golang.org/grpc to 1.83.2.

This fixes CVE-2026-33818, CVE-2026-39821, CVE-2026-46600, CVE-2026-56852, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, CVE-2026-56862, CVE-2026-84304, GHSA-hrxh-6v49-42gf, and GHSA-vp52-pcj8-j9qc.

This PR originally upgraded to v0.4.56, which left CVE-2026-84304 unresolved because it requires grpc 1.83.1 or later. v0.4.57 was released while this PR was under review and includes grpc 1.83.2, so that CVE is now fixed as well. All 12 gobinary findings reported by the scheduled vulnerability check are resolved.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl-enterprise/pull/1841

## Changes made

- Upgraded the grpc_health_probe binary from v0.4.53 to v0.4.57

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

Fixed CVE-2026-33818, CVE-2026-39821, CVE-2026-46600, CVE-2026-56852, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860, CVE-2026-56862, CVE-2026-84304, GHSA-hrxh-6v49-42gf, and GHSA-vp52-pcj8-j9qc.
