### PR TITLE
Backport to branch(3.13) : Upgrade grpc_health_probe to v0.4.57 to fix security issues

### DIFF
--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/busybox:1.36 AS tools
 
 ENV DOCKERIZE_VERSION v0.6.1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.53
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.57
 
 # Install dockerize
 RUN set -x && \


### PR DESCRIPTION
This is an automated request for a manual backport of the following:

- **Original PR:** https://github.com/scalar-labs/scalardl/pull/681
- **Commit to backport:** ece77838a56048e677a98c18ba8796d79d841aa0

1. Resolve any conflicts that occur during the cherry-picking process.

```console
git fetch origin &&
git checkout 3.13-pull-681 &&
git cherry-pick --no-rerere-autoupdate -m1 ece77838a56048e677a98c18ba8796d79d841aa0
```

2. Push the changes.
3. Merge this PR after all checks have passed.

Thank you!